### PR TITLE
Tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.27
+
+* Changed `LimitedMap` and `LimitedSet` to not verify whether input is sorted, if they use `kRequireSortedInput` and `NDEBUG` is defined.
+
 # 0.2.26
 
 * Fixed comparison of `Extend` types with other types. Requires the other type can be turned into a tuple.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This C++20 library provides some general useful building blocks and integrates
 with [Google's Abseil library](https://abseil.io/).
 
-[![Test](https://github.com/helly25/mbo/actions/workflows/main.yml/badge.svg)](https://github.com/helly25/mbo/actions/workflows/main.yml)
+The library is tested with Clang and GCC using continuous integration: [![Test](https://github.com/helly25/mbo/actions/workflows/main.yml/badge.svg)](https://github.com/helly25/mbo/actions/workflows/main.yml). Manual testing with native Apple clang version 15.0.0 ARM is also done.
 
 The C++ library is organized in functional groups each residing in their own directory.
 
@@ -178,3 +178,18 @@ http_archive(
 ```
 
 The project is formatted with specific clang-format settings which require clang 16+ (in case of MacOs LLVM 16+ can be installed using brew).
+
+# Presentations
+
+## Practical Production-proven Constexpr API Elements
+
+Presented at [C++ On Sea 2024](https://cpponsea.uk/2024/session/practical-production-proven-constexpr-api-elements), this presentation covers the theory behind:
+* `mbo::hash::simple::GetHash`,
+* `mbo::container::LimitedVector`,
+* `mbo::container::LimitedMap`, and
+* `mbo::container::LimitedSet`.
+
+Slides are available at:
+<br/>
+<br/>
+[<img src="https://helly25.com/wp-content/uploads/2024/07/Practical-Production-proven-Constexpr-API-Elements_TitleCard-copy-980x551.png">](helly25.com/practical-production-proven-constexpr-api-elements/)

--- a/mbo/container/internal/limited_ordered.h
+++ b/mbo/container/internal/limited_ordered.h
@@ -430,9 +430,11 @@ class LimitedOrdered {
   template<std::forward_iterator It>
   requires std::convertible_to<mbo::types::ForwardIteratorValueType<It>, Value>
   constexpr LimitedOrdered(It first, It last, const Compare& key_comp = Compare()) noexcept : key_comp_(key_comp) {
+#ifndef NDEBUG
     if constexpr (Options::Has(LimitedOptionsFlag::kRequireSortedInput)) {
       LV_REQUIRE(FATAL, std::is_sorted(first, last, key_comp_));
     }
+#endif  // NDEBUG
     while (first < last) {
       if constexpr (Options::Has(LimitedOptionsFlag::kRequireSortedInput)) {
         std::construct_at(&values_[size_++].data, *first);

--- a/mbo/container/limited_options.h
+++ b/mbo/container/limited_options.h
@@ -36,6 +36,7 @@ enum class LimitedOptionsFlag {
   // based constructors). This is an optimization for constexpr construction and allows the compiler to handle much
   // larger sets/maps, as the compiler does not need to execute the `emplace` (which requires sorting and shifting) and
   // can instead just place the elements.
+  // Note: If `NDEBUG` is defined, then the requirement will not be checked.
   kRequireSortedInput,
 
   // If true, then do NOT use the optimized `index_of` implementation, and also do not use `index_of` in methods like

--- a/mbo/hash/hash_simple.h
+++ b/mbo/hash/hash_simple.h
@@ -44,32 +44,23 @@ inline constexpr uint64_t GetSimpleHash(std::string_view data) {
   //               [-Werror=tautological-compare]
   if (std::is_constant_evaluated()) {
     std::size_t len = data.length();
-    uint64_t result = kArbitrary + len;
     std::size_t pos = 0;
+    uint64_t result = kArbitrary + len;
     while (len >= 4) {
       uint64_t add = 0;
-      add += static_cast<uint64_t>(data[pos++]);
-      add += static_cast<uint64_t>(data[pos++]) << 8U;
-      add += static_cast<uint64_t>(data[pos++]) << 16U;
-      add += static_cast<uint64_t>(data[pos++]) << 24U;
+      add += data[pos++];
+      add += data[pos++] << 8U;
+      add += data[pos++] << 16U;
+      add += data[pos++] << 24U;
       result = result * 6'571 ^ ((17 * add + (add >> 16U)) ^ (result >> 32U));
       len -= 4;
     }
-    if (len == 3) {
-      uint64_t add = 0;
-      add += static_cast<uint64_t>(data[pos++]);
-      add += static_cast<uint64_t>(data[pos++]) << 8U;
-      add += static_cast<uint64_t>(data[pos++]) << 16U;
-      return result * 193 + kPrimeNum10k * add;
-    } else if (len == 2) {
-      uint64_t add = 0;
-      add += static_cast<uint64_t>(data[pos++]);
-      add += static_cast<uint64_t>(data[pos++]) << 8U;
-      return result * 193 + kPrimeNum10k * add;
-    } else if (len == 1) {
-      uint64_t add = 0;
-      add += static_cast<uint64_t>(data[pos++]);
-      return result * 193 + kPrimeNum10k * add;
+    uint64_t add = 0;
+    switch (len) {
+      case 3: add += data[pos + 2] << 16U;
+      case 2: add += data[pos + 1] << 8U;
+      case 1: add += data[pos]; return result * 193 + kPrimeNum10k * add;
+      default: break;
     }
     return result;
   } else {

--- a/mbo/types/internal/struct_names_clang.h
+++ b/mbo/types/internal/struct_names_clang.h
@@ -159,7 +159,7 @@ class StructMeta final {
   }
 
   // Older compilers may not allow this to be a `constexpr`.
-  inline static constexpr FieldData kFieldData = []() constexpr {
+  inline static constexpr FieldData kFieldData = []() consteval {
     FieldData fields;
     if constexpr (!std::is_empty_v<T>) {
       typename StructMetaBase<T>::Storage storage{};
@@ -169,7 +169,7 @@ class StructMeta final {
     return fields;
   }();
 
-  inline static constexpr std::array<std::string_view, kFieldCount> kFieldNames = []() constexpr {
+  inline static constexpr std::array<std::string_view, kFieldCount> kFieldNames = []() consteval {
     std::array<std::string_view, kFieldCount> data;
     if constexpr (!std::is_empty_v<T>) {
       for (std::size_t pos = 0; pos < kFieldCount; ++pos) {


### PR DESCRIPTION
* No unnecessary static_cast in hash implementation.
* Use consteval in struct_names_clang to enforce compile time.
* Changed `LimitedMap` and `LimitedSet` to not verify whether input is sorted, if they use `kRequireSortedInput` and `NDEBUG` is defined.
* Update REDME and add presentation link.