### PR TITLE
* Provide a new `mbo::types::extender::Default` which wraps all default extenders.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.2.22
 
 * Change the way `mbo::types::Extend` types are constructed to support more complex and deeper nested types.
+* Provide a new `mbo::types::extender::Default` which wraps all default extenders.
 
 # 0.2.21
 

--- a/mbo/types/extend.h
+++ b/mbo/types/extend.h
@@ -42,16 +42,7 @@ namespace mbo::types {
 // compare itself. In the above example `{"First", "Last"}` will be printed.
 // If compiled on Clang it will print `{first: "First", last: "Last"}`.
 template<typename T, typename... Extender>
-struct Extend
-    : extender_internal::ExtendImpl<
-          T,
-          // Default `Extend` functionality
-          extender::AbslStringify,
-          extender::AbslHashable,
-          extender::Comparable,
-          extender::Printable,
-          extender::Streamable,
-          Extender...> {};
+struct Extend : extender_internal::ExtendImpl<T, extender::Default, Extender...> {};
 
 // Same as `Extend` but without default extenders. This alows to control the
 // exact extender set to be used.


### PR DESCRIPTION
This shortens the default extender type names drastically.