### PR TITLE
Fix `LimitedOptionsFlag::kEmptyDestructor` use in `LimitedVector`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -15,7 +15,6 @@ build --cxxopt=-std=c++20 --host_cxxopt=-std=c++20 --cxxopt=-Werror
 test --test_output=errors
 
 # Custom --config=asan mode:
-build:asan --distinct_host_configuration=true
 build:asan --copt -fsanitize=address,undefined
 build:asan --linkopt -fsanitize=address,undefined
 build:asan --copt -fno-sanitize=vptr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.16
+
+* Fix `LimitedOptionsFlag::kEmptyDestructor` use in `LimitedVector`.
+
 # 0.2.15
 
 * Added `LimitedOptions` support to `LimitedVector`.
@@ -19,7 +23,7 @@
 
 * Added `ConstScan` and `MakeConstScan`.
 * Changed all `Make*Scan` types to create intermediate adapters.
-* Made all `*Scan` and `Make*Scan` to accept `std::initializer` types. 
+* Made all `*Scan` and `Make*Scan` to accept `std::initializer` types.
 * Added support for move-only types.
 * Improved `*scan` handling of initializer_lists.
 

--- a/mbo/container/limited_map.h
+++ b/mbo/container/limited_map.h
@@ -77,7 +77,7 @@ class LimitedMap final
   using container_internal::LimitedOrdered<Key, Value, std::pair<const Key, Value>, CapacityOrOptions, KeyComp>::
       LimitedOrdered;
 
-  ~LimitedMap() noexcept = default;
+  constexpr ~LimitedMap() noexcept = default;
 
   constexpr LimitedMap() noexcept = default;
 

--- a/mbo/container/limited_ordered_test.cc
+++ b/mbo/container/limited_ordered_test.cc
@@ -75,7 +75,8 @@ TEST_F(LimitedOrderedTest, ConstexprData) {
 }
 
 TEST_F(LimitedOrderedTest, ConstexprNoDtor) {
-  constexpr auto kTest = LimitedOrdered<int, int, int, LimitedOptions<3, LimitedOptionsFlag::kEmptyDestructor>{}>{};
+  static constexpr auto kTest =
+      LimitedOrdered<int, int, int, LimitedOptions<3, LimitedOptionsFlag::kEmptyDestructor>{}>{};
   EXPECT_THAT(kTest, IsEmpty());
   EXPECT_THAT(kTest, SizeIs(0));
   EXPECT_THAT(kTest, CapacityIs(3));
@@ -83,7 +84,8 @@ TEST_F(LimitedOrderedTest, ConstexprNoDtor) {
 }
 
 TEST_F(LimitedOrderedTest, ConstexprRequireSortedInput) {
-  constexpr auto kTest = LimitedOrdered<int, int, int, LimitedOptions<3, LimitedOptionsFlag::kRequireSortedInput>{}>{};
+  static constexpr auto kTest =
+      LimitedOrdered<int, int, int, LimitedOptions<3, LimitedOptionsFlag::kRequireSortedInput>{}>{};
   EXPECT_THAT(kTest, IsEmpty());
   EXPECT_THAT(kTest, SizeIs(0));
   EXPECT_THAT(kTest, CapacityIs(3));

--- a/mbo/container/limited_set.h
+++ b/mbo/container/limited_set.h
@@ -70,7 +70,7 @@ class LimitedSet final : public container_internal::LimitedOrdered<Key, Key, Key
  public:
   using container_internal::LimitedOrdered<Key, Key, Key, CapacityOrOptions, Compare>::LimitedOrdered;
 
-  ~LimitedSet() noexcept = default;
+  constexpr ~LimitedSet() noexcept = default;
 
   constexpr explicit LimitedSet(const Compare& key_comp) noexcept : LimitedBase(key_comp){};
 

--- a/mbo/container/limited_vector.h
+++ b/mbo/container/limited_vector.h
@@ -82,7 +82,13 @@ class LimitedVector final {
     constexpr Data(Data&&) noexcept = default;
     constexpr Data& operator=(Data&&) noexcept = default;
 
-    constexpr ~Data() noexcept {}  // NON DEFAULT
+    constexpr ~Data() noexcept
+    requires(std::is_trivially_destructible_v<T>)
+    = default;
+
+    constexpr ~Data() noexcept
+    requires(!std::is_trivially_destructible_v<T>)
+    {};
 
     None none;
     T data;


### PR DESCRIPTION
Fix `LimitedOptionsFlag::kEmptyDestructor` use in `LimitedVector`.
Bump version to 0.2.16.