### PR TITLE
Format control for AbslStringify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.30
+
+* Added formatting control for `AbslStringify` externder using struct and method `AbslStringifyFieldOptions`.
+
 # 0.2.29
 
 * Added crtp-struct `ExtendNoPrint` Like `Extend` but without `Printable` and `Streamable` extender functionality.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ The C++ library is organized in functional groups each residing in their own dir
                 * The output is a comma separated list of field values, e.g. `{ 25, 42 }`.
                 * If available (Clang 16+) this function prints field names `{ first = 25, second = 42 }`.
             * extender-struct `Streamable`: Extender that injects functionality to make an `Extend`ed type streamable. This allows the type to be used directly with `std::ostream`s.
+        * struct `AbslStringifyFieldOptions` which can be used to control `AbslStringify` formatting.
     * mbo/types:no_destruct_cc, mbo/types/no_destruct.h
         * struct `NoDestruct<T>`: Implements a type that allows to use any type as a static constant.
         * Mainly, this prevents calling the destructor and thus prevents termination issues (initialization order fiasco).

--- a/mbo/types/BUILD.bazel
+++ b/mbo/types/BUILD.bazel
@@ -67,6 +67,21 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "extend_stringify_test",
+    size = "small",
+    srcs = ["extend_stringify_test.cc"],
+    deps = [
+        ":extend_cc",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/hash:hash_testing",
+        "@com_google_absl//absl/log:absl_check",
+        "@com_google_absl//absl/log:absl_log",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 cc_library(
     name = "no_destruct_cc",
     hdrs = ["no_destruct.h"],

--- a/mbo/types/extend_stringify_test.cc
+++ b/mbo/types/extend_stringify_test.cc
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string_view>
+#include <vector>
+
+#include "absl/log/absl_check.h"  // IWYU pragma: keep
+#include "absl/log/absl_log.h"    // IWYU pragma: keep
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "mbo/types/extend.h"
+#include "mbo/types/extender.h"
+
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wunknown-pragmas"
+# pragma clang diagnostic ignored "-Wunused-local-typedef"
+#endif
+
+namespace mbo::types {
+namespace {
+
+// NOLINTBEGIN(*-magic-numbers)
+
+struct ExtenderStringifyTest : ::testing::Test {};
+
+TEST_F(ExtenderStringifyTest, Basic) {
+  struct TestStruct : mbo::types::Extend<TestStruct> {
+    using MboTypesExtendDoNotPrintFieldNames = void;
+
+    int number = 25;
+    std::string str = "42";
+  };
+
+  EXPECT_THAT(TestStruct{}.ToString(), "{25, \"42\"}");
+}
+
+TEST_F(ExtenderStringifyTest, KeyNames) {
+  struct TestStruct : mbo::types::Extend<TestStruct> {
+    using MboTypesExtendDoNotPrintFieldNames = void;
+
+    int one = 11;
+    int two = 25;
+    int tre = 33;
+
+    static struct AbslStringifyFieldOptions AbslStringifyFieldOptions(
+        const Type& /*unused*/,  // The type `Type` is provided by `Extend`.
+        std::size_t field_index,
+        std::string_view field_name) {
+      ABSL_CHECK(field_name.empty());
+      return {
+          .field_suppress = field_index > 1,
+          .field_separator = "++",
+          .key_prefix = "__",
+          .key_value_separator = "..==",
+          .key_alternative_name = field_index == 0 ? "first" : "second",
+      };
+    }
+  };
+
+  ASSERT_TRUE(mbo::types::HasAbslStringifyFieldOptions<TestStruct>);
+
+  EXPECT_THAT(TestStruct{}.ToString(), "{__first..==11++__second..==25}");
+}
+
+TEST_F(ExtenderStringifyTest, FieldNames) {
+  struct TestStruct : mbo::types::Extend<TestStruct> {
+    using MboTypesExtendDoNotPrintFieldNames = void;
+
+    int one = 11;
+    int two = 25;
+    int tre = 33;
+
+    static struct AbslStringifyFieldOptions AbslStringifyFieldOptions(
+        const Type& /*unused*/,  // The type `Type` is provided by `Extend`.
+        std::size_t field_index,
+        std::string_view /* unused */) {
+      static constexpr std::array<std::string_view, 3> kFieldNames{
+          "ONE",
+          "TWO",
+          "three",
+      };
+      return {
+          .key_prefix = "",
+          .key_value_separator = " = ",
+          .key_alternative_name = kFieldNames[field_index],  // NOLINT(*-constant-array-index)
+      };
+    }
+  };
+
+  ASSERT_TRUE(mbo::types::HasAbslStringifyFieldOptions<TestStruct>);
+
+  EXPECT_THAT(TestStruct{}.ToString(), "{ONE = 11, TWO = 25, three = 33}");
+}
+
+TEST_F(ExtenderStringifyTest, Shorten) {
+  struct TestStruct : mbo::types::Extend<TestStruct> {
+    using MboTypesExtendDoNotPrintFieldNames = void;
+
+    std::string_view one = "1";
+    std::string_view two = "22";
+    std::string_view tre = "333";
+    std::string_view fou = "4444";
+    std::string_view fiv;
+
+    static struct AbslStringifyFieldOptions AbslStringifyFieldOptions(
+        const Type& /*unused*/,  // The type `Type` is provided by `Extend`.
+        std::size_t field_index,
+        std::string_view /* unused */) {
+      static constexpr std::array<std::string_view, 5> kFieldNames{
+          "one", "two", "three", "four", "five",
+      };
+      return {
+          .key_prefix = "",
+          .key_value_separator = " = ",
+          .key_alternative_name = kFieldNames[field_index],  // NOLINT(*-constant-array-index)
+          .value_max_length = field_index >= 3 && field_index <= 4 ? 0U : 1U,
+          .value_cutoff_suffix = field_index < 2 ? AbslStringifyFieldOptions::Default().value_cutoff_suffix : "**",
+      };
+    }
+  };
+
+  ASSERT_TRUE(mbo::types::HasAbslStringifyFieldOptions<TestStruct>);
+
+  EXPECT_THAT(TestStruct{}.ToString(), R"({one = "1", two = "2...", three = "3**", four = "**", five = ""})");
+}
+
+TEST_F(ExtenderStringifyTest, ValueReplacement) {
+  struct TestStruct : mbo::types::Extend<TestStruct> {
+    using MboTypesExtendDoNotPrintFieldNames = void;
+
+    int one = 1;
+    std::string_view two = "22";
+    std::vector<int> tre = {331, 332, 333};
+    std::vector<std::string_view> fou{"41", "42", "43"};
+
+    static struct AbslStringifyFieldOptions AbslStringifyFieldOptions(
+        const Type& /*unused*/,  // The type `Type` is provided by `Extend`.
+        std::size_t field_index,
+        std::string_view /* unused */) {
+      static constexpr std::array<std::string_view, 4> kFieldNames{
+          "one", "two", "three", "four",
+      };
+      return {
+          .key_prefix = "",
+          .key_value_separator = " = ",
+          .key_alternative_name = kFieldNames[field_index],  // NOLINT(*-constant-array-index)
+          .value_replacement_str = "<XX>",
+          .value_replacement_other = "<YY>"
+      };
+    }
+  };
+
+  ASSERT_TRUE(mbo::types::HasAbslStringifyFieldOptions<TestStruct>);
+
+  EXPECT_THAT(TestStruct{}.ToString(), R"({one = <YY>, two = "<XX>", three = {<YY>, <YY>, <YY>}, four = {"<XX>", "<XX>", "<XX>"}})");
+}
+
+
+TEST_F(ExtenderStringifyTest, Container) {
+  struct TestStruct : mbo::types::Extend<TestStruct> {
+    using MboTypesExtendDoNotPrintFieldNames = void;
+
+    std::vector<int> one = {1, 2, 3};
+    std::vector<int> two = {};
+    std::vector<int> tre = {1, 2, 3};
+
+    static struct AbslStringifyFieldOptions AbslStringifyFieldOptions(
+        const Type& /*unused*/,  // The type `Type` is provided by `Extend`.
+        std::size_t field_index,
+        std::string_view /* unused */) {
+      static constexpr std::array<std::string_view, 3> kFieldNames{
+          "one", "two", "three",
+      };
+      return {
+          .key_prefix = "",
+          .key_value_separator = " = ",
+          .key_alternative_name = kFieldNames[field_index],  // NOLINT(*-constant-array-index)
+          .value_container_prefix = "[",
+          .value_container_suffix = "]",
+          .value_container_max_len = field_index == 1 ? 0U : 2U,
+      };
+    }
+  };
+
+  ASSERT_TRUE(mbo::types::HasAbslStringifyFieldOptions<TestStruct>);
+
+  EXPECT_THAT(TestStruct{}.ToString(), R"({one = [1, 2], two = [], three = [1, 2]})");
+}
+
+// NOLINTEND(*-magic-numbers)
+
+}  // namespace
+}  // namespace mbo::types
+
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif

--- a/mbo/types/extend_stringify_test.cc
+++ b/mbo/types/extend_stringify_test.cc
@@ -27,6 +27,9 @@
 # pragma clang diagnostic push
 # pragma clang diagnostic ignored "-Wunknown-pragmas"
 # pragma clang diagnostic ignored "-Wunused-local-typedef"
+#elif defined(__GNUC__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #endif
 
 namespace mbo::types {
@@ -212,4 +215,6 @@ TEST_F(ExtenderStringifyTest, Container) {
 
 #ifdef __clang__
 # pragma clang diagnostic pop
+#elif defined(__GNUC__)
+# pragma GCC diagnostic pop
 #endif

--- a/mbo/types/extend_stringify_test.cc
+++ b/mbo/types/extend_stringify_test.cc
@@ -151,23 +151,26 @@ TEST_F(ExtenderStringifyTest, ValueReplacement) {
         std::size_t field_index,
         std::string_view /* unused */) {
       static constexpr std::array<std::string_view, 4> kFieldNames{
-          "one", "two", "three", "four",
+          "one",
+          "two",
+          "three",
+          "four",
       };
       return {
           .key_prefix = "",
           .key_value_separator = " = ",
           .key_alternative_name = kFieldNames[field_index],  // NOLINT(*-constant-array-index)
           .value_replacement_str = "<XX>",
-          .value_replacement_other = "<YY>"
-      };
+          .value_replacement_other = "<YY>"};
     }
   };
 
   ASSERT_TRUE(mbo::types::HasAbslStringifyFieldOptions<TestStruct>);
 
-  EXPECT_THAT(TestStruct{}.ToString(), R"({one = <YY>, two = "<XX>", three = {<YY>, <YY>, <YY>}, four = {"<XX>", "<XX>", "<XX>"}})");
+  EXPECT_THAT(
+      TestStruct{}.ToString(),
+      R"({one = <YY>, two = "<XX>", three = {<YY>, <YY>, <YY>}, four = {"<XX>", "<XX>", "<XX>"}})");
 }
-
 
 TEST_F(ExtenderStringifyTest, Container) {
   struct TestStruct : mbo::types::Extend<TestStruct> {
@@ -182,7 +185,9 @@ TEST_F(ExtenderStringifyTest, Container) {
         std::size_t field_index,
         std::string_view /* unused */) {
       static constexpr std::array<std::string_view, 3> kFieldNames{
-          "one", "two", "three",
+          "one",
+          "two",
+          "three",
       };
       return {
           .key_prefix = "",

--- a/mbo/types/extender.h
+++ b/mbo/types/extender.h
@@ -177,7 +177,7 @@ struct AbslStringifyFieldOptions {
   std::size_t value_container_max_len = std::numeric_limits<std::size_t>::max();
 
   std::string_view value_replacement_str;    // Allows "redacted" for string values
-  std::string_view value_replacement_other;  // Allows "redacted" for string values
+  std::string_view value_replacement_other;  // Allows "redacted" for non string values
 
   // Maximum length of value (prior to escaping).
   std::string_view::size_type value_max_length{std::string_view::npos};


### PR DESCRIPTION
Format control for AbslStringify:
* Added formatting control for `AbslStringify` externder using struct and method `AbslStringifyFieldOptions`.