### PR TITLE
Added crtp-struct ExtendNoPrint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.2.29
+
+* Added crtp-struct `ExtendNoPrint` Like `Extend` but without `Printable` and `Streamable` extender functionality.
+* Added support for type `char` in extender `AbslStringify`.
+* Added `mbo::types::TupleCat` which concatenates tuple types.
+* Fixed `//mbo/log:log_timing_test` for systems with limited `std::source_location` support (e.g. MacOS).
+
 # 0.2.28
 
 * Improved `LimitedVector::insert` to deal better with conversions and complex types.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ The C++ library is organized in functional groups each residing in their own dir
     * mbo/types:extend_cc, mbo/types/extend.h
         * crtp-struct `Extend`: Enables extending of struct/class types with basic functionality.
         * crtp-struct `ExtendNoDefault` Like `Extend` but without default extender functionality.
+        * crtp-struct `ExtendNoPrint` Like `Extend` but without `Printable` and `Streamable` extender functionality.
         * `namespace extender`
             * extender-struct `AbslStringify`: Extender that injects functionality to make an `Extend`ed type work with abseil format/print functions.
             * extender-struct `AbslHashable`: Extender that injects functionality to make an `Extend`ed type work with abseil hashing (and also `std::hash`).
@@ -156,6 +157,8 @@ The C++ library is organized in functional groups each residing in their own dir
     * mbo/types:tstring_cc, mbo/types/tstring.h
         * struct `tstring`: Implements type `tstring` a compile time string-literal type.
         * operator `operator"" _ts`: String literal support for Clang, GCC and derived compilers.
+    * mbo/types:tuple_cc, mbo/types/tuple.h
+        * template struct `mbo::types::TupleCat` which concatenates tuple types.
 
 In addition some Bazel macros are implemented that are not direct part of the library:
 

--- a/mbo/types/BUILD.bazel
+++ b/mbo/types/BUILD.bazel
@@ -156,7 +156,7 @@ cc_test(
 cc_library(
     name = "tuple_cc",
     hdrs = ["tuple.h"],
-    visibility = ["//mbo/types/internal:__pkg__"],
+    visibility = ["//visibility:public"],
     deps = [":traits_cc"],
 )
 

--- a/mbo/types/extend.h
+++ b/mbo/types/extend.h
@@ -49,23 +49,42 @@ namespace mbo::types {
 template<typename T, typename... Extender>
 struct Extend : ::mbo::extender::Extend<T, ::mbo::types::extender::Default, Extender...> {};
 
-// Same as `Extend` but without default extenders. This alows to control the
+// Same as `Extend` but without default extenders. This allows to control the
 // exact extender set to be used.
 //
 // Example:
 // ```c++
-// struct Name : mbo::types::ExtendNoDEfault<mbo::types::Comparable> {
+// struct Name : mbo::types::ExtendNoDefault<mbo::types::Comparable> {
+//    std::string first;
+//    std::string last;
+// };
+// ```
+//
+// Here `Name` gets injected with some fundamental conversion helpers but it
+// will not get print, stream, comparison or hash functionality.
+//
+// NOTE: No member may be an anonymous union or struct.
+template<typename T, typename... Extender>
+struct ExtendNoDefault : ::mbo::extender::Extend<T, Extender...> {};
+
+// Same as `Extend` but without the `Printable` and `Streamable` externder.
+// This makes it easy to customize printing and streaming, while still retaining
+// other default behavior.
+//
+// Example:
+// ```c++
+// struct Name : mbo::types::ExtendNoPrint<mbo::types::Comparable> {
 //    std::string first;
 //    std::string last;
 // };
 // ```
 //
 // Here `Name` gets injected with all comparison operators but it will not get
-// print, stream or hash functionality.
+// print, stream, comparison or hash functionality.
 //
 // NOTE: No member may be an anonymous union or struct.
 template<typename T, typename... Extender>
-struct ExtendNoDefault : ::mbo::extender::Extend<T, Extender...> {};
+struct ExtendNoPrint : ::mbo::extender::Extend<T, ::mbo::types::extender::NoPrint, Extender...> {};
 
 }  // namespace mbo::types
 

--- a/mbo/types/extend_test.cc
+++ b/mbo/types/extend_test.cc
@@ -634,8 +634,7 @@ TEST_F(ExtendTest, NoPrint) {
 
   ASSERT_THAT((::mbo::types::types_internal::IsExtended<NameNoPrint>), true);
   EXPECT_THAT(
-      NameNoPrint::RegisteredExtenderNames(),
-      UnorderedElementsAre("AbslHashable", "AbslStringify", "Comparable"));
+      NameNoPrint::RegisteredExtenderNames(), UnorderedElementsAre("AbslHashable", "AbslStringify", "Comparable"));
   EXPECT_THAT((::mbo::types::types_internal::HasExtender<NameNoPrint, Printable>), false);
   EXPECT_THAT((::mbo::types::types_internal::HasExtender<NameNoPrint, Streamable>), false);
   EXPECT_THAT((::mbo::types::types_internal::HasExtender<NameNoPrint, Comparable>), true);

--- a/mbo/types/extender.h
+++ b/mbo/types/extender.h
@@ -365,7 +365,7 @@ namespace extender_internal {
 //  template<typename ExtenderOrActualType>
 //  using Impl : Expand<ExtenderOrActualType, ExtenderTuple>;
 #if MBO_TYPES_EXTENDER_USE_EXPAND
-template <typename... T>
+template<typename... T>
 struct Expand;
 
 template<typename Base>
@@ -379,7 +379,8 @@ struct Expand<Base, std::tuple<T>> : ::mbo::types::types_internal::UseExtender<B
 };
 
 template<typename Base, typename T, typename... U>
-struct Expand<Base, std::tuple<T, U...>> : ::mbo::types::types_internal::UseExtender<Expand<Base, std::tuple<U...>>, T>::type {};
+struct Expand<Base, std::tuple<T, U...>>
+    : ::mbo::types::types_internal::UseExtender<Expand<Base, std::tuple<U...>>, T>::type {};
 #endif
 }  // namespace extender_internal
 

--- a/mbo/types/extender.h
+++ b/mbo/types/extender.h
@@ -31,6 +31,14 @@
 //   * This is a default extender.
 //   * Requires `AbslStringify`
 //
+// * Comparable
+//
+//   * Implements all comparison operators by means of `<=>` referring to the
+//     `<=>` operator for the temporary `std::tuple` copies.
+//   * Since the comparison is implemented with templated left/right parameters,
+//     it might be necessary to provide concrete implementations for operators
+//     `==` and/or `<` for types that have no known conversion or comparison.
+//
 // * AbslStringify (default)
 //
 //   * Provides: friend void AbslStringify(Sink&, const Type& t)
@@ -38,14 +46,17 @@
 //   * Enables use of the struct with `absl::Format` library.
 //   * Required by: Printable, Streamable
 //
-// * Comparable
-//
-//   * Implements all comparison operators by means of `<=>` referring to the
-//     `<=>` operator for the temporary `std::tuple` copies.
-//
-// * Hashable
+// * AbslHashable
 //
 //   * Make the extended type hashable.
+//
+// * Default:
+//
+//    * Printable, Streamable, Comparable, AbslHashable, AbslStringify.
+//
+//  * NoPrint:
+//
+//    * Comparable, AbslHashable, AbslStringify.
 //
 #ifndef MBO_TYPES_EXTENDER_H_
 #define MBO_TYPES_EXTENDER_H_
@@ -58,6 +69,8 @@
 #include <type_traits>
 
 #include "absl/hash/hash.h"  // IWYU pragma: keep
+#include "absl/strings/ascii.h"
+#include "absl/strings/escaping.h"
 #include "absl/strings/str_format.h"
 #include "mbo/types/internal/extender.h"      // IWYU pragma: export
 #include "mbo/types/internal/struct_names.h"  // IWYU pragma: keep
@@ -178,6 +191,13 @@ struct AbslStringify_ : ExtenderBase {  // NOLINT(readability-identifier-naming)
       }
     } else if constexpr (std::is_convertible_v<V, std::string_view>) {
       os << absl::StreamFormat("\"%s\"", v);
+    } else if constexpr (std::is_same_v<V, char>) {
+      if (absl::ascii_isprint(v)) {
+        os << "'" << v << "'";
+      } else {
+        std::string str({v});
+        os << "'" << absl::CHexEscape(str) << "'";
+      }
     } else {
       os << absl::StreamFormat("%v", v);
     }
@@ -339,6 +359,30 @@ struct Printable final : MakeExtender<"Printable"_ts, Printable_, AbslStringify>
 // This default Extender is automatically available through `mb::types::Extend`.
 struct Streamable final : MakeExtender<"Streamable"_ts, Streamable_, AbslStringify> {};
 
+namespace extender_internal {
+// Temporarily unused: This would allow to simplify the default wrapper combos (e.g. `Default`).
+// However it also massively increases their typename lengths. Use:
+//  template<typename ExtenderOrActualType>
+//  using Impl : Expand<ExtenderOrActualType, ExtenderTuple>;
+#if MBO_TYPES_EXTENDER_USE_EXPAND
+template <typename... T>
+struct Expand;
+
+template<typename Base>
+struct Expand<Base, std::tuple<>> : Base {
+  using Type = Base::Type;
+};
+
+template<typename Base, typename T>
+struct Expand<Base, std::tuple<T>> : ::mbo::types::types_internal::UseExtender<Base, T>::type {
+  using Type = Base::Type;
+};
+
+template<typename Base, typename T, typename... U>
+struct Expand<Base, std::tuple<T, U...>> : ::mbo::types::types_internal::UseExtender<Expand<Base, std::tuple<U...>>, T>::type {};
+#endif
+}  // namespace extender_internal
+
 // The default extender is a wrapper around:
 // * Streamable
 // * Printable
@@ -347,6 +391,7 @@ struct Streamable final : MakeExtender<"Streamable"_ts, Streamable_, AbslStringi
 // * AbslStringify
 struct Default final {
   using RequiredExtender = void;
+  using ExtenderTuple = std::tuple<Streamable, Printable, Comparable, AbslStringify, AbslHashable>;
 
   static constexpr std::string_view GetExtenderName() { return decltype("Default"_ts)::str(); }
 
@@ -356,10 +401,36 @@ struct Default final {
   template<typename T, typename Extender>
   friend struct ::mbo::types::types_internal::UseExtender;
 
-  // NOTE: The list of wrapped extenders needs to be in sync with `mbo::extender::Extend`.
+  // NOTE: The list of wrapped extenders needs to be in sync with `ExtenderTuple`.
 
   template<typename ExtenderOrActualType>
   struct Impl : Streamable_<Printable_<Comparable_<AbslHashable_<AbslStringify_<ExtenderOrActualType>>>>> {
+    using Type = ExtenderOrActualType::Type;
+  };
+};
+
+// This default extender is a wrapper around:
+// * NOT Streamable
+// * NOT Printable
+// * Comparable
+// * AbslHashable
+// * AbslStringify
+struct NoPrint final {
+  using RequiredExtender = void;
+  using ExtenderTuple = std::tuple<AbslHashable, AbslStringify, Comparable>;
+
+  static constexpr std::string_view GetExtenderName() { return decltype("NoPrint"_ts)::str(); }
+
+ private:
+  // This friend is necessary to keep symbol visibility in check. But it has to
+  // be either 'struct' or 'class' and thus results in `ImplT` being a struct.
+  template<typename T, typename Extender>
+  friend struct ::mbo::types::types_internal::UseExtender;
+
+  // NOTE: The list of wrapped extenders needs to be in sync with `ExtenderTuple`.
+
+  template<typename ExtenderOrActualType>
+  struct Impl : Comparable_<AbslHashable_<AbslStringify_<ExtenderOrActualType>>> {
     using Type = ExtenderOrActualType::Type;
   };
 };

--- a/mbo/types/traits.h
+++ b/mbo/types/traits.h
@@ -322,15 +322,15 @@ concept IsVariant = types_internal::IsVariantImpl<T>::value;
 namespace types_internal {
 
 template<typename T>
-struct is_tuple : std::false_type {};
+struct IsTuple : std::false_type {};
 
 template<typename... Ts>
-struct is_tuple<std::tuple<Ts...>> : std::true_type {};
+struct IsTuple<std::tuple<Ts...>> : std::true_type {};
 
 }  // namespace types_internal
 
 template<typename T>
-concept IsTuple = types_internal::is_tuple<T>::value;
+concept IsTuple = types_internal::IsTuple<T>::value;
 
 }  // namespace mbo::types
 

--- a/mbo/types/tuple.h
+++ b/mbo/types/tuple.h
@@ -86,6 +86,22 @@ concept HasVariantMember =
     ::mbo::types::CanCreateTuple<T>
     && types_internal::HasVariantMemberImpl<decltype(::mbo::types::StructToTuple(std::declval<T>()))>;
 
+namespace types_internal {
+
+template<typename... T>
+struct TupleCat;
+
+template<typename... T, typename... U>
+struct TupleCat<std::tuple<T...>, std::tuple<U...>> {
+  using type = std::tuple<T..., U...>;
+};
+
+}  // namespace types_internal
+
+// Concatenate tuples.
+template<typename T, typename U>
+using TupleCat = types_internal::TupleCat<T, U>::type;
+
 }  // namespace mbo::types
 
 #endif  // MBO_TYPES_TUPLE_H_


### PR DESCRIPTION
* Added crtp-struct `ExtendNoPrint` Like `Extend` but without `Printable` and `Streamable` extender functionality.
* Added support for type `char` in extender `AbslStringify`.
* Added `mbo::types::TupleCat` which concatenates tuple types.
* Fixed `//mbo/log:log_timing_test` for systems with limited `std::source_location` support (e.g. MacOS).