### PR TITLE
Updates and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 0.2.27
 
+* Fixed a bug in `LimitedVector::assign`.
+* Updated https://github.com/bazel-contrib/toolchains_llvm past version 1.0.0.
 * Changed `LimitedMap` and `LimitedSet` to not verify whether input is sorted, if they use `kRequireSortedInput` and `NDEBUG` is defined.
 
 # 0.2.26

--- a/mbo/container/limited_vector.h
+++ b/mbo/container/limited_vector.h
@@ -16,8 +16,10 @@
 #ifndef MBO_CONTAINER_LIMITED_VECTOR_H_
 #define MBO_CONTAINER_LIMITED_VECTOR_H_
 
+#include <algorithm>
 #include <compare>   // IWYU pragma: keep
 #include <concepts>  // IWYU pragma: keep
+#include <cstddef>
 #include <initializer_list>
 #include <memory>
 #include <new>  // IWYU pragma: keep
@@ -361,15 +363,16 @@ class LimitedVector final {
   constexpr void assign(It begin, It end) noexcept {
     clear();
     while (begin < end) {
-      emplace_back(std::forward<mbo::types::ForwardIteratorValueType<It>>(*begin));
+      emplace_back(std::forward<mbo::types::ForwardIteratorValueType<It>>(*begin++));
     }
   }
 
   constexpr void assign(const std::initializer_list<T>& list) noexcept {
+    LV_REQUIRE(FATAL, list.size() <= Capacity) << "Called `assign` at capacity.";
     clear();
     auto it = list.begin();
     while (it < list.end()) {
-      emplace_back(std::forward<T>(*it));
+      emplace_back(*it++);
     }
   }
 
@@ -441,7 +444,7 @@ class LimitedVector final {
   std::size_t size_{0};
   // Array would be better but that does not work with ASAN builds.
   // std::array<Data, Capacity == 0 ? 1 : Capacity> values_;
-  // Add an unused sentinal, so that `end` and other functions do not cause memory issues.
+  // Add an unused sentinel, so that `end` and other functions do not cause memory issues.
   Data values_[Capacity + 1];  // NOLINT(*-avoid-c-arrays)
 };
 

--- a/mbo/container/limited_vector_test.cc
+++ b/mbo/container/limited_vector_test.cc
@@ -488,6 +488,33 @@ TEST_F(LimitedVectorTest, ToLimitedVectorEmptyDtorCheck) {
   EXPECT_THAT(kData, ElementsAre(3, 5));
 }
 
+TEST_F(LimitedVectorTest, Assign1) {
+  static constexpr auto kData = [] {
+    LimitedVector<int, 4> result({1, 2, 3, 4});
+    result.assign(2, 3);
+    return result;
+  }();
+  EXPECT_THAT(kData, ElementsAre(3, 3));
+}
+
+TEST_F(LimitedVectorTest, Assign2) {
+  static constexpr auto kData = [] {
+    LimitedVector<int, 4> result({1, 2, 3, 4});
+    result.assign({5, 6});
+    return result;
+  }();
+  EXPECT_THAT(kData, ElementsAre(5, 6));
+}
+
+TEST_F(LimitedVectorTest, Assign3) {
+  static constexpr auto kData = [] {
+    LimitedVector<int, 4> result({1, 2, 3, 4});
+    result.assign({5, 6});
+    return result;
+  }();
+  EXPECT_THAT(kData, ElementsAre(5, 6));
+}
+
 // NOLINTEND(*-magic-numbers)
 
 }  // namespace

--- a/workspace.bzl
+++ b/workspace.bzl
@@ -102,11 +102,13 @@ def mbo_workspace_load_modules():
     # Minimum requirements:
     # * 2023.10.06: https://github.com/bazel-contrib/toolchains_llvm/pull/229: Move minimum supported version to Bazel
     # * 2024.03.12: https://github.com/bazel-contrib/toolchains_llvm/pull/286: Support LLD linker for Darwin
+    # In order to go past version 1.0.0 we also add the actual fix:
+    # * 2024.06.06: https://github.com/bazel-contrib/toolchains_llvm/pull/337: Force Clang modules with LLVM >= 14q
     github_archive(
         name = "toolchains_llvm",
-        commit = "6bca3e279afa248495a25a586dfe06949cbf05cb",  # https://github.com/bazel-contrib/toolchains_llvm/pull/286
+        commit = "b193952cdb9dd3134f51159d820614ff32dba079",  # https://github.com/bazel-contrib/toolchains_llvm/pull/337
         repo = "https://github.com/bazel-contrib/toolchains_llvm",
-        integrity = "sha256-4syq1T8CQTyPrfxLcyo7LEHmMpkBF/tANnKbfvKPuTU=",
+        integrity = "sha256-eqCfrC/cwTsdE2+DkJQKQmxtlM8mb/nNaZSdg2H8dbk=",
     )
     #http_archive(
     #    name = "toolchains_llvm",


### PR DESCRIPTION
* Fixed a bug in `LimitedVector::assign`.
* Updated https://github.com/bazel-contrib/toolchains_llvm past version 1.0.0.