### PR TITLE
Improved LimitedVector::insert

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: Test
 on: [push]
 jobs:
-  test:
+  test-clang-asan:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -15,15 +15,47 @@ jobs:
         with:
           path: |
             ~/.cache/bazel
-          key: ${{ runner.os }}-{{ env.version }}-bazel-cache
+          key: ${{ runner.os }}-{{ env.version }}-bazel-cache-clang-asan
 
       - name: Test Clang/ASAN
         run: |
           bazel test --config=clang --config=asan -c dbg //...
 
+  test-clang-opt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Bazel cache
+        id: bazel-cache
+        uses: actions/cache@v2
+        env:
+          version: 4.2.1
+        with:
+          path: |
+            ~/.cache/bazel
+          key: ${{ runner.os }}-{{ env.version }}-bazel-cache-clang-opt
+
       - name: Test Clang/OPT
         run: |
           bazel test --config=clang -c opt //...
+
+  test-gcc-fastbuild:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Bazel cache
+        id: bazel-cache
+        uses: actions/cache@v2
+        env:
+          version: 4.2.1
+        with:
+          path: |
+            ~/.cache/bazel
+          key: ${{ runner.os }}-{{ env.version }}-bazel-cache-gcc-fastbuild
 
       - name: Test GCC/Fastbuild
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,10 @@ jobs:
           version: 4.2.1
         with:
           path: |
+            ~/.cache/bazelisk
             ~/.cache/bazel
-          key: ${{ runner.os }}-{{ env.version }}-bazel-cache-clang-asan
+            ~/.cache/bazel-cache
+          key: ${{ runner.os }}-${{ env.version }}-bazel-cache-clang-asan
 
       - name: Test Clang/ASAN
         run: |
@@ -34,8 +36,10 @@ jobs:
           version: 4.2.1
         with:
           path: |
+            ~/.cache/bazelisk
             ~/.cache/bazel
-          key: ${{ runner.os }}-{{ env.version }}-bazel-cache-clang-opt
+            ~/.cache/bazel-cache
+          key: ${{ runner.os }}-${{ env.version }}-bazel-cache-clang-opt
 
       - name: Test Clang/OPT
         run: |
@@ -54,8 +58,10 @@ jobs:
           version: 4.2.1
         with:
           path: |
+            ~/.cache/bazelisk
             ~/.cache/bazel
-          key: ${{ runner.os }}-{{ env.version }}-bazel-cache-gcc-fastbuild
+            ~/.cache/bazel-cache
+          key: ${{ runner.os }}-${{ env.version }}-bazel-cache-gcc-fastbuild
 
       - name: Test GCC/Fastbuild
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,19 +5,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
+      - name: Setup Bazelisk
+        uses: bazelbuild/setup-bazelisk@v3
 
       - name: Bazel cache
-        id: bazel-cache
-        uses: actions/cache@v2
-        env:
-          version: 4.2.1
+        uses: actions/cache@v4
         with:
-          path: |
-            ~/.cache/bazelisk
-            ~/.cache/bazel
-            ~/.cache/bazel-cache
-          key: ${{ runner.os }}-${{ env.version }}-bazel-cache-clang-asan
+            path: "~/.cache/bazel"
+            key: bazel-cache-clang-asan
 
       - name: Test Clang/ASAN
         run: |
@@ -27,19 +24,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
+      - name: Setup Bazelisk
+        uses: bazelbuild/setup-bazelisk@v3
 
       - name: Bazel cache
-        id: bazel-cache
-        uses: actions/cache@v2
-        env:
-          version: 4.2.1
+        uses: actions/cache@v4
         with:
-          path: |
-            ~/.cache/bazelisk
-            ~/.cache/bazel
-            ~/.cache/bazel-cache
-          key: ${{ runner.os }}-${{ env.version }}-bazel-cache-clang-opt
+            path: "~/.cache/bazel"
+            key: bazel-cache-clang-opt
 
       - name: Test Clang/OPT
         run: |
@@ -49,19 +43,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
+      - name: Setup Bazelisk
+        uses: bazelbuild/setup-bazelisk@v3
 
       - name: Bazel cache
-        id: bazel-cache
-        uses: actions/cache@v2
-        env:
-          version: 4.2.1
+        uses: actions/cache@v4
         with:
-          path: |
-            ~/.cache/bazelisk
-            ~/.cache/bazel
-            ~/.cache/bazel-cache
-          key: ${{ runner.os }}-${{ env.version }}-bazel-cache-gcc-fastbuild
+            path: "~/.cache/bazel"
+            key: bazel-cache-gcc-fastbuild
 
       - name: Test GCC/Fastbuild
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.28
+
+* Improved `LimitedVector::insert` to deal better with conversions and complex types.
+
 # 0.2.27
 
 * Implemented `LimitedVector::insert`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.2.28
 
 * Improved `LimitedVector::insert` to deal better with conversions and complex types.
+* Improved `LimitedMap`, `LimitedOrdered`, `LimitedSet` and `LimitedVector` ability to handle conversions.
 
 # 0.2.27
 

--- a/mbo/container/internal/limited_ordered.h
+++ b/mbo/container/internal/limited_ordered.h
@@ -428,7 +428,7 @@ class LimitedOrdered {
   // Constructors and assignment from other LimitVector/value types.
 
   template<std::forward_iterator It>
-  requires std::convertible_to<mbo::types::ForwardIteratorValueType<It>, Value>
+  requires std::constructible_from<Value, mbo::types::ForwardIteratorValueType<It>>
   constexpr LimitedOrdered(It first, It last, const Compare& key_comp = Compare()) noexcept : key_comp_(key_comp) {
 #ifndef NDEBUG
     if constexpr (Options::Has(LimitedOptionsFlag::kRequireSortedInput)) {
@@ -448,13 +448,13 @@ class LimitedOrdered {
   constexpr LimitedOrdered(const std::initializer_list<value_type>& list, const Compare& key_comp = Compare()) noexcept
       : LimitedOrdered(list.begin(), list.end(), key_comp) {}
 
-  template<typename U>
-  requires(std::convertible_to<U, value_type> && !std::same_as<U, value_type>)
+  template<std::constructible_from<value_type> U>
+  requires(!std::same_as<U, value_type>)
   constexpr LimitedOrdered(const std::initializer_list<U>& list, const Compare& key_comp = Compare()) noexcept
       : LimitedOrdered(list.begin(), list.end(), key_comp) {}
 
-  template<typename U, auto OtherN>
-  requires(std::convertible_to<U, value_type> && MakeLimitedOptions<OtherN>().kCapacity <= Capacity)
+  template<std::constructible_from<value_type> U, auto OtherN>
+  requires(MakeLimitedOptions<OtherN>().kCapacity <= Capacity)
   constexpr LimitedOrdered& operator=(const std::initializer_list<U>& list) noexcept {
     assign(list);
     return *this;

--- a/mbo/container/internal/limited_ordered.h
+++ b/mbo/container/internal/limited_ordered.h
@@ -460,10 +460,13 @@ class LimitedOrdered {
     return *this;
   }
 
-  template<typename OK, typename OM, typename OV, auto OtherN, typename OtherCompare>
-  requires(
-      std::convertible_to<OK, Key> && std::convertible_to<OM, Mapped>
-      && MakeLimitedOptions<OtherN>().kCapacity <= Capacity)
+  template<
+      std::constructible_from<Key> OK,
+      std::constructible_from<Mapped> OM,
+      typename OV,
+      auto OtherN,
+      typename OtherCompare>
+  requires(MakeLimitedOptions<OtherN>().kCapacity <= Capacity)
   constexpr explicit LimitedOrdered(const LimitedOrdered<OK, OM, OV, OtherN, OtherCompare>& other) noexcept {
     for (auto it = other.begin(); it < other.end(); ++it) {
       if constexpr (kKeyOnly) {
@@ -474,10 +477,13 @@ class LimitedOrdered {
     }
   }
 
-  template<typename OK, typename OM, typename OV, auto OtherN, typename OtherCompare>
-  requires(
-      std::convertible_to<OK, Key> && std::convertible_to<OM, Mapped>
-      && MakeLimitedOptions<OtherN>().kCapacity <= Capacity)
+  template<
+      std::constructible_from<Key> OK,
+      std::constructible_from<Mapped> OM,
+      typename OV,
+      auto OtherN,
+      typename OtherCompare>
+  requires(MakeLimitedOptions<OtherN>().kCapacity <= Capacity)
   constexpr LimitedOrdered& operator=(const LimitedOrdered<OK, OM, OV, OtherN, OtherCompare>& other) noexcept {
     clear();
     for (auto it = other.begin(); it < other.end(); ++it) {
@@ -745,10 +751,13 @@ class LimitedOrdered {
     }
   }
 
-  template<typename OK, typename OM, typename OV, auto OtherN, typename OtherCompare>
-  requires(
-      std::convertible_to<OK, Key> && std::convertible_to<OM, Mapped>
-      && MakeLimitedOptions<OtherN>().kCapacity == Capacity && std::same_as<OtherCompare, Compare>)
+  template<
+      std::constructible_from<Key> OK,
+      std::constructible_from<Mapped> OM,
+      typename OV,
+      auto OtherN,
+      typename OtherCompare>
+  requires(MakeLimitedOptions<OtherN>().kCapacity == Capacity && std::same_as<OtherCompare, Compare>)
   constexpr void swap(LimitedOrdered<OK, OM, OV, OtherN, OtherCompare>& other) noexcept {
     std::size_t pos = 0;
     for (; pos < size_ && pos < other.size(); ++pos) {

--- a/mbo/container/limited_map.h
+++ b/mbo/container/limited_map.h
@@ -105,20 +105,20 @@ class LimitedMap final
   // Constructors and assignment from other LimitMap/value types.
 
   template<std::forward_iterator It>
-  requires std::convertible_to<mbo::types::ForwardIteratorValueType<It>, KeyValueType>
+  requires std::constructible_from<KeyValueType, mbo::types::ForwardIteratorValueType<It>>
   constexpr LimitedMap(It begin, It end, const KeyComp& key_comp = KeyComp()) noexcept
       : LimitedBase(begin, end, key_comp) {}
 
   constexpr LimitedMap(const std::initializer_list<KeyValueType>& list, const KeyComp& key_comp = KeyComp()) noexcept
       : LimitedBase(list, key_comp) {}
 
-  template<typename U>
-  requires(std::convertible_to<U, KeyValueType> && !std::same_as<U, KeyValueType>)
+  template<std::constructible_from<KeyValueType> U>
+  requires(!std::same_as<U, KeyValueType>)
   constexpr LimitedMap(const std::initializer_list<U>& list, const KeyComp& key_comp = KeyComp()) noexcept
       : LimitedBase(list, key_comp) {}
 
-  template<typename U, auto OtherN>
-  requires(std::convertible_to<U, KeyValueType> && MakeLimitedOptions<OtherN>().kCapacity <= kCapacity)
+  template<std::constructible_from<KeyValueType> U, auto OtherN>
+  requires(MakeLimitedOptions<OtherN>().kCapacity <= kCapacity)
   constexpr LimitedMap& operator=(const std::initializer_list<U>& list) noexcept {
     LimitedBase::operator=(list);
     return *this;

--- a/mbo/container/limited_map.h
+++ b/mbo/container/limited_map.h
@@ -124,32 +124,24 @@ class LimitedMap final
     return *this;
   }
 
-  template<typename OK, typename OV, auto OtherN, typename OtherCompare>
-  requires(
-      std::convertible_to<OK, Key> && std::convertible_to<OV, Value>
-      && MakeLimitedOptions<OtherN>().kCapacity <= kCapacity)
+  template<std::constructible_from<Key> OK, std::constructible_from<Value> OV, auto OtherN, typename OtherCompare>
+  requires(MakeLimitedOptions<OtherN>().kCapacity <= kCapacity)
   constexpr explicit LimitedMap(const LimitedMap<OK, OV, OtherN, OtherCompare>& other) noexcept : LimitedBase(other) {}
 
-  template<typename OK, typename OV, auto OtherN, typename OtherCompare>
-  requires(
-      std::convertible_to<OK, Key> && std::convertible_to<OV, Value>
-      && MakeLimitedOptions<OtherN>().kCapacity <= kCapacity)
+  template<std::constructible_from<Key> OK, std::constructible_from<Value> OV, auto OtherN, typename OtherCompare>
+  requires(MakeLimitedOptions<OtherN>().kCapacity <= kCapacity)
   constexpr LimitedMap& operator=(const LimitedMap<OK, OV, OtherN, OtherCompare>& other) noexcept {
     LimitedBase::operator=(other);
     return *this;
   }
 
-  template<typename OK, typename OV, auto OtherN, typename OtherCompare>
-  requires(
-      std::convertible_to<OK, Key> && std::convertible_to<OV, Value>
-      && MakeLimitedOptions<OtherN>().kCapacity <= kCapacity)
+  template<std::constructible_from<Key> OK, std::constructible_from<Value> OV, auto OtherN, typename OtherCompare>
+  requires(MakeLimitedOptions<OtherN>().kCapacity <= kCapacity)
   constexpr explicit LimitedMap(LimitedMap<OK, OV, OtherN, OtherCompare>&& other) noexcept
       : LimitedBase(std::move(other)) {}
 
-  template<typename OK, typename OV, auto OtherN, typename OtherCompare>
-  requires(
-      std::convertible_to<OK, Key> && std::convertible_to<OV, Value>
-      && MakeLimitedOptions<OtherN>().kCapacity <= kCapacity)
+  template<std::constructible_from<Key> OK, std::constructible_from<Value> OV, auto OtherN, typename OtherCompare>
+  requires(MakeLimitedOptions<OtherN>().kCapacity <= kCapacity)
   constexpr LimitedMap& operator=(LimitedMap<OK, OV, OtherN, OtherCompare>&& other) noexcept {
     LimitedBase::operator=(std::move(other));
     return *this;

--- a/mbo/container/limited_set.h
+++ b/mbo/container/limited_set.h
@@ -115,19 +115,19 @@ class LimitedSet final : public container_internal::LimitedOrdered<Key, Key, Key
     return *this;
   }
 
-  template<typename OK, auto OtherN, typename OtherCompare>
-  requires(std::convertible_to<OK, Key> && MakeLimitedOptions<OtherN>().kCapacity <= kCapacity)
+  template<std::constructible_from<Key> OK, auto OtherN, typename OtherCompare>
+  requires(MakeLimitedOptions<OtherN>().kCapacity <= kCapacity)
   constexpr explicit LimitedSet(const LimitedSet<OK, OtherN, OtherCompare>& other) noexcept : LimitedBase(other) {}
 
-  template<typename OK, auto OtherN, typename OtherCompare>
-  requires(std::convertible_to<OK, Key> && MakeLimitedOptions<OtherN>().kCapacity <= kCapacity)
+  template<std::constructible_from<Key> OK, auto OtherN, typename OtherCompare>
+  requires(MakeLimitedOptions<OtherN>().kCapacity <= kCapacity)
   constexpr LimitedSet& operator=(const LimitedSet<OK, OtherN, OtherCompare>& other) noexcept {
     LimitedBase::operator=(other);
     return *this;
   }
 
-  template<typename OK, auto OtherN, typename OtherCompare>
-  requires(std::convertible_to<OK, Key> && MakeLimitedOptions<OtherN>().kCapacity <= kCapacity)
+  template<std::constructible_from<Key> OK, auto OtherN, typename OtherCompare>
+  requires(MakeLimitedOptions<OtherN>().kCapacity <= kCapacity)
   constexpr explicit LimitedSet(LimitedSet<OK, OtherN, OtherCompare>&& other) noexcept
       : LimitedBase(std::move(other)) {}
 

--- a/mbo/container/limited_set.h
+++ b/mbo/container/limited_set.h
@@ -96,20 +96,20 @@ class LimitedSet final : public container_internal::LimitedOrdered<Key, Key, Key
   // Constructors and assignment from other LimitSet/value types.
 
   template<std::forward_iterator It>
-  requires std::convertible_to<mbo::types::ForwardIteratorValueType<It>, Key>
+  requires std::constructible_from<Key, mbo::types::ForwardIteratorValueType<It>>
   constexpr LimitedSet(It begin, It end, const Compare& key_comp = Compare()) noexcept
       : LimitedBase(begin, end, key_comp) {}
 
   constexpr LimitedSet(const std::initializer_list<Key>& list, const Compare& key_comp = Compare()) noexcept
       : LimitedBase(list, key_comp) {}
 
-  template<typename U>
-  requires(std::convertible_to<U, Key> && !std::same_as<U, Key>)
+  template<std::constructible_from<Key> U>
+  requires(!std::same_as<U, Key>)
   constexpr LimitedSet(const std::initializer_list<U>& list, const Compare& key_comp = Compare()) noexcept
       : LimitedBase(list, key_comp) {}
 
-  template<typename U, auto OtherN>
-  requires(std::convertible_to<U, Key> && MakeLimitedOptions<OtherN>().kCapacity <= kCapacity)
+  template<std::constructible_from<Key> U, auto OtherN>
+  requires(MakeLimitedOptions<OtherN>().kCapacity <= kCapacity)
   constexpr LimitedSet& operator=(const std::initializer_list<U>& list) noexcept {
     LimitedBase::operator=(list);
     return *this;

--- a/mbo/container/limited_vector.h
+++ b/mbo/container/limited_vector.h
@@ -168,7 +168,7 @@ class LimitedVector final {
   // Constructors and assignment from other LimitVector/value types.
 
   template<std::forward_iterator It>
-  requires std::convertible_to<mbo::types::ForwardIteratorValueType<It>, T>
+  requires std::constructible_from<T, mbo::types::ForwardIteratorValueType<It>>
   constexpr LimitedVector(It begin, It end) noexcept {
     while (begin < end) {
       emplace_back(*begin++);
@@ -405,7 +405,8 @@ class LimitedVector final {
 
   constexpr iterator insert(const_iterator pos, const T& value) { return insert(pos, 1, value); }
 
-  template<std::convertible_to<const_iterator> InputIt>
+  template<typename InputIt>
+  requires(std::constructible_from<T, decltype(*std::declval<InputIt>())>)
   constexpr iterator insert(const_iterator pos, InputIt first, InputIt last) {
     LV_REQUIRE(FATAL, begin() <= pos && pos <= end()) << "Invalid `pos`.";
     LV_REQUIRE(FATAL, first <= last) << "First > Last.";

--- a/mbo/container/limited_vector_test.cc
+++ b/mbo/container/limited_vector_test.cc
@@ -570,6 +570,7 @@ TEST_F(LimitedVectorTest, Insert1WithMovingNonConstexpr) {
   static constexpr std::string_view kStrA = "A................,";
   static constexpr std::string_view kStrB = "B................,";
   static constexpr std::string_view kStrC = "C................,";
+  static constexpr std::string_view kStrD = "D................,";
   {
     static const auto kData = [] {
       LimitedVector<std::string, 3> result{};
@@ -582,13 +583,13 @@ TEST_F(LimitedVectorTest, Insert1WithMovingNonConstexpr) {
   }
   {
     static const auto kData = [] {
-      LimitedVector<std::string, 5> result(std::initializer_list<std::string_view>{kStr1, kStr2});
+      LimitedVector<std::string, 6> result(std::initializer_list<std::string_view>{kStr1, kStr2});
       result.insert(result.begin(), kStrA);
       result.insert(&result[2], kStrB);
-      result.insert(result.end(), kStrC);
+      result.insert(result.end(), std::initializer_list<std::string_view>{kStrC, kStrD});
       return result;
     }();
-    EXPECT_THAT(kData, ElementsAre(kStrA, kStr1, kStrB, kStr2, kStrC));
+    EXPECT_THAT(kData, ElementsAre(kStrA, kStr1, kStrB, kStr2, kStrC, kStrD));
   }
 }
 

--- a/mbo/container/limited_vector_test.cc
+++ b/mbo/container/limited_vector_test.cc
@@ -559,6 +559,39 @@ TEST_F(LimitedVectorTest, Insert1WithMoving) {
   }
 }
 
+TEST_F(LimitedVectorTest, Insert1WithMovingNonConstexpr) {
+  // The test uses the non trivial type `std::string` which cannot be handled at compile time in a constexpr (in C++20).
+  // It verifies that element moving is performed correctly by employing `std::construct_at(dst, std::move(src))` in
+  // `LimitedVector::move_backward()` just as is done in `LimitedOrdered`.
+  // Each test string uses an identification char (e.g. `1`), 16 dots and a comma in order to force memory allocation.
+  static constexpr std::string_view kStr1 = "1................,";
+  static constexpr std::string_view kStr2 = "2................,";
+  static constexpr std::string_view kStr3 = "3................,";
+  static constexpr std::string_view kStrA = "A................,";
+  static constexpr std::string_view kStrB = "B................,";
+  static constexpr std::string_view kStrC = "C................,";
+  {
+    static const auto kData = [] {
+      LimitedVector<std::string, 3> result{};
+      result.insert(result.begin(), kStr1);
+      result.insert(result.begin(), kStr2);
+      result.insert(result.begin(), kStr3);
+      return result;
+    }();
+    EXPECT_THAT(kData, ElementsAre(kStr3, kStr2, kStr1));
+  }
+  {
+    static const auto kData = [] {
+      LimitedVector<std::string, 5> result(std::initializer_list<std::string_view>{kStr1, kStr2});
+      result.insert(result.begin(), kStrA);
+      result.insert(&result[2], kStrB);
+      result.insert(result.end(), kStrC);
+      return result;
+    }();
+    EXPECT_THAT(kData, ElementsAre(kStrA, kStr1, kStrB, kStr2, kStrC));
+  }
+}
+
 TEST_F(LimitedVectorTest, Insert2) {
   {
     static constexpr auto kData = [] {
@@ -600,10 +633,10 @@ TEST_F(LimitedVectorTest, Insert3) {
   {
     static constexpr auto kData = [] {
       LimitedVector<int, 6> result{};
-      result.insert(result.begin(), {11});
+      result.insert(result.begin(), std::initializer_list<int>{11});
       result.insert(result.begin(), {21, 22});
       result.insert(result.begin(), {31, 32, 33});
-      result.insert(result.begin(), {});
+      result.insert(result.begin(), std::initializer_list<int>{});
       return result;
     }();
     EXPECT_THAT(kData, ElementsAre(31, 32, 33, 21, 22, 11));
@@ -611,10 +644,10 @@ TEST_F(LimitedVectorTest, Insert3) {
   {
     static constexpr auto kData = [] {
       LimitedVector<int, 6> result{};
-      result.insert(result.end(), {11});
+      result.insert(result.end(), std::initializer_list<int>{11});
       result.insert(result.end(), {21, 22});
       result.insert(result.end(), {31, 32, 33});
-      result.insert(result.end(), {});
+      result.insert(result.end(), std::initializer_list<int>{});
       return result;
     }();
     EXPECT_THAT(kData, ElementsAre(11, 21, 22, 31, 32, 33));

--- a/mbo/container/limited_vector_test.cc
+++ b/mbo/container/limited_vector_test.cc
@@ -536,7 +536,7 @@ TEST_F(LimitedVectorTest, Insert1WithoutMoving) {
   }
 }
 
-TEST_F(LimitedVectorTest, Insert1WithMoving) {
+TEST_F(LimitedVectorTest, Insert1Moving) {
   {
     static constexpr auto kData = [] {
       LimitedVector<int, 5> result{};
@@ -559,7 +559,7 @@ TEST_F(LimitedVectorTest, Insert1WithMoving) {
   }
 }
 
-TEST_F(LimitedVectorTest, Insert1WithMovingNonConstexpr) {
+TEST_F(LimitedVectorTest, Insert1ComplexType) {
   // The test uses the non trivial type `std::string` which cannot be handled at compile time in a constexpr (in C++20).
   // It verifies that element moving is performed correctly by employing `std::construct_at(dst, std::move(src))` in
   // `LimitedVector::move_backward()` just as is done in `LimitedOrdered`.


### PR DESCRIPTION
* Improved `LimitedVector::insert` to deal better with conversions and complex types.
* Improved `LimitedMap`, `LimitedOrdered`, `LimitedSet` and `LimitedVector` ability to handle conversions.
* Split commit into multiple independent tasks, each with their own cache key.
* Minimalistic ability to cache bazel results.