### PR TITLE
Move hash functionality into new hash library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.2.26
 
-* Added `GetHash(std::string_view)` which is constexpr safe.
+* Added `mbo::hash::simple::GetHash(std::string_view)` which is constexpr safe.
 * Added hash support to tstring.
 
 # 0.2.25

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ The C++ library is organized in functional groups each residing in their own dir
         * function `SetContents`: Writes contents to a file.
     * mbo/file/ini:ini_file_cc, mbo/file/ini/ini_file.h
         * class `IniFile`: A simple INI file reader.
+* Hash
+    * `namespace mbo::hash`
+    * mbo/hash:hash_cc, mbo/hash/hash.h
+        * function `simple::GetHash(std::string_view)`: A constexpr capable hash function.
 * Mope
     * `namespace mbo::mope`
     * The `MOPE` templating engine. Run `bazel run //mbo/mope -- --help` for detailed documentation.
@@ -115,8 +119,6 @@ The C++ library is organized in functional groups each residing in their own dir
                 * The output is a comma separated list of field values, e.g. `{ 25, 42 }`.
                 * If available (Clang 16+) this function prints field names `{ first = 25, second = 42 }`.
             * extender-struct `Streamable`: Extender that injects functionality to make an `Extend`ed type streamable. This allows the type to be used directly with `std::ostream`s.
-    * mbo/types:hash_cc, mbo/types/hash.h
-        * function `GetHash(std::string_view)`: A constexpr capable hash function.
     * mbo/types:no_destruct_cc, mbo/types/no_destruct.h
         * struct `NoDestruct<T>`: Implements a type that allows to use any type as a static constant.
         * Mainly, this prevents calling the destructor and thus prevents termination issues (initialization order fiasco).

--- a/mbo/hash/BUILD.bazel
+++ b/mbo/hash/BUILD.bazel
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//visibility:private"])
+
+cc_library(
+    name = "hash_cc",
+    srcs = ["hash_simple.h"],
+    hdrs = ["hash.h"],
+    visibility = ["//visibility:public"],
+)
+
+cc_test(
+    name = "hash_test",
+    srcs = ["hash_test.cc"],
+    deps = [
+        ":hash_cc",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/mbo/hash/hash.h
+++ b/mbo/hash/hash.h
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MBO_HASH_HASH_H_
+#define MBO_HASH_HASH_H_
+
+#include "mbo/hash/hash_simple.h"  // IWYU pragma: export
+
+#endif  // MBO_HASH_HASH_H_

--- a/mbo/hash/hash_simple.h
+++ b/mbo/hash/hash_simple.h
@@ -13,20 +13,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef MBO_TYPES_HASH_H_
-#define MBO_TYPES_HASH_H_
+#ifndef MBO_HASH_SIMPLE_HASH_H_
+#define MBO_HASH_SIMPLE_HASH_H_
+
+// IWYU pragma: private, include "mbo/hash/hash.h"
 
 #include <cstdint>
 #include <cstring>
 #include <string_view>
 #include <type_traits>
 
-namespace mbo::types {
+// Namespace `mbo::hash::simple` offers a `GetHash` a constexpr safe simple hash function.
+namespace mbo::hash::simple {
 
 // In theory this should be a random number or at least an arbitray number that
 // changes on every program start. Howeverm this number must be constexpr.
 static constexpr uint64_t kMaybeRandom = 5'008'709'998'333'326'415ULL;
 
+// A simple constexpr safe hash function. This function uses an optimized implementation at run-time
+// and a constexpr safe implementation that yields the exact same values for compile-time usage.
 inline constexpr uint64_t GetHash(std::string_view data) {
   // NOLINTBEGIN(*-magic-numbers)
   if (data.empty()) {
@@ -102,6 +107,6 @@ inline constexpr uint64_t GetHash(std::string_view data) {
   // NOLINTEND(*-magic-numbers)
 }
 
-}  // namespace mbo::types
+}  // namespace mbo::hash::simple
 
-#endif  // MBO_TYPES_HASH_H_
+#endif  // MBO_HASH_SIMPLE_HASH_H_

--- a/mbo/hash/hash_test.cc
+++ b/mbo/hash/hash_test.cc
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "mbo/types/hash.h"
+#include "mbo/hash/hash.h"
 
 #include <array>
 #include <string_view>
@@ -23,8 +23,10 @@
 
 // NOLINTBEGIN(cppcoreguidelines-pro-bounds-constant-array-index)
 
-namespace mbo::types {
+namespace mbo::hash::simple {
 namespace {
+
+using ::testing::Ne;
 
 struct HashTest : ::testing::Test {};
 
@@ -32,8 +34,7 @@ TEST_F(HashTest, TestEmty) {
   constexpr std::size_t kHashEmpty = GetHash("");
   constexpr std::size_t kHashNull = GetHash(std::string_view());
   EXPECT_THAT(kHashEmpty, kHashNull);
-  // By providing non const string_view variables to `GetHash` the non constexpr version will
-  // be chosen.
+  // Force using non constexpr `GetHash` by providing a non const string_view variable.
   std::string_view sv_empty{""};  // NOLINT(*-redundant-string-init)
   std::string_view sv_null{};
   const std::size_t hash_empty = GetHash(sv_empty);
@@ -53,13 +54,17 @@ TEST_F(HashTest, Test) {
   };
   std::string_view sv;
   for (std::size_t n = 0; n < kData.size(); ++n) {
+    // Force using non constexpr `GetHash` by providing a non const string_view variable.
     sv = kData[n];
     EXPECT_THAT(GetHash(sv), kHashes[n]) << "Using the non const `string_view sv` to compute a hash should result the "
                                             "same value as the compile-time computed hash.";
+    EXPECT_THAT(GetHash(sv), Ne(0));
+    EXPECT_THAT(GetHash(sv), Ne(-1));
+    EXPECT_THAT(GetHash(sv), Ne(~0ULL));
   }
 }
 
 }  // namespace
-}  // namespace mbo::types
+}  // namespace mbo::hash::simple
 
 // NOLINTEND(cppcoreguidelines-pro-bounds-constant-array-index)

--- a/mbo/types/BUILD.bazel
+++ b/mbo/types/BUILD.bazel
@@ -68,21 +68,6 @@ cc_test(
 )
 
 cc_library(
-    name = "hash_cc",
-    hdrs = ["hash.h"],
-    visibility = ["//visibility:public"],
-)
-
-cc_test(
-    name = "hash_test",
-    srcs = ["hash_test.cc"],
-    deps = [
-        ":hash_cc",
-        "@com_google_googletest//:gtest_main",
-    ],
-)
-
-cc_library(
     name = "no_destruct_cc",
     hdrs = ["no_destruct.h"],
     visibility = ["//visibility:public"],
@@ -152,7 +137,7 @@ cc_library(
     name = "tstring_cc",
     srcs = ["tstring.h"],
     hdrs = ["tstring.h"],
-    deps = [":hash_cc"],
+    deps = ["//mbo/hash:hash_cc"],
     visibility = ["//visibility:public"],
 )
 
@@ -162,6 +147,7 @@ cc_test(
     srcs = ["tstring_test.cc"],
     deps = [
         ":tstring_cc",
+        "//mbo/hash:hash_cc",
         "@com_google_absl//absl/hash:hash_testing",
         "@com_google_googletest//:gtest_main",
     ],

--- a/mbo/types/tstring_test.cc
+++ b/mbo/types/tstring_test.cc
@@ -23,7 +23,7 @@
 #include "absl/hash/hash_testing.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "mbo/types/hash.h"
+#include "mbo/hash/hash.h"
 
 namespace mbo::types {
 namespace {
@@ -658,13 +658,15 @@ TEST_F(TStringTest, FindFirstLast) {
 }
 
 TEST_F(TStringTest, StdHash) {
+  using ::mbo::hash::simple::GetHash;
   // "bar"_ts
   constexpr tstring<'b', 'a', 'r'> kTsBar;
   using TsBar = decltype(kTsBar);
   const std::size_t k_bar_hash_ts = std::hash<TsBar>{}(kTsBar);
   EXPECT_THAT(std::hash<TsBar>{}(), k_bar_hash_ts);
   constexpr auto kBarDirectHashTs = GetHash("bar");
-  EXPECT_THAT(kBarDirectHashTs, k_bar_hash_ts);
+  EXPECT_THAT(kBarDirectHashTs, Ne(k_bar_hash_ts));
+  EXPECT_THAT(kBarDirectHashTs, decltype(kTsBar)::StringHash());
   std::string_view vs_bar{"bar"};
   const auto k_bar_volatile_hash_ts = GetHash(vs_bar);
   EXPECT_THAT(k_bar_volatile_hash_ts, kBarDirectHashTs);
@@ -674,7 +676,8 @@ TEST_F(TStringTest, StdHash) {
   const std::size_t k_foo_hash_ts = std::hash<TsFoo>{}(kTsFoo);
   EXPECT_THAT(std::hash<TsFoo>{}(), k_foo_hash_ts);
   constexpr auto kFooDirectHashTs = GetHash("foo");
-  EXPECT_THAT(kFooDirectHashTs, k_foo_hash_ts);
+  EXPECT_THAT(kFooDirectHashTs, Ne(k_foo_hash_ts));
+  EXPECT_THAT(kFooDirectHashTs, decltype(kTsFoo)::StringHash());
   std::string_view vs_foo{"foo"};
   const auto k_foo_volatile_hash_ts = GetHash(vs_foo);
   EXPECT_THAT(k_foo_volatile_hash_ts, kFooDirectHashTs);


### PR DESCRIPTION
Move hash functionality into new hash library `//mbo/hash` with namespace `mbo::hash`.