### PR TITLE
Improve AbslStringify functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.2.30
 
-* Added formatting control for `AbslStringify` externder using struct and method `AbslStringifyFieldOptions`.
+* Added formatting control for `AbslStringify` externder using struct and method `AbslStringifyOptions`.
 
 # 0.2.29
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The C++ library is organized in functional groups each residing in their own dir
                 * The output is a comma separated list of field values, e.g. `{ 25, 42 }`.
                 * If available (Clang 16+) this function prints field names `{ first = 25, second = 42 }`.
             * extender-struct `Streamable`: Extender that injects functionality to make an `Extend`ed type streamable. This allows the type to be used directly with `std::ostream`s.
-        * struct `AbslStringifyFieldOptions` which can be used to control `AbslStringify` formatting.
+        * struct `AbslStringifyOptions` which can be used to control `AbslStringify` formatting.
     * mbo/types:no_destruct_cc, mbo/types/no_destruct.h
         * struct `NoDestruct<T>`: Implements a type that allows to use any type as a static constant.
         * Mainly, this prevents calling the destructor and thus prevents termination issues (initialization order fiasco).

--- a/mbo/types/BUILD.bazel
+++ b/mbo/types/BUILD.bazel
@@ -49,6 +49,7 @@ cc_library(
         "//mbo/types/internal:extend_cc",
         "//mbo/types/internal:struct_names_cc",
         "@com_google_absl//absl/hash",
+        "@com_google_absl//absl/log:absl_check",
         "@com_google_absl//absl/strings:str_format",
     ],
 )

--- a/mbo/types/BUILD.bazel
+++ b/mbo/types/BUILD.bazel
@@ -71,6 +71,9 @@ cc_test(
     name = "extend_stringify_test",
     size = "small",
     srcs = ["extend_stringify_test.cc"],
+    copts = [
+        "-ftemplate-depth=5000",
+    ],
     deps = [
         ":extend_cc",
         "@com_google_absl//absl/container:flat_hash_map",

--- a/mbo/types/extend_stringify_test.cc
+++ b/mbo/types/extend_stringify_test.cc
@@ -71,10 +71,17 @@ struct ExtenderStringifyTest : ::testing::Test {
     return options;
   }
 
-  static Tester tester;
+  ExtenderStringifyTest() { tester = new Tester(); }
+
+  ~ExtenderStringifyTest() override {
+    delete tester;
+    tester = nullptr;
+  }
+
+  static Tester* tester;
 };
 
-ExtenderStringifyTest::Tester ExtenderStringifyTest::tester;
+ExtenderStringifyTest::Tester* ExtenderStringifyTest::tester = nullptr;
 
 TEST_F(ExtenderStringifyTest, SuppressFieldNames) {
   struct SuppressFieldNames : ::mbo::types::Extend<SuppressFieldNames> {
@@ -106,11 +113,11 @@ TEST_F(ExtenderStringifyTest, KeyNames) {
         const Type&,
         std::size_t field_index,
         std::string_view field_name) {
-      return tester.FieldOptions(field_index, field_name);
+      return tester->FieldOptions(field_index, field_name);
     }
   };
 
-  EXPECT_CALL(tester, FieldOptions(0, HasFieldName("one")))
+  EXPECT_CALL(*tester, FieldOptions(0, HasFieldName("one")))
       .WillOnce(::testing::Return(AbslStringifyFieldOptions{
           .field_suppress = false,
           .field_separator = "++",
@@ -119,7 +126,7 @@ TEST_F(ExtenderStringifyTest, KeyNames) {
           .key_value_separator = "==",
           .key_use_name = "first",
       }));
-  EXPECT_CALL(tester, FieldOptions(1, HasFieldName("two")))
+  EXPECT_CALL(*tester, FieldOptions(1, HasFieldName("two")))
       .WillOnce(::testing::Return(AbslStringifyFieldOptions{
           .field_suppress = false,
           .field_separator = "++",
@@ -128,7 +135,7 @@ TEST_F(ExtenderStringifyTest, KeyNames) {
           .key_value_separator = "==",
           .key_use_name = "second",
       }));
-  EXPECT_CALL(tester, FieldOptions(2, HasFieldName("tre")))
+  EXPECT_CALL(*tester, FieldOptions(2, HasFieldName("tre")))
       .WillOnce(::testing::Return(AbslStringifyFieldOptions{
           .field_suppress = true,
       }));

--- a/mbo/types/extend_stringify_test.cc
+++ b/mbo/types/extend_stringify_test.cc
@@ -360,8 +360,10 @@ TEST_F(ExtenderStringifyTest, PrintWithControl) {
   };
 
   const TestStruct v;
-  EXPECT_THAT(v.ToString(WithFieldNames<TestStruct>(AbslStringifyOptions::AsCpp<TestStruct>, {"one"})), R"({.one = 25})");
-  EXPECT_THAT(v.ToString(WithFieldNames<TestStruct>(AbslStringifyOptions::AsJson<TestStruct>, {"one"})), R"({"one": 25})");
+  EXPECT_THAT(
+      v.ToString(WithFieldNames<TestStruct>(AbslStringifyOptions::AsCpp<TestStruct>, {"one"})), R"({.one = 25})");
+  EXPECT_THAT(
+      v.ToString(WithFieldNames<TestStruct>(AbslStringifyOptions::AsJson<TestStruct>, {"one"})), R"({"one": 25})");
 }
 
 // NOLINTEND(*-magic-numbers,*-named-parameter)

--- a/mbo/types/extend_test.cc
+++ b/mbo/types/extend_test.cc
@@ -34,6 +34,15 @@
 #include "mbo/types/traits.h"           // IWYU pragma: keep
 #include "mbo/types/tuple.h"
 
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wunknown-pragmas"
+# pragma clang diagnostic ignored "-Wunused-local-typedef"
+#elif defined(__GNUC__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-local-typedefs"
+#endif
+
 namespace std {
 
 template<typename Sink>
@@ -753,6 +762,7 @@ TEST_F(ExtendTest, NoDefaultConstructor) {
 }
 
 struct AbslFlatHashMapUser : Extend<AbslFlatHashMapUser> {
+  using MboTypesExtendDoNotPrintFieldNames = void;
   absl::flat_hash_map<int, std::string> flat_hash_map;
 };
 
@@ -834,3 +844,9 @@ TEST_F(ExtendTest, MoveOnlyTuple) {
 
 }  // namespace
 }  // namespace mbo::types
+
+#ifdef __clang__
+# pragma clang diagnostic pop
+#elif defined(__GNUC__)
+# pragma GCC diagnostic pop
+#endif

--- a/mbo/types/extend_test.cc
+++ b/mbo/types/extend_test.cc
@@ -394,21 +394,6 @@ TEST_F(ExtendTest, StreamableWithUnion) {
   EXPECT_THAT(kTest.ToString(), R"({25, 42, 99})");
 }
 
-struct SuppressFieldNames : ::mbo::types::Extend<SuppressFieldNames> {
-  using MboTypesExtendDoNotPrintFieldNames = void;
-
-  int first{1};
-  int second{2};
-};
-
-TEST_F(ExtendTest, SuppressFieldNames) {
-  constexpr SuppressFieldNames kTest{
-      .first = 25,
-      .second = 42,
-  };
-  EXPECT_THAT(kTest.ToString(), R"({25, 42})");
-}
-
 TEST_F(ExtendTest, Comparable) {
   struct TestComparable : public ExtendNoDefault<TestComparable, Comparable> {
     int a = 0;

--- a/mbo/types/extender.h
+++ b/mbo/types/extender.h
@@ -219,7 +219,7 @@ struct AbslStringifyOptions {
   }
 
   // Formatting control that mostly produces JSON data.
-  template <typename T>
+  template<typename T>
   static constexpr AbslStringifyOptions AsJson(
       const T& /* object */,
       std::size_t /* field_index */,

--- a/mbo/types/extender.h
+++ b/mbo/types/extender.h
@@ -376,10 +376,14 @@ struct AbslStringify_ : ExtenderBase {  // NOLINT(readability-identifier-naming)
       os << "'";
     } else if constexpr (mbo::types::IsPair<RawV>) {
       os << "{";
-      OStreamKey(os, options.special_pair_first, options, /*allow_key_override=*/false);
+      if constexpr (!requires { typename Type::MboTypesExtendDoNotPrintFieldNames; }) {
+        OStreamKey(os, options.special_pair_first, options, /*allow_key_override=*/false);
+      }
       OStreamValue(os, v.first, options);
       os << ", ";
-      OStreamKey(os, options.special_pair_second, options, /*allow_key_override=*/false);
+      if constexpr (!requires { typename Type::MboTypesExtendDoNotPrintFieldNames; }) {
+        OStreamKey(os, options.special_pair_second, options, /*allow_key_override=*/false);
+      }
       OStreamValue(os, v.second, options);
       os << "}";
     } else if constexpr (std::is_arithmetic_v<RawV>) {

--- a/mbo/types/traits.h
+++ b/mbo/types/traits.h
@@ -284,6 +284,16 @@ concept IsPair = requires(T pair) {
   requires std::same_as<std::remove_const_t<T>, std::pair<typename T::first_type, typename T::second_type>>;
 };
 
+template<typename T>
+concept IsPairFirstStr = requires(T pair) {
+  typename T::first_type;
+  typename T::second_type;
+  requires std::is_convertible_v<typename T::first_type, std::string_view>;
+  requires std::is_same_v<std::remove_reference_t<decltype(pair.first)>, typename T::first_type>;
+  requires std::is_same_v<std::remove_reference_t<decltype(pair.second)>, typename T::second_type>;
+  requires std::same_as<std::remove_const_t<T>, std::pair<typename T::first_type, typename T::second_type>>;
+};
+
 namespace types_internal {
 
 template<typename SameAs, typename... Ts>


### PR DESCRIPTION
Improve AbslStringify functionality:
* Support arithmetic types correctly as direct types.
* Add preliminary JSON default option.
* Explain more functionality in the tests.
* Add special pair support.