### PR TITLE
Drastically shorten generated extender names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
-# 0.3
+# 0.2.23
 
 * Add llvm/clang which can be triggered with `bazel ... --config=clang`.
+* Drastically shorten generated extender names (<1/3rd)>.
 
 # 0.2.22
 
 * Change the way `mbo::types::Extend` types are constructed to support more complex and deeper nested types.
-* Provide a new `mbo::types::extender::Default` which wraps all default extenders.
+* Provide a new `mbo::extender::Default` which wraps all default extenders.
 
 # 0.2.21
 
@@ -95,8 +96,8 @@
   * Allow `LimitedOption` configuration instead of simple length specification.
     * Option to suppress calling clear in the destructor for cases where that is not a constexpr.
     * Option to require presorted input: Allows much large constexpr `LimitedSet`/`LimitedValue`.
-* Renamed `Extender::AbslFormat` to `Extender::AbslStringify` to better reflect its purpose.
-* Changed `Extender::AbslStringify` to print field names prefixed with a fot '.' (requires Clang).
+* Renamed `types::AbslFormat` to `types::AbslStringify` to better reflect its purpose.
+* Changed `types::AbslStringify` to print field names prefixed with a fot '.' (requires Clang).
 
 # 0.2.6
 

--- a/mbo/types/extend.h
+++ b/mbo/types/extend.h
@@ -43,14 +43,14 @@ namespace mbo::types {
 // compare itself. In the above example `{"First", "Last"}` will be printed.
 // If compiled on Clang it will print `{first: "First", last: "Last"}`.
 template<typename T, typename... Extender>
-struct Extend : extender_internal::ExtendImpl<T, extender::Default, Extender...> {};
+struct Extend : ::mbo::extender::Extend<T, ::mbo::types::extender::Default, Extender...> {};
 
 // Same as `Extend` but without default extenders. This alows to control the
 // exact extender set to be used.
 //
 // Example:
 // ```c++
-// struct Name : mbo::types::ExtendNoDEfault<mbo::types::extender::Comparable> {
+// struct Name : mbo::types::ExtendNoDEfault<mbo::types::Comparable> {
 //    std::string first;
 //    std::string last;
 // };
@@ -59,7 +59,7 @@ struct Extend : extender_internal::ExtendImpl<T, extender::Default, Extender...>
 // Here `Name` gets injected with all comparison operators but it will not get
 // print, stream or hash functionality.
 template<typename T, typename... Extender>
-struct ExtendNoDefault : extender_internal::ExtendImpl<T, Extender...> {};
+struct ExtendNoDefault : ::mbo::extender::Extend<T, Extender...> {};
 
 }  // namespace mbo::types
 
@@ -81,7 +81,7 @@ namespace std {
 // }
 // ```
 template<typename Extended>
-requires mbo::types::extender_internal::HasExtender<Extended, mbo::types::extender::AbslHashable>
+requires mbo::types_internal::HasExtender<Extended, mbo::types::extender::AbslHashable>
 struct hash<Extended> {  // NOLINT(cert-dcl58-cpp)
 
   std::size_t operator()(const Extended& obj) const noexcept { return absl::HashOf(obj); }

--- a/mbo/types/extender.h
+++ b/mbo/types/extender.h
@@ -125,7 +125,7 @@ struct MakeExtender {
 };
 
 template<typename ExtenderBase>
-struct _AbslStringify : ExtenderBase {
+struct AbslStringify_ : ExtenderBase {
   using Type = typename ExtenderBase::Type;
 
   void OStreamFields(std::ostream& os) const { OStreamFieldsImpl(os, this->ToTuple()); }
@@ -196,7 +196,7 @@ struct _AbslStringify : ExtenderBase {
 };
 
 template<typename ExtenderBase>
-struct _AbslHashable : ExtenderBase {
+struct AbslHashable_ : ExtenderBase {
  private:
   using T = typename ExtenderBase::Type;
 
@@ -208,7 +208,7 @@ struct _AbslHashable : ExtenderBase {
 };
 
 template<typename ExtenderBase>
-struct _Comparable : ExtenderBase {
+struct Comparable_ : ExtenderBase {
  private:
   using T = typename ExtenderBase::Type;
 
@@ -244,7 +244,7 @@ struct _Comparable : ExtenderBase {
 };
 
 template<typename ExtenderBase>
-struct _Printable : ExtenderBase {
+struct Printable_ : ExtenderBase {
   std::string ToString() const {
     std::ostringstream os;
     this->OStreamFields(os);
@@ -253,7 +253,7 @@ struct _Printable : ExtenderBase {
 };
 
 template<typename ExtenderBase>
-struct _Streamable : ExtenderBase {
+struct Streamable_ : ExtenderBase {
   friend std::ostream& operator<<(std::ostream& os, const ExtenderBase::Type& v) {
     v.OStreamFields(os);
     return os;
@@ -267,7 +267,7 @@ namespace extender {
 // [AbslStringify](https://abseil.io/docs/cpp/guides/format#abslstringify)).
 //
 // This default Extender is automatically available through `mb::types::Extend`.
-struct AbslStringify final : MakeExtender<"AbslStringify"_ts, _AbslStringify> {};
+struct AbslStringify final : MakeExtender<"AbslStringify"_ts, AbslStringify_> {};
 
 // Extender that injects functionality to make an `Extend`ed type work with
 // abseil hashing (and also `std::hash`).
@@ -288,25 +288,25 @@ struct AbslStringify final : MakeExtender<"AbslStringify"_ts, _AbslStringify> {}
 // ```
 //
 // This default Extender is automatically available through `mb::types::Extend`.
-struct AbslHashable final : MakeExtender<"AbslHashable"_ts, _AbslHashable> {};
+struct AbslHashable final : MakeExtender<"AbslHashable"_ts, AbslHashable_> {};
 
 // Extender that injects functionality to make an `Extend`ed type comparable.
 // All comparators will be injected: `<=>`, `==`, `!=`, `<`, `<=`, `>`, `>=`.
 //
 // This default Extender is automatically available through `mb::types::Extend`.
-struct Comparable final : MakeExtender<"Comparable"_ts, _Comparable> {};
+struct Comparable final : MakeExtender<"Comparable"_ts, Comparable_> {};
 
 // Extender that injects functionality to make an `Extend`ed type get a
 // `ToString` function which can be used to convert a type into a `std::string`.
 //
 // This default Extender is automatically available through `mb::types::Extend`.
-struct Printable final : MakeExtender<"Printable"_ts, _Printable, AbslStringify> {};
+struct Printable final : MakeExtender<"Printable"_ts, Printable_, AbslStringify> {};
 
 // Extender that injects functionality to make an `Extend`ed type streamable.
 // This allows the type to be used directly with `std::ostream`s.
 //
 // This default Extender is automatically available through `mb::types::Extend`.
-struct Streamable final : MakeExtender<"Streamable"_ts, _Streamable, AbslStringify> {};
+struct Streamable final : MakeExtender<"Streamable"_ts, Streamable_, AbslStringify> {};
 
 // The default extender is a wrapper around:
 // * Streamable
@@ -325,21 +325,10 @@ struct Default final {
   template<typename T, typename Extender>
   friend struct ::mbo::types::types_internal::UseExtender;
 
-  // NOTE: The list of wrapped extenders needs to be in sync with `mbo::types_internal::ExtendImpl`.
-
-  template<typename E>
-  using StreamableImpl = _Streamable<E>;
-  template<typename E>
-  using PrintableImpl = _Printable<E>;
-  template<typename E>
-  using ComparableImpl = _Comparable<E>;
-  template<typename E>
-  using AbslHashableImpl = _AbslHashable<E>;
-  template<typename E>
-  using AbslStringifyImpl = _AbslStringify<E>;
+  // NOTE: The list of wrapped extenders needs to be in sync with `mbo::extender::Extend`.
 
   template<typename ExtenderOrActualType>
-  struct Impl : StreamableImpl<PrintableImpl<ComparableImpl<AbslHashableImpl<AbslStringifyImpl<ExtenderOrActualType>>>>> {
+  struct Impl : Streamable_<Printable_<Comparable_<AbslHashable_<AbslStringify_<ExtenderOrActualType>>>>> {
     using Type = ExtenderOrActualType::Type;
   };
 };
@@ -350,6 +339,7 @@ struct Default final {
 
 }  // namespace mbo::types
 
+// Add a convenience namespace to clearly isolate just the extenders.
 namespace mbo::extender {
 using namespace ::mbo::types::extender;
 }

--- a/mbo/types/internal/extender.h
+++ b/mbo/types/internal/extender.h
@@ -18,24 +18,17 @@
 
 // IWYU pragma private, include "mbo/types/extend.h"
 
-namespace mbo::types::extender_internal {
-
-// Type used to chain CRTP functionality and to inject the final type 'T'.
-template<typename T, typename ExtenderBaseT>
-struct ExtenderInfo {
-  using Type = T;
-  using ExtenderBase = ExtenderBaseT;
-};
+namespace mbo::types::types_internal {
 
 // Access to the extender implementation for constructing the CRTP chain using
 // `ExtendBuildChain`.
 // This is done via a distinct struct, so that the non specialized templates
 // can be private.
-template<typename T, typename Extender>
+template<typename ExtenderBase, typename Extender>
 struct UseExtender {
-  using type = typename Extender::template Impl<ExtenderInfo<typename T::Type, T>>;
+  using type = typename Extender::template Impl<ExtenderBase>;
 };
 
-}  // namespace mbo::types::extender_internal
+}  // namespace mbo::types::types_internal
 
 #endif  // MBO_TYPES_INTERNAL_EXTENDER_H_


### PR DESCRIPTION
* Drastically shorten generated extender names (<1/3rd)>.