### PR TITLE
Chaneg suppression typename to `MboExtendNoFieldNames`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Added llvm/clang which can be triggered with `bazel ... --config=clang`.
 * Shortened generated extender names drastically (< 1/3rd).
 * Added union member identification (enables union members for `Extend`'s printing/streaming).
-* Added ability to suppress field name support in `Extend` by adding `using NoFieldNames = void;`.
+* Added ability to suppress field name support in `Extend` by adding `using MboExtendDoNotPrintFieldNames = void;`.
 
 # 0.2.22
 

--- a/mbo/types/extend.h
+++ b/mbo/types/extend.h
@@ -43,7 +43,7 @@ namespace mbo::types {
 // compare itself. In the above example `{"First", "Last"}` will be printed.
 // If compiled on Clang it will print `{first: "First", last: "Last"}` (see
 // AbslStringify for restrictions). Also, the field names can be suppressed
-// by adding `using NoFieldNames = void;` to the type.
+// by adding `using MboExtendDoNotPrintFieldNames = void;` to the type.
 //
 // NOTE: No member may be an anonymous union or struct.
 template<typename T, typename... Extender>

--- a/mbo/types/extend_test.cc
+++ b/mbo/types/extend_test.cc
@@ -358,7 +358,7 @@ TEST_F(ExtendTest, StreamableWithUnion) {
 }
 
 struct SuppressFieldNames : ::mbo::types::Extend<SuppressFieldNames> {
-  using NoFieldNames = void;
+  using MboExtendDoNotPrintFieldNames = void;
 
   int first{1};
   int second{2};

--- a/mbo/types/extender.h
+++ b/mbo/types/extender.h
@@ -187,7 +187,7 @@ struct AbslStringify_ : ExtenderBase {  // NOLINT(readability-identifier-naming)
     if (idx) {
       os << ", ";
     }
-    if constexpr (!requires { typename Type::NoFieldNames; }) {
+    if constexpr (!requires { typename Type::MboExtendDoNotPrintFieldNames; }) {
       static constexpr auto kNames = ::mbo::types::types_internal::GetFieldNames<Type>();
       if (idx < kNames.length() && !kNames[idx].empty()) {
         os << "." << kNames[idx] << ": ";
@@ -275,8 +275,8 @@ namespace extender {
 // If the compiler and the structure support `__buildtin_dump_struct` (e.g. if
 // compiled with Clang), then this automatically supports field names. However,
 // this does not work with `union`s. Further, providing field names can be
-// suppressed by providing a typename `NoFieldNames`, e.g.:
-//   `using NoFieldNames = void;`
+// suppressed by providing a typename `MboExtendDoNotPrintFieldNames`, e.g.:
+//   `using MboExtendDoNotPrintFieldNames = void;`
 struct AbslStringify final : MakeExtender<"AbslStringify"_ts, AbslStringify_> {};
 
 // Extender that injects functionality to make an `Extend`ed type work with


### PR DESCRIPTION
Chaneg suppression typename to `MboExtendNoFieldNames`.

This makes the type's use more obvious.