### PR TITLE
Added template-type `RefWrap<T>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+# 0.2.17
+
+* Added template-type `RefWrap<T>`: similar to `std::reference_wrapper` but supports operators `->` and `*`.
+
 # 0.2.16
 
-* Fix `LimitedOptionsFlag::kEmptyDestructor` use in `LimitedVector`.
+* Fixed `LimitedOptionsFlag::kEmptyDestructor` use in `LimitedVector`.
 
 # 0.2.15
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ The C++ library is organized in functional groups each residing in their own dir
     * mbo/types:no_destruct_cc, mbo/types/no_destruct.h
         * struct `NoDestruct<T>`: Implements a type that allows to use any type as a static constant.
         * Mainly, this prevents calling the destructor and thus prevents termination issues (initialization order fiasco).
+    * mbo/types:ref_wrap_cc, mbo/types/ref_wrap.h
+        * template-type `RefWrap<T>`: similar to `std::reference_wrapper` but supports operators `->` and `*`.
     * mbo/types:traits_cc, mbo/types/traits.h
         * type alias `ContainerConstIteratorValueType` returned the value-type of the const_iterator of a container.
         * concept `ContainerIsForwardIteratable` determines whether a types can be used in forward iteration.

--- a/mbo/types/BUILD.bazel
+++ b/mbo/types/BUILD.bazel
@@ -83,6 +83,21 @@ cc_test(
 )
 
 cc_library(
+  name = "ref_wrap_cc",
+  hdrs = ["ref_wrap.h"],
+  visibility = ["//visibility:public"],
+)
+
+cc_test(
+  name = "ref_wrap_test",
+  srcs = ["ref_wrap_test.cc"],
+  deps = [
+    ":ref_wrap_cc",
+    "@com_google_googletest//:gtest_main",
+  ]
+)
+
+cc_library(
     name = "traits_cc",
     hdrs = ["traits.h"],
     visibility = ["//visibility:public"],

--- a/mbo/types/ref_wrap.h
+++ b/mbo/types/ref_wrap.h
@@ -1,0 +1,103 @@
+// Copyright 2024 M. Boerger (helly25.com)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MBO_TYPES_REF_WRAP_H_
+#define MBO_TYPES_REF_WRAP_H_
+
+#include <compare>   // IWYU pragma: keep
+#include <concepts>  // IWYU pragma: keep
+#include <cstddef>
+
+namespace mbo::types {
+
+// Template class `RefWrap<T>` is a reference wrapper for a type `T`. It has
+// similar goals to `std::reference_wrapper` or GSL's `not_null`. However, the
+// wrapper behaves like a pointer that cannot be a nullptr. In details:
+// Unlike `std::reference_wrapper`:
+//   * Can be used directly without calling `get`.
+//   * The reference can be updated directly.
+//
+// Unlike GSL's `not_null`:
+//   * Cannot be initialized with a nullptr. Instead it must be initialized by
+//     an actual reference (note that technically you could still construct a
+//     nullptr that way).
+//   * Comparison is on the values not the pointer (since we mimic references).
+template<typename T>
+class RefWrap final {
+ public:
+  ~RefWrap() noexcept = default;
+
+  RefWrap() = delete;
+
+  explicit RefWrap(T& ref) noexcept : ptr_(&ref) {}
+
+  RefWrap(const RefWrap&) noexcept = default;
+  RefWrap& operator=(const RefWrap&) noexcept = default;
+  RefWrap(RefWrap&&) noexcept = default;
+  RefWrap& operator=(RefWrap&&) noexcept = default;
+
+  RefWrap& operator=(T& ref) noexcept {
+    ptr_ = &ref;
+    return *this;
+  }
+
+  T* get() noexcept __attribute__((returns_nonnull)) { return ptr_; }  // NOLINT(*-identifier-naming)
+
+  const T* get() const noexcept __attribute__((returns_nonnull)) { return ptr_; }  // NOLINT(*-identifier-naming)
+
+  T* operator->() noexcept __attribute__((returns_nonnull)) { return ptr_; }
+
+  const T* operator->() const noexcept __attribute__((returns_nonnull)) { return ptr_; }
+
+  T& operator*() noexcept { return *ptr_; }
+
+  const T& operator*() const noexcept { return *ptr_; }
+
+  operator T&() noexcept { return *ptr_; }  // NOLINT(*-explicit-*)
+
+  operator const T &() const noexcept { return *ptr_; }  // NOLINT(*-explicit-*)
+
+  RefWrap& operator++() = delete;
+  RefWrap& operator--() = delete;
+  RefWrap operator++(int) = delete;  // NOLINT(cert-dcl21-cpp)
+  RefWrap operator--(int) = delete;  // NOLINT(cert-dcl21-cpp)
+  RefWrap& operator+=(std::ptrdiff_t) = delete;
+  RefWrap& operator-=(std::ptrdiff_t) = delete;
+  void operator[](std::ptrdiff_t) const = delete;
+
+  auto operator<=>(const RefWrap& other) const noexcept {
+    if (ptr_ == other.ptr_) {
+      return decltype(*ptr_ <=> other)::equivalent;
+    }
+    return *ptr_ <=> *other.ptr_;
+  }
+
+  template<typename U>
+  requires(std::three_way_comparable_with<T, U>)
+  auto operator<=>(const U& other) const noexcept {
+    if (ptr_ == &other) {
+      return decltype(*ptr_ <=> other)::equivalent;
+    }
+    return *ptr_ <=> other;
+  }
+
+  friend auto operator<=>(const RefWrap& lhs, const RefWrap& rhs) noexcept = default;
+
+ private:
+  T* ptr_;
+};
+
+}  // namespace mbo::types
+
+#endif  // MBO_TYPES_REF_WRAP_H_

--- a/mbo/types/ref_wrap_test.cc
+++ b/mbo/types/ref_wrap_test.cc
@@ -1,0 +1,137 @@
+// Copyright 2024 M. Boerger (helly25.com)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mbo/types/ref_wrap.h"
+
+#include <utility>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace mbo::types {
+namespace {
+
+// NOLINTBEGIN(*-magic-numbers)
+
+using ::testing::Ge;
+using ::testing::Le;
+using ::testing::Not;
+using ::testing::Pair;
+
+struct RefWrapTest : ::testing::Test {};
+
+TEST_F(RefWrapTest, Basics) {
+  int num = 25;
+  {
+    RefWrap<int> ref(num);
+    ASSERT_THAT(&*ref, &num);
+    EXPECT_THAT(ref, 25);
+    num = 42;
+    EXPECT_THAT(ref, 42);
+    EXPECT_THAT(num, 42);
+  }
+  {
+    RefWrap<int> ref{num};
+    ASSERT_THAT(&*ref, &num);
+    EXPECT_THAT(ref, 42);
+    num = 25;
+    EXPECT_THAT(ref, 25);
+    EXPECT_THAT(num, 25);
+  }
+}
+
+TEST_F(RefWrapTest, BasicConst) {
+  const int num = 25;
+  RefWrap<const int> ref(num);
+  ASSERT_THAT(&*ref, &num);
+  EXPECT_THAT(ref, 25);
+}
+
+TEST_F(RefWrapTest, BasicConstFromNonConst) {
+  int num = 25;
+  RefWrap<const int> ref(num);
+  ASSERT_THAT(&*ref, &num);
+  EXPECT_THAT(ref, 25);
+  num = 42;
+  EXPECT_THAT(ref, 42);
+  EXPECT_THAT(ref, Le(55));
+  EXPECT_THAT(ref, Ge(33));
+  num = 99;
+  EXPECT_THAT(ref, 99);
+  EXPECT_THAT(ref, Ge(55));
+  EXPECT_THAT(ref, Ge(33));
+}
+
+TEST_F(RefWrapTest, Compare) {
+  const int num = 25;
+  RefWrap<const int> ref(num);
+  ASSERT_THAT(&*ref, &num);
+  EXPECT_THAT(ref, 25);
+  EXPECT_THAT(ref <= 55, true);
+  EXPECT_THAT(ref < 55, true);
+  EXPECT_THAT(ref <= 11, false);
+  EXPECT_THAT(ref < 11, false);
+  EXPECT_THAT(ref == 55, false);
+  EXPECT_THAT(ref != 55, true);
+  EXPECT_THAT(ref == 25, true);
+  EXPECT_THAT(ref != 25, false);
+  EXPECT_THAT(55 >= ref, true);
+  EXPECT_THAT(55 > ref, true);
+  EXPECT_THAT(11 >= ref, false);
+  EXPECT_THAT(11 > ref, false);
+  EXPECT_THAT(ref, Le(55));
+  EXPECT_THAT(ref, Le(25));
+  EXPECT_THAT(ref, Not(Le(11)));
+  EXPECT_THAT(ref, Ge(11));
+  EXPECT_THAT(ref, Ge(25));
+  EXPECT_THAT(ref, Not(Ge(33)));
+  int val = 25;
+  RefWrap<int> cmp(val);
+  EXPECT_THAT(ref == val, true);
+  EXPECT_THAT(ref != val, false);
+  EXPECT_THAT(ref <= val, true);
+  EXPECT_THAT(ref >= val, true);
+  EXPECT_THAT(ref < val, false);
+  EXPECT_THAT(ref > val, false);
+  val = 11;
+  EXPECT_THAT(ref == val, false);
+  EXPECT_THAT(ref != val, true);
+  EXPECT_THAT(ref <= val, false);
+  EXPECT_THAT(ref >= val, true);
+  EXPECT_THAT(ref < val, false);
+  EXPECT_THAT(ref > val, true);
+  val = 33;
+  EXPECT_THAT(ref == val, false);
+  EXPECT_THAT(ref != val, true);
+  EXPECT_THAT(ref <= val, true);
+  EXPECT_THAT(ref >= val, false);
+  EXPECT_THAT(ref < val, true);
+  EXPECT_THAT(ref > val, false);
+}
+
+TEST_F(RefWrapTest, Pair) {
+  std::pair<int, int> data{25, 33};
+  RefWrap<std::pair<int, int>> ref(data);
+  ASSERT_THAT(&*ref, &data);
+  ASSERT_THAT(&ref->first, &data.first);
+  ASSERT_THAT(&ref->second, &data.second);
+  EXPECT_THAT(*ref, Pair(data.first, data.second));
+  EXPECT_THAT(ref->first, data.first);
+  EXPECT_THAT(ref->second, data.second);
+}
+
+// NOLINTEND(*-magic-numbers)
+
+}  // namespace
+}  // namespace mbo::types


### PR DESCRIPTION
Added template-type `RefWrap<T>`: similar to `std::reference_wrapper` but supports operators `->` and `*`.