### PR TITLE
Change the way `mbo::types::Extend` types are constructed to support more complex and deeper nested types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.22
+
+* Change the way `mbo::types::Extend` types are constructed to support more complex and deeper nested types.
+
 # 0.2.21
 
 * Optimize `AnyScan`, `ConstScan` and `ConvertingScan` by dropping clone layer. We also explicitly support multiple iterations on one object.

--- a/mbo/types/extend_test.cc
+++ b/mbo/types/extend_test.cc
@@ -276,7 +276,8 @@ TEST_F(ExtendTest, StreamableComplexFields) {
   EXPECT_THAT(
       out.str(),
       Conditional(
-          kStructNameSupport, R"({25, {.name: {.first: "Hugo", .last: "Meyer"}, .age: 42}, *{{"bar", "foo"}}})",
+          kStructNameSupport,
+          R"({.index: 25, .person: {.name: {.first: "Hugo", .last: "Meyer"}, .age: 42}, .data: *{{"bar", "foo"}}})",
           R"({25, {{"Hugo", "Meyer"}, 42}, *{{"bar", "foo"}}})"));
 #ifdef __clang__
   if (HasFailure()) {

--- a/mbo/types/extender.h
+++ b/mbo/types/extender.h
@@ -108,7 +108,7 @@ template<tstring ExtenderNameT, template<typename> typename ImplT, typename Requ
 struct MakeExtender {
   using RequiredExtender = RequiredExtenderT;
 
-  static constexpr std::string_view kExtenderName = decltype(ExtenderNameT)::str();
+  static constexpr std::string_view GetExtenderName() { return decltype(ExtenderNameT)::str(); }
 
  private:
   // This friend is necessary to keep symbol visibility in check. But it has to

--- a/mbo/types/extender.h
+++ b/mbo/types/extender.h
@@ -106,8 +106,9 @@ namespace mbo::types::extender {
 // ```
 template<tstring ExtenderNameT, template<typename> typename ImplT, typename RequiredExtenderT = void>
 struct MakeExtender {
-  using ExtenderName = decltype(ExtenderNameT);
   using RequiredExtender = RequiredExtenderT;
+
+  static constexpr std::string_view kExtenderName = decltype(ExtenderNameT)::str();
 
  private:
   // This friend is necessary to keep symbol visibility in check. But it has to

--- a/mbo/types/internal/extend.h
+++ b/mbo/types/internal/extend.h
@@ -34,8 +34,7 @@ struct NoRequirement {};
 // `kExtenderName` that can be converted into a `std::string_view`.
 template<typename MaybeExtender>
 concept IsExtender = requires {
-  MaybeExtender::kExtenderName;
-  std::convertible_to<decltype(MaybeExtender::kExtenderName), std::string_view>;
+  { MaybeExtender::GetExtenderName() } -> std::convertible_to<std::string_view>;
 };
 
 template<typename T, typename... Ts>
@@ -134,7 +133,7 @@ struct ExtendImpl
   using RegisteredExtenders = std::tuple<Extender...>;
 
   static constexpr std::array<std::string_view, sizeof...(Extender)> RegisteredExtenderNames() {
-    return {Extender::kExtenderName...};
+    return {Extender::GetExtenderName()...};
   }
 };
 

--- a/mbo/types/internal/extend.h
+++ b/mbo/types/internal/extend.h
@@ -30,14 +30,12 @@ namespace mbo::types::extender_internal {
 
 struct NoRequirement {};
 
-// Identify `Extender` classes by the fact that they have a type `ExtenderName`
-// that can be converted into a `std::string_view`.
+// Identify `Extender` classes by the fact that they have a member named
+// `kExtenderName` that can be converted into a `std::string_view`.
 template<typename MaybeExtender>
 concept IsExtender = requires {
-  typename MaybeExtender::ExtenderName;
-  //{
-  //    typename MaybeExtender::ExtenderName()
-  //  } -> std::convertible_to<std::string_view>;
+  MaybeExtender::kExtenderName;
+  std::convertible_to<decltype(MaybeExtender::kExtenderName), std::string_view>;
 };
 
 template<typename T, typename... Ts>
@@ -136,7 +134,7 @@ struct ExtendImpl
   using RegisteredExtenders = std::tuple<Extender...>;
 
   static constexpr std::array<std::string_view, sizeof...(Extender)> RegisteredExtenderNames() {
-    return {Extender::ExtenderName::str()...};
+    return {Extender::kExtenderName...};
   }
 };
 


### PR DESCRIPTION
* Change the way `mbo::types::Extend` types are constructed to support more complex and deeper nested types. This is accomplished by not making the types name a member types that gets repeated in the field printing, but rather just a member field of type `constexpr std::string_view`.