### PR TITLE
Small fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.2.27
+
+* Fixed comparison of `Extend` types with other types. Requires the other type can be turned into a tuple.
+* Fixed internal consistencies.
+* Updated `mope` to allow comments by setting a section to nothing: `{{#section=}}...{{/section}}`.
+* Added concept `IsTuple` which determines whether a type is a `std::tuple`.
+
 # 0.2.26
 
 * Added `mbo::hash::simple::GetHash(std::string_view)` which is constexpr safe.

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ The C++ library is organized in functional groups each residing in their own dir
         * concept `IsBracesConstructibleV` determines whether a type can be constructe from given argument types.
         * concept `IsPair` determines whether a type is a `std::pair`.
         * concept `IsSameAsAnyOfRaw` / `NotSameAsAnyOfRaw` which determine whether type is one of a list of types.
+        * concept `IsTuple` determines whether a type is a `std::tuple`.
         * concept `IsVariant` determines whether a type is a `std::variant` type.
     * mbo/types:tstring_cc, mbo/types/tstring.h
         * struct `tstring`: Implements type `tstring` a compile time string-literal type.

--- a/mbo/mope/mope.cc
+++ b/mbo/mope/mope.cc
@@ -352,6 +352,10 @@ absl::Status Template::ExpandSectionTag(const TagInfo& tag, Context& ctx, std::s
   if (RE2::FullMatch(*tag.config, *kReFor, &range.start, &range.end, &range.step, &range.join)) {
     return ExpandRangeData(tag, range, ctx, output);
   }
+  if (*tag.config == "") {
+    output = "";
+    return absl::OkStatus();
+  }
   if (!tag.config->starts_with('[')) {
     return absl::UnimplementedError(
         absl::StrCat("Tag '", tag.name, "' has unknown config format '", *tag.config, "'."));
@@ -393,7 +397,7 @@ absl::StatusOr<bool> Template::ExpandValueTag(const TagInfo& tag, Context& ctx, 
 std::optional<const Template::TagInfo> Template::FindAndConsumeTag(std::string_view& pos) {
   // Grab parts as string_view. Done in a separate block so these cannot escape.
   // They will be invalid upon the first change of `output`.
-  static constexpr LazyRE2 kTagRegex = {"({{(#?)([_a-zA-Z]\\w*)(?:([=:])((?:[^}]|[}][^}])+))?}})"};
+  static constexpr LazyRE2 kTagRegex = {"({{(#?)([_a-zA-Z]\\w*)(?:([=:])((?:[^}]|[}][^}])*))?}})"};
   std::string_view start;
   std::string_view type;
   std::string_view name;

--- a/mbo/mope/mope_main.cc
+++ b/mbo/mope/mope_main.cc
@@ -108,7 +108,7 @@ that are made up of sections and values.
 calling `SetValue`.
 
 ```c++
-mbo::mope::Templaye mope;
+mbo::mope::Template mope;
 mope.SetValue("foo", "bar");
 std::string output("My {{foo}}.");
 mope.Expand(output);
@@ -120,7 +120,7 @@ times for the same `name` which becomes the section name. The section starts
 with '{{#' <name> (':' <join>)? '}}' and ends with '{{/' <name> '}};.
 
 ```c++
-mbo::mope::Templaye mope;
+mbo::mope::Template mope;
 mope.AddSectionDictinary("section")->SetValue("foo", "bar");
 mope.AddSectionDictinary("section")->SetValue("foo", "-");
 mope.AddSectionDictinary("section")->SetValue("foo", "baz");
@@ -134,7 +134,15 @@ The optional <join> value can be a quoted string or a reference. It is used to
 join the section values and won't be used if the section has fewer then 2
 elements.
 
-3) The template supports for-loops:
+3) Comments
+
+'{{#'<name>'=}}'...'{{/'<name>'}}'
+
+The section tags can have additional configurations as explained below. However,
+there is a special configuration, the empty one, which is otherwise illegal. It
+functions as a comment becasue it replaces the whole section with nothing.
+
+4) The template supports for-loops:
 
 '{{#'<name>'='<start>';'<end>(';'<step>(';'<join> )? )? '}}'...'{{/'<name>'}}'
 
@@ -151,14 +159,14 @@ This creates an automatic 'section' with a dynamic value under <name> which
 can be accessed by '{{' <name> '}}'.
 
 ```c++
-mbo::mope::Templaye mope;
+mbo::mope::Template mope;
 mope.SetValue("max", "5");
-std::string output("My {{#foo=1;max;2;"."}}{{foo}}{{/foor}}");
+std::string output("My {{#foo=1;max;2;"."}}{{foo}}{{/foo}}");
 mope.Expand(output);
 CHECK_EQ(output, "My 1.3.5.");
 ```
 
-4) The template allows to set tags from within the template. This allows to
+5) The template allows to set tags from within the template. This allows to
 provide centralized configuration values for instance to for-loops. The values
 are global but can be overwritten at any point. However, they cannot override
 template tags.
@@ -166,17 +174,17 @@ template tags.
 These are value tags with a configuration: '{{' <<name> '=' <value> '}}'
 
 ```c++
-mbo::mope::Templaye mope;
+mbo::mope::Template mope;
 std::string output(R"(
    {{foo_start=1}}
    {{foo_end=8}}
    {{foo_step=2}}
-   My {{#foo=foo_start;foo_end;foo_step;'.'}}{{foo}}{{/foor}})"R);
+   My {{#foo=foo_start;foo_end;foo_step;'.'}}{{foo}}{{/foo}})"R);
 mope.Expand(output);
 CHECK_EQ(output, "My 1.3.5.7.");
 ```
 
-5) The template supports lists:
+6) The template supports lists:
 
 '{{#' <name> '=[' <values> '] (';' <join>)? }}'...'{{/'<name>'}}'
 
@@ -188,7 +196,7 @@ CHECK_EQ(output, "My 1.3.5.7.");
               reference or a string in single (') or double quotes (").
 
 ```c++
-mbo::mope::Templaye mope;
+mbo::mope::Template mope;
 std::string output(R"({{#foo=['1,2',3\,4]}}[{{foo}}]{{/foo}})"R);
 mope.Expand(output);
 CHECK_EQ(output, "[1,2][3,4]");

--- a/mbo/types/extend.h
+++ b/mbo/types/extend.h
@@ -87,7 +87,7 @@ namespace std {
 // }
 // ```
 template<typename Extended>
-requires mbo::types_internal::HasExtender<Extended, mbo::types::extender::AbslHashable>
+requires mbo::types::types_internal::HasExtender<Extended, mbo::types::extender::AbslHashable>
 struct hash<Extended> {  // NOLINT(cert-dcl58-cpp)
 
   std::size_t operator()(const Extended& obj) const noexcept { return absl::HashOf(obj); }

--- a/mbo/types/extend_test.cc
+++ b/mbo/types/extend_test.cc
@@ -76,8 +76,8 @@ using ::testing::WhenSorted;
 static_assert(std::same_as<::mbo::types::extender::AbslStringify, ::mbo::extender::AbslStringify>);
 static_assert(std::same_as<::mbo::types::extender::Default, ::mbo::extender::Default>);
 
-static_assert(::mbo::types_internal::ExtenderListValid<::mbo::extender::Default>);
-static_assert(::mbo::types_internal::ExtenderListValid<AbslHashable, AbslStringify, Comparable, Printable, Streamable>);
+static_assert(::mbo::types::types_internal::ExtenderListValid<::mbo::extender::Default>);
+static_assert(::mbo::types::types_internal::ExtenderListValid<AbslHashable, AbslStringify, Comparable, Printable, Streamable>);
 
 struct Empty {};
 
@@ -412,11 +412,21 @@ TEST_F(ExtendTest, Comparable) {
     int a = 0;
     int b = 0;
   };
+  struct Flat {
+    int a = 0;
+    int b = 0;
+  };
 
   constexpr TestComparable kTest1{.a = 25, .b = 42};
   constexpr TestComparable kTest2{.a = 25, .b = 43};
   constexpr TestComparable kTest3{.a = 26, .b = 42};
   constexpr TestComparable kTest4{.a = 25, .b = 42};
+
+  constexpr Flat kFlat1{.a = 25, .b = 42};
+  constexpr Flat kFlat2{.a = 25, .b = 43};
+  constexpr Flat kFlat3{.a = 26, .b = 42};
+  constexpr Flat kFlat4{.a = 25, .b = 42};
+
   {
     EXPECT_THAT(kTest1 == kTest1, true);
     EXPECT_THAT(kTest1 != kTest1, false);
@@ -424,7 +434,22 @@ TEST_F(ExtendTest, Comparable) {
     EXPECT_THAT(kTest1 <= kTest1, true);
     EXPECT_THAT(kTest1 > kTest1, false);
     EXPECT_THAT(kTest1 >= kTest1, true);
-    EXPECT_THAT(kTest1, kTest1);  // sortcut for Eq, see below
+    // Same kind of comparison, just with similar type.
+    EXPECT_THAT(kTest1 == kFlat1, true);
+    EXPECT_THAT(kTest1 != kFlat1, false);
+    EXPECT_THAT(kTest1 < kFlat1, false);
+    EXPECT_THAT(kTest1 <= kFlat1, true);
+    EXPECT_THAT(kTest1 > kFlat1, false);
+    EXPECT_THAT(kTest1 >= kFlat1, true);
+    // Same kind of comparison, just with similar type, otherway round.
+    EXPECT_THAT(kFlat1 == kTest1, true);
+    EXPECT_THAT(kFlat1 != kTest1, false);
+    EXPECT_THAT(kFlat1 < kTest1, false);
+    EXPECT_THAT(kFlat1 <= kTest1, true);
+    EXPECT_THAT(kFlat1 > kTest1, false);
+    EXPECT_THAT(kFlat1 >= kTest1, true);
+    // Gmock
+    EXPECT_THAT(kTest1, kTest1);  // shortcut for Eq, see below
     EXPECT_THAT(kTest1, Eq(kTest1));
     EXPECT_THAT(kTest1, Not(Lt(kTest1)));
     EXPECT_THAT(kTest1, Le(kTest1));
@@ -438,6 +463,14 @@ TEST_F(ExtendTest, Comparable) {
     EXPECT_THAT(kTest1 <= kTest2, true);
     EXPECT_THAT(kTest1 > kTest2, false);
     EXPECT_THAT(kTest1 >= kTest2, false);
+    // Same kind of comparison, just with similar type.
+    EXPECT_THAT(kTest1 == kFlat2, false);
+    EXPECT_THAT(kTest1 != kFlat2, true);
+    EXPECT_THAT(kTest1 < kFlat2, true);
+    EXPECT_THAT(kTest1 <= kFlat2, true);
+    EXPECT_THAT(kTest1 > kFlat2, false);
+    EXPECT_THAT(kTest1 >= kFlat2, false);
+    // GMock
     EXPECT_THAT(kTest1, Not(kTest2));
     EXPECT_THAT(kTest1, Not(Eq(kTest2)));
     EXPECT_THAT(kTest1, Lt(kTest2));
@@ -452,6 +485,14 @@ TEST_F(ExtendTest, Comparable) {
     EXPECT_THAT(kTest1 <= kTest3, true);
     EXPECT_THAT(kTest1 > kTest3, false);
     EXPECT_THAT(kTest1 >= kTest3, false);
+    // Same kind of comparison, just with similar type.
+    EXPECT_THAT(kTest1 == kFlat3, false);
+    EXPECT_THAT(kTest1 != kFlat3, true);
+    EXPECT_THAT(kTest1 < kFlat3, true);
+    EXPECT_THAT(kTest1 <= kFlat3, true);
+    EXPECT_THAT(kTest1 > kFlat3, false);
+    EXPECT_THAT(kTest1 >= kFlat3, false);
+    // GMock
     EXPECT_THAT(kTest1, Not(kTest3));
     EXPECT_THAT(kTest1, Not(Eq(kTest3)));
     EXPECT_THAT(kTest1, Lt(kTest3));
@@ -466,7 +507,15 @@ TEST_F(ExtendTest, Comparable) {
     EXPECT_THAT(kTest1 <= kTest4, true);
     EXPECT_THAT(kTest1 > kTest4, false);
     EXPECT_THAT(kTest1 >= kTest4, true);
-    EXPECT_THAT(kTest1, kTest4);  // sortcut for Eq, see below
+    // Same kind of comparison, just with similar type.
+    EXPECT_THAT(kTest1 == kFlat4, true);
+    EXPECT_THAT(kTest1 != kFlat4, false);
+    EXPECT_THAT(kTest1 < kFlat4, false);
+    EXPECT_THAT(kTest1 <= kFlat4, true);
+    EXPECT_THAT(kTest1 > kFlat4, false);
+    EXPECT_THAT(kTest1 >= kFlat4, true);
+    // GMock
+    EXPECT_THAT(kTest1, kTest4);  // shortcut for Eq, see below
     EXPECT_THAT(kTest1, Eq(kTest4));
     EXPECT_THAT(kTest1, Not(Lt(kTest4)));
     EXPECT_THAT(kTest1, Le(kTest4));
@@ -529,13 +578,13 @@ TEST_F(ExtendTest, Hashable) {
 
   EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly({person, Person{}}));
 
-  ASSERT_THAT((::mbo::types_internal::IsExtended<Name>), true);
-  ASSERT_THAT((::mbo::types_internal::IsExtended<Person>), true);
-  ASSERT_THAT((::mbo::types_internal::IsExtended<PlainName>), false);
-  ASSERT_THAT((::mbo::types_internal::IsExtended<PlainPerson>), false);
+  ASSERT_THAT((::mbo::types::types_internal::IsExtended<Name>), true);
+  ASSERT_THAT((::mbo::types::types_internal::IsExtended<Person>), true);
+  ASSERT_THAT((::mbo::types::types_internal::IsExtended<PlainName>), false);
+  ASSERT_THAT((::mbo::types::types_internal::IsExtended<PlainPerson>), false);
   ASSERT_THAT(Person::RegisteredExtenderNames(), Contains("AbslHashable"));
   ASSERT_THAT(Person::RegisteredExtenderNames().size(), std::tuple_size_v<Person::RegisteredExtenders>);
-  ASSERT_THAT((::mbo::types_internal::HasExtender<Person, AbslHashable>), true);
+  ASSERT_THAT((::mbo::types::types_internal::HasExtender<Person, AbslHashable>), true);
 
   EXPECT_THAT(absl::HashOf(person), Ne(0));
   EXPECT_THAT(absl::HashOf(person), absl::HashOf(plain_person));
@@ -546,8 +595,8 @@ TEST_F(ExtendTest, Hashable) {
     std::string last;
   };
 
-  ASSERT_THAT((::mbo::types_internal::IsExtended<NameNoDefault>), true);
-  ASSERT_THAT((::mbo::types_internal::HasExtender<NameNoDefault, AbslHashable>), false);
+  ASSERT_THAT((::mbo::types::types_internal::IsExtended<NameNoDefault>), true);
+  ASSERT_THAT((::mbo::types::types_internal::HasExtender<NameNoDefault, AbslHashable>), false);
 }
 
 TEST_F(ExtendTest, ExtenderNames) {

--- a/mbo/types/extender.h
+++ b/mbo/types/extender.h
@@ -63,6 +63,7 @@
 #include "mbo/types/internal/struct_names.h"  // IWYU pragma: keep
 #include "mbo/types/traits.h"                 // IWYU pragma: keep
 #include "mbo/types/tstring.h"
+#include "mbo/types/tuple.h"
 
 namespace mbo::types {
 
@@ -234,15 +235,23 @@ struct Comparable_ : ExtenderBase {  // NOLINT(readability-identifier-naming)
   friend bool operator<(const T& lhs, const T& rhs) { return lhs.ToTuple() < rhs.ToTuple(); }
 
   // Define operator `<=>` on `const T&` and another type.
-  template<typename Lhs>
-  friend auto operator<=>(const Lhs& lhs, const T& rhs) {
-    return lhs <=> rhs.ToTupl();
-  }
+  template<typename Other, typename = decltype(StructToTuple(std::declval<const Other&>()))>
+  auto operator<=>(const Other& other) const { return this->ToTuple() <=> StructToTuple(other); }
 
-  template<typename Rhs>
-  friend auto operator<=>(const T& lhs, const Rhs& rhs) {
-    return lhs.ToTuple() <=> rhs;
-  }
+  template<IsTuple Other>
+  auto operator<=>(const Other& other) const { return this->ToTuple() <=> other; }
+
+  template<typename Other, typename = decltype(StructToTuple(std::declval<const Other&>()))>
+  bool operator==(const Other& other) const { return this->ToTuple() == StructToTuple(other); }
+
+  template<IsTuple Other>
+  bool operator==(const Other& other) const { return this->ToTuple() == other; }
+
+  template<typename Other, typename = decltype(StructToTuple(std::declval<const Other&>()))>
+  bool operator<(const Other& other) const { return this->ToTuple() < StructToTuple(other); }
+
+  template<IsTuple Other>
+  bool operator<(const Other& other) const { return this->ToTuple() < other; }
 };
 
 template<typename ExtenderBase>

--- a/mbo/types/internal/BUILD.bazel
+++ b/mbo/types/internal/BUILD.bazel
@@ -77,5 +77,8 @@ mope_test(
     name = "decompose_count_test",
     srcs = ["decompose_count.h.mope"],
     outs = ["decompose_count.h"],
+    args = [
+      #"--set=clang_pre_17=x",
+    ],
     clang_format = True,
 )

--- a/mbo/types/internal/decompose_count.h
+++ b/mbo/types/internal/decompose_count.h
@@ -85,377 +85,6 @@ struct AggregateHasNonEmptyBaseImpl : AggregateHasNonEmptyBaseRaw<std::remove_cv
 template<typename T>
 concept AggregateHasNonEmptyBase = AggregateHasNonEmptyBaseImpl<T>::value;
 
-#if defined(__clang__) && __clang_major__ < 17
-// ----------------------------------------------------
-
-template<typename T, size_t N, typename = void>
-struct DecomposeCount final : std::false_type {};
-
-template<typename T>
-struct DecomposeCount<T, 1, std::void_t<decltype([]() { const auto& [a1] = T(); })>> final : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<T, 2, std::void_t<decltype([]() { const auto& [a1, a2] = T(); })>> final : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<T, 3, std::void_t<decltype([]() { const auto& [a1, a2, a3] = T(); })>> final : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<T, 4, std::void_t<decltype([]() { const auto& [a1, a2, a3, a4] = T(); })>> final
-    : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<T, 5, std::void_t<decltype([]() { const auto& [a1, a2, a3, a4, a5] = T(); })>> final
-    : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<T, 6, std::void_t<decltype([]() { const auto& [a1, a2, a3, a4, a5, a6] = T(); })>> final
-    : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<T, 7, std::void_t<decltype([]() { const auto& [a1, a2, a3, a4, a5, a6, a7] = T(); })>> final
-    : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<T, 8, std::void_t<decltype([]() { const auto& [a1, a2, a3, a4, a5, a6, a7, a8] = T(); })>> final
-    : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<T, 9, std::void_t<decltype([]() { const auto& [a1, a2, a3, a4, a5, a6, a7, a8, a9] = T(); })>>
-    final : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<T, 10, std::void_t<decltype([]() {
-                        const auto& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10] = T();
-                      })>>
-    final : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<T, 11, std::void_t<decltype([]() {
-                        const auto& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11] = T();
-                      })>>
-    final : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<T, 12, std::void_t<decltype([]() {
-                        const auto& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12] = T();
-                      })>>
-    final : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<T, 13, std::void_t<decltype([]() {
-                        const auto& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13] = T();
-                      })>>
-    final : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<T, 14, std::void_t<decltype([]() {
-                        const auto& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14] = T();
-                      })>>
-    final : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<T, 15, std::void_t<decltype([]() {
-                        const auto& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15] = T();
-                      })>>
-    final : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<T, 16, std::void_t<decltype([]() {
-                        const auto& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16] = T();
-                      })>>
-    final : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<T, 17, std::void_t<decltype([]() {
-                        const auto& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17] = T();
-                      })>>
-    final : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<T, 18, std::void_t<decltype([]() {
-                        const auto& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18] =
-                            T();
-                      })>>
-    final : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<
-    T,
-    19,
-    std::void_t<decltype([]() {
-      const auto& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19] = T();
-    })>>
-    final : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<
-    T,
-    20,
-    std::void_t<decltype([]() {
-      const auto& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20] = T();
-    })>>
-    final : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<
-    T,
-    21,
-    std::void_t<decltype([]() {
-      const auto& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21] =
-          T();
-    })>>
-    final : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<
-    T,
-    22,
-    std::void_t<decltype([]() {
-      const auto& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22] =
-          T();
-    })>>
-    final : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<
-    T,
-    23,
-    std::void_t<decltype([]() {
-      const auto& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23] =
-          T();
-    })>>
-    final : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<
-    T,
-    24,
-    std::void_t<decltype([]() {
-      const auto& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24] =
-          T();
-    })>>
-    final : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<
-    T,
-    25,
-    std::void_t<decltype([]() {
-      const auto& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25] =
-          T();
-    })>>
-    final : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<
-    T,
-    26,
-    std::void_t<decltype([]() {
-      const auto& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26] =
-          T();
-    })>>
-    final : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<
-    T,
-    27,
-    std::void_t<decltype([]() {
-      const auto& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27] =
-          T();
-    })>>
-    final : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<
-    T,
-    28,
-    std::void_t<decltype([]() {
-      const auto& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28] =
-          T();
-    })>>
-    final : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<
-    T,
-    29,
-    std::void_t<decltype([]() {
-      const auto& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29] =
-          T();
-    })>>
-    final : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<
-    T,
-    30,
-    std::void_t<decltype([]() {
-      const auto& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30] =
-          T();
-    })>>
-    final : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<
-    T,
-    31,
-    std::void_t<decltype([]() {
-      const auto& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31] =
-          T();
-    })>>
-    final : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<
-    T,
-    32,
-    std::void_t<decltype([]() {
-      const auto& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32] =
-          T();
-    })>>
-    final : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<
-    T,
-    33,
-    std::void_t<decltype([]() {
-      const auto& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33] =
-          T();
-    })>>
-    final : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<
-    T,
-    34,
-    std::void_t<decltype([]() {
-      const auto& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34] =
-          T();
-    })>>
-    final : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<
-    T,
-    35,
-    std::void_t<decltype([]() {
-      const auto& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35] =
-          T();
-    })>>
-    final : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<
-    T,
-    36,
-    std::void_t<decltype([]() {
-      const auto& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36] =
-          T();
-    })>>
-    final : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<
-    T,
-    37,
-    std::void_t<decltype([]() {
-      const auto& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37] =
-          T();
-    })>>
-    final : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<
-    T,
-    38,
-    std::void_t<decltype([]() {
-      const auto& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38] =
-          T();
-    })>>
-    final : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<
-    T,
-    39,
-    std::void_t<decltype([]() {
-      const auto& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39] =
-          T();
-    })>>
-    final : std::true_type {};
-
-template<typename T>
-struct DecomposeCount<
-    T,
-    40,
-    std::void_t<decltype([]() {
-      const auto& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40] =
-          T();
-    })>>
-    final : std::true_type {};
-
-template<typename T>
-struct DecomposeCountnImpl
-    : std::integral_constant<
-          std::size_t,
-          CaseIndexImpl<
-              DecomposeCount<T, 1>,
-              DecomposeCount<T, 2>,
-              DecomposeCount<T, 3>,
-              DecomposeCount<T, 4>,
-              DecomposeCount<T, 5>,
-              DecomposeCount<T, 6>,
-              DecomposeCount<T, 7>,
-              DecomposeCount<T, 8>,
-              DecomposeCount<T, 9>,
-              DecomposeCount<T, 10>,
-              DecomposeCount<T, 11>,
-              DecomposeCount<T, 12>,
-              DecomposeCount<T, 13>,
-              DecomposeCount<T, 14>,
-              DecomposeCount<T, 15>,
-              DecomposeCount<T, 16>,
-              DecomposeCount<T, 17>,
-              DecomposeCount<T, 18>,
-              DecomposeCount<T, 19>,
-              DecomposeCount<T, 20>,
-              DecomposeCount<T, 21>,
-              DecomposeCount<T, 22>,
-              DecomposeCount<T, 23>,
-              DecomposeCount<T, 24>,
-              DecomposeCount<T, 25>,
-              DecomposeCount<T, 26>,
-              DecomposeCount<T, 27>,
-              DecomposeCount<T, 28>,
-              DecomposeCount<T, 29>,
-              DecomposeCount<T, 30>,
-              DecomposeCount<T, 31>,
-              DecomposeCount<T, 32>,
-              DecomposeCount<T, 33>,
-              DecomposeCount<T, 34>,
-              DecomposeCount<T, 35>,
-              DecomposeCount<T, 36>,
-              DecomposeCount<T, 37>,
-              DecomposeCount<T, 38>,
-              DecomposeCount<T, 39>,
-              DecomposeCount<T, 40>>::index> {};
-
-template<typename T>
-concept DecomposeConditionRaw = std::is_aggregate_v<T> && (std::is_empty_v<T> || DecomposeCountnImpl<T>::value != 0);
-
-template<typename T>
-concept DecomposeCondition = DecomposeConditionRaw<std::remove_cvref_t<T>>;
-
-template<typename T>
-struct DecomposeCountraw : std::conditional_t<DecomposeCondition<T>, DecomposeCountnImpl<T>, NotDecomposableImpl> {};
-
-template<typename T>
-struct DecomposeCountImpl : DecomposeCountraw<std::remove_cvref_t<T>> {};
-
-#else  // defined(__clang__) && __clang_major__ < 17
 // ----------------------------------------------------
 
 // From
@@ -735,15 +364,15 @@ struct DecomposeInfo final {
   static std::string Debug() {  // NOLINT(readability-function-cognitive-complexity)
     std::string str;
     std::string_view sep;
-# define DEBUG_ADD(f)                                                                             \
-   str += std::string(sep) + #f + ": "                                                            \
-          + (std::same_as<std::remove_cvref_t<decltype(DecomposeInfo<T>::f)>, bool>               \
-                 ? std::string(DecomposeInfo<T>::f ? "Yes" : "No")                                \
-                 : (std::same_as<std::remove_cvref_t<decltype(DecomposeInfo<T>::f)>, std::size_t> \
-                            && DecomposeInfo<T>::f == NotDecomposableImpl::value                  \
-                        ? std::string("N/A")                                                      \
-                        : std::to_string(DecomposeInfo<T>::f)));                                  \
-   sep = ", "
+#define DEBUG_ADD(f)                                                                             \
+  str += std::string(sep) + #f + ": "                                                            \
+         + (std::same_as<std::remove_cvref_t<decltype(DecomposeInfo<T>::f)>, bool>               \
+                ? std::string(DecomposeInfo<T>::f ? "Yes" : "No")                                \
+                : (std::same_as<std::remove_cvref_t<decltype(DecomposeInfo<T>::f)>, std::size_t> \
+                           && DecomposeInfo<T>::f == NotDecomposableImpl::value                  \
+                       ? std::string("N/A")                                                      \
+                       : std::to_string(DecomposeInfo<T>::f)));                                  \
+  sep = ", "
     DEBUG_ADD(kIsAggregate);
     DEBUG_ADD(kIsEmpty);
     // DEBUG_ADD(kInitializerCount);
@@ -756,7 +385,7 @@ struct DecomposeInfo final {
     // DEBUG_ADD(kCountBases);
     // DEBUG_ADD(kCountEmptyBases);
     DEBUG_ADD(kDecomposeCount);
-# undef DEBUG_ADD
+#undef DEBUG_ADD
     return str;
   }
 };
@@ -784,15 +413,15 @@ struct DecomposeInfo<T, true> final {
   static std::string Debug() {  // NOLINT(readability-function-cognitive-complexity)
     std::string str;
     std::string_view sep;
-# define DEBUG_ADD(f)                                                                             \
-   str += std::string(sep) + #f + ": "                                                            \
-          + (std::same_as<std::remove_cvref_t<decltype(DecomposeInfo<T>::f)>, bool>               \
-                 ? std::string(DecomposeInfo<T>::f ? "Yes" : "No")                                \
-                 : (std::same_as<std::remove_cvref_t<decltype(DecomposeInfo<T>::f)>, std::size_t> \
-                            && DecomposeInfo<T>::f == NotDecomposableImpl::value                  \
-                        ? std::string("N/A")                                                      \
-                        : std::to_string(DecomposeInfo<T>::f)));                                  \
-   sep = ", "
+#define DEBUG_ADD(f)                                                                             \
+  str += std::string(sep) + #f + ": "                                                            \
+         + (std::same_as<std::remove_cvref_t<decltype(DecomposeInfo<T>::f)>, bool>               \
+                ? std::string(DecomposeInfo<T>::f ? "Yes" : "No")                                \
+                : (std::same_as<std::remove_cvref_t<decltype(DecomposeInfo<T>::f)>, std::size_t> \
+                           && DecomposeInfo<T>::f == NotDecomposableImpl::value                  \
+                       ? std::string("N/A")                                                      \
+                       : std::to_string(DecomposeInfo<T>::f)));                                  \
+  sep = ", "
     DEBUG_ADD(kIsAggregate);
     DEBUG_ADD(kIsEmpty);
     DEBUG_ADD(kInitializerCount);
@@ -805,7 +434,7 @@ struct DecomposeInfo<T, true> final {
     DEBUG_ADD(kCountBases);
     DEBUG_ADD(kCountEmptyBases);
     DEBUG_ADD(kDecomposeCount);
-# undef DEBUG_ADD
+#undef DEBUG_ADD
     return str;
   }
 };
@@ -818,7 +447,6 @@ concept DecomposeCondition = DecomposeInfo<T>::kDecomposable;
 template<typename T>
 struct DecomposeCountImpl : std::integral_constant<std::size_t, DecomposeInfo<T>::kDecomposeCount> {};
 
-#endif  // defined(__clang__) && __clang_major__ < 17
 // ----------------------------------------------------
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)

--- a/mbo/types/internal/decompose_count.h.mope
+++ b/mbo/types/internal/decompose_count.h.mope
@@ -86,6 +86,7 @@ struct AggregateHasNonEmptyBaseImpl : AggregateHasNonEmptyBaseRaw<std::remove_cv
 template<typename T>
 concept AggregateHasNonEmptyBase = AggregateHasNonEmptyBaseImpl<T>::value;
 
+{{#clang_pre_17=}}
 #if defined(__clang__) && __clang_major__ < 17
 // ----------------------------------------------------
 
@@ -119,6 +120,7 @@ template<typename T>
 struct DecomposeCountImpl : DecomposeCountraw<std::remove_cvref_t<T>> {};
 
 #else  // defined(__clang__) && __clang_major__ < 17
+{{/clang_pre_17}}
 // ----------------------------------------------------
 
 // From
@@ -481,7 +483,9 @@ concept DecomposeCondition = DecomposeInfo<T>::kDecomposable;
 template<typename T>
 struct DecomposeCountImpl : std::integral_constant<std::size_t, DecomposeInfo<T>::kDecomposeCount> {};
 
+{{#clang_pre_17=}}
 #endif  // defined(__clang__) && __clang_major__ < 17
+{{/clang_pre_17}}
 // ----------------------------------------------------
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)

--- a/mbo/types/internal/extender.h
+++ b/mbo/types/internal/extender.h
@@ -20,6 +20,14 @@
 
 namespace mbo::types::types_internal {
 
+// Determine whether type `Extended` is an `Extend`ed type.
+template<typename Extended>
+concept IsExtended = requires {
+  typename Extended::Type;
+  typename Extended::RegisteredExtenders;
+  { Extended::RegisteredExtenderNames() };
+};
+
 // Access to the extender implementation for constructing the CRTP chain using
 // `ExtendBuildChain`.
 // This is done via a distinct struct, so that the non specialized templates

--- a/mbo/types/traits.h
+++ b/mbo/types/traits.h
@@ -319,6 +319,19 @@ struct IsVariantImpl<std::variant<Args...>> : std::true_type {};
 template<typename T>
 concept IsVariant = types_internal::IsVariantImpl<T>::value;
 
+namespace types_internal {
+
+template <typename T>
+struct is_tuple : std::false_type {};
+
+template <typename... Ts>
+struct is_tuple<std::tuple<Ts...>> : std::true_type {};
+
+}  // namespace types_internal
+
+template <typename T>
+concept IsTuple = types_internal::is_tuple<T>::value;
+
 }  // namespace mbo::types
 
 #endif  // MBO_TYPES_TRAITS_H_

--- a/mbo/types/traits_test.cc
+++ b/mbo/types/traits_test.cc
@@ -96,19 +96,11 @@ TEST_F(TraitsTest, DecomposeCountV) {
 
   ASSERT_THAT(IsAggregate<CtorDefault>, false);
   EXPECT_THAT(IsDecomposable<CtorDefault>, false);
-#if defined(__clang__) && __clang_major__ < 17
-  EXPECT_THAT(DecomposeCountV<CtorDefault>, NotDecomposableV);
-#else
   EXPECT_THAT(DecomposeCountV<CtorDefault>, 0);
-#endif
 
   ASSERT_THAT(IsAggregate<CtorUser>, false);
   EXPECT_THAT(IsDecomposable<CtorUser>, false);
-#if defined(__clang__) && __clang_major__ < 17
-  EXPECT_THAT(DecomposeCountV<CtorUser>, NotDecomposableV);
-#else
   EXPECT_THAT(DecomposeCountV<CtorUser>, 0);
-#endif
 
   ASSERT_THAT(types_internal::AggregateHasNonEmptyBase<CtorBase>, false);
   ASSERT_THAT(IsAggregate<CtorBase>, true);


### PR DESCRIPTION
* Fixed comparison of `Extend` types with other types. Requires the other type can be turned into a tuple.
* Fixed internal consistencies.
* Updated `mope` to allow comments by setting a section to nothing: `{{#section=}}...{{/section}}`.
* Added concept `IsTuple` which determines whether a type is a `std::tuple`.