### PR TITLE
Add hash support for tstring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.26
+
+* Added `GetHash(std::string_view)` which is constexpr safe.
+* Added hash support to tstring.
+
 # 0.2.25
 
 * Added concept `mbo::types::IsVariant`.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ The C++ library is organized in functional groups each residing in their own dir
                 * The output is a comma separated list of field values, e.g. `{ 25, 42 }`.
                 * If available (Clang 16+) this function prints field names `{ first = 25, second = 42 }`.
             * extender-struct `Streamable`: Extender that injects functionality to make an `Extend`ed type streamable. This allows the type to be used directly with `std::ostream`s.
+    * mbo/types:hash_cc, mbo/types/hash.h
+        * function `GetHash(std::string_view)`: A constexpr capable hash function.
     * mbo/types:no_destruct_cc, mbo/types/no_destruct.h
         * struct `NoDestruct<T>`: Implements a type that allows to use any type as a static constant.
         * Mainly, this prevents calling the destructor and thus prevents termination issues (initialization order fiasco).

--- a/mbo/types/BUILD.bazel
+++ b/mbo/types/BUILD.bazel
@@ -68,6 +68,21 @@ cc_test(
 )
 
 cc_library(
+    name = "hash_cc",
+    hdrs = ["hash.h"],
+    visibility = ["//visibility:public"],
+)
+
+cc_test(
+    name = "hash_test",
+    srcs = ["hash_test.cc"],
+    deps = [
+        ":hash_cc",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
     name = "no_destruct_cc",
     hdrs = ["no_destruct.h"],
     visibility = ["//visibility:public"],
@@ -137,6 +152,7 @@ cc_library(
     name = "tstring_cc",
     srcs = ["tstring.h"],
     hdrs = ["tstring.h"],
+    deps = [":hash_cc"],
     visibility = ["//visibility:public"],
 )
 
@@ -146,6 +162,7 @@ cc_test(
     srcs = ["tstring_test.cc"],
     deps = [
         ":tstring_cc",
+        "@com_google_absl//absl/hash:hash_testing",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/mbo/types/hash.h
+++ b/mbo/types/hash.h
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MBO_TYPES_HASH_H_
+#define MBO_TYPES_HASH_H_
+
+#include <cstdint>
+#include <cstring>
+#include <string_view>
+#include <type_traits>
+
+namespace mbo::types {
+
+// In theory this should be a random number or at least an arbitray number that
+// changes on every program start. Howeverm this number must be constexpr.
+static constexpr uint64_t kMaybeRandom = 5'008'709'998'333'326'415ULL;
+
+inline constexpr uint64_t GetHash(std::string_view data) {
+  // NOLINTBEGIN(*-magic-numbers)
+  if (data.empty()) {
+    return 0x892df5cfULL ^ kMaybeRandom;  // Arbitrary number (neither 0 nor -1).
+  }
+  constexpr uint64_t kPrimeNum10k = 104'729ULL;
+  // Below we use an optimized form that directly reads from memory (using`memcpy`). However, that
+  // is not allowed in a constant evaluated expression (assign result to constexpr var). In order to
+  // work around that limitation, we check `std::is_constant_evaluated()` and provide a slower, yet
+  // compile-time evaluated variant. Now we could think that the function needs to be checked in
+  // `if constexpr ()`, but that leads to nice errors as it would seemingly always be true.
+  // Clang: error: 'std::is_constant_evaluated' will always evaluate to 'true' in a manifestly
+  //               constant-evaluated expression [-Werror,-Wconstant-evaluated]
+  // GCC:   error: 'std::is_constant_evaluated' always evaluates to true in 'if constexpr'
+  //               [-Werror=tautological-compare]
+  if (std::is_constant_evaluated()) {
+    std::size_t len = data.length();
+    uint64_t result = kMaybeRandom;
+    std::size_t pos = 0;
+    while (len >= 4) {
+      uint64_t add = 0;
+      add += static_cast<uint64_t>(data[pos++]);
+      add += static_cast<uint64_t>(data[pos++]) << 8U;
+      add += static_cast<uint64_t>(data[pos++]) << 16U;
+      add += static_cast<uint64_t>(data[pos++]) << 24U;
+      result = result * 6'571 + (17 * add + (add >> 16U));
+      len -= 4;
+    }
+    if (len == 3) {
+      uint64_t add = 0;
+      add += static_cast<uint64_t>(data[pos++]);
+      add += static_cast<uint64_t>(data[pos++]) << 8U;
+      add += static_cast<uint64_t>(data[pos++]) << 16U;
+      return result * 193 + kPrimeNum10k * add;
+    } else if (len == 2) {
+      uint64_t add = 0;
+      add += static_cast<uint64_t>(data[pos++]);
+      add += static_cast<uint64_t>(data[pos++]) << 8U;
+      return result * 193 + kPrimeNum10k * add;
+    } else if (len == 1) {
+      uint64_t add = 0;
+      add += static_cast<uint64_t>(data[pos++]);
+      return result * 193 + kPrimeNum10k * add;
+    }
+    return result;
+  } else {
+    const char* str = data.data();
+    const char* end = data.end() - 3;
+    uint64_t result = kMaybeRandom;
+    uint64_t add = 0;
+    while (str < end) {
+      std::memcpy(&add, str, 4);
+      result = result * 6'571 + (17 * add + (add >> 16U));
+      str += 4;  // NOLINT(*-pointer-arithmetic)
+    }
+    switch (data.length() % 4) {  // NOLINT(*-default-case)
+      case 3:
+        add = 0;
+        std::memcpy(&add, str, 3);
+        return result * 193 + kPrimeNum10k * add;
+      case 2:
+        add = 0;
+        std::memcpy(&add, str, 2);
+        return result * 193 + kPrimeNum10k * add;
+      case 1:
+        add = 0;
+        std::memcpy(&add, str, 1);
+        return result * 193 + kPrimeNum10k * add;
+      case 0: return result;
+    }
+    return result;
+  }
+  // NOLINTEND(*-magic-numbers)
+}
+
+}  // namespace mbo::types
+
+#endif  // MBO_TYPES_HASH_H_

--- a/mbo/types/hash_test.cc
+++ b/mbo/types/hash_test.cc
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mbo/types/hash.h"
+
+#include <array>
+#include <string_view>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+// NOLINTBEGIN(cppcoreguidelines-pro-bounds-constant-array-index)
+
+namespace mbo::types {
+namespace {
+
+struct HashTest : ::testing::Test {};
+
+TEST_F(HashTest, TestEmty) {
+  constexpr std::size_t kHashEmpty = GetHash("");
+  constexpr std::size_t kHashNull = GetHash(std::string_view());
+  EXPECT_THAT(kHashEmpty, kHashNull);
+  // By providing non const string_view variables to `GetHash` the non constexpr version will
+  // be chosen.
+  std::string_view sv_empty{""};  // NOLINT(*-redundant-string-init)
+  std::string_view sv_null{};
+  const std::size_t hash_empty = GetHash(sv_empty);
+  const std::size_t hash_null = GetHash(sv_null);
+  EXPECT_THAT(kHashEmpty, hash_empty);
+  EXPECT_THAT(kHashEmpty, hash_null);
+}
+
+TEST_F(HashTest, Test) {
+  constexpr std::array<std::string_view, 10> kData{
+      "1", "12", "123", "1234", "12345", "123456", "1234567", "12345678", "123456789", "1234567890",
+  };
+  // Generate the constexpr hashes.
+  constexpr std::array<uint64_t, kData.size()> kHashes{
+      GetHash(kData[0]), GetHash(kData[1]), GetHash(kData[2]), GetHash(kData[3]), GetHash(kData[4]),
+      GetHash(kData[5]), GetHash(kData[6]), GetHash(kData[7]), GetHash(kData[8]), GetHash(kData[9]),
+  };
+  std::string_view sv;
+  for (std::size_t n = 0; n < kData.size(); ++n) {
+    sv = kData[n];
+    EXPECT_THAT(GetHash(sv), kHashes[n]) << "Using the non const `string_view sv` to compute a hash should result the "
+                                            "same value as the compile-time computed hash.";
+  }
+}
+
+}  // namespace
+}  // namespace mbo::types
+
+// NOLINTEND(cppcoreguidelines-pro-bounds-constant-array-index)


### PR DESCRIPTION
* Implement `GetHash(std::string_view)` which is constexpr capable.
* Add hash support to tstring.
