### PR TITLE
Feat/nesting_support_20240925

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.2.30
 
-* Added formatting control for `AbslStringify` externder using `AbslStringifyOptions`.
+* Added formatting control for `AbslStringify` externder using struct `AbslStringifyOptions`.
 * Added `AbslStringify` ADL API extension entry points `MboTypesExtendStringifyOptions` and `MboTypesExtendStringifyOptions`.
 * Added function `extender::WithFieldNames` a format control adapter for `AbslStringify`.
 * Added field name support for non literal types in Clang.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # 0.2.30
 
-* Added formatting control for `AbslStringify` externder using struct and ADL method `MboTypesExtendStringifyOptions`.
+* Added formatting control for `AbslStringify` externder using `AbslStringifyOptions`.
 * Added `AbslStringify` ADL API extension entry points `MboTypesExtendStringifyOptions` and `MboTypesExtendStringifyOptions`.
-* Added function `WithFieldNames` a format control adapter for `AbslStringify`.
-* Added field name support for non literal typesin Clang.
+* Added function `extender::WithFieldNames` a format control adapter for `AbslStringify`.
+* Added field name support for non literal types in Clang.
 
 # 0.2.29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.2.30
 
-* Added formatting control for `AbslStringify` externder using struct and method `AbslStringifyOptions`.
+* Added formatting control for `AbslStringify` externder using struct and ADL method `MboTypesExtendStringifyOptions`.
+* Added `AbslStringify` ADL API extension entry points `MboTypesExtendStringifyOptions` and `MboTypesExtendStringifyOptions`.
 * Added function `WithFieldNames` a format control adapter for `AbslStringify`.
 * Added field name support for non literal typesin Clang.
 

--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ The C++ library is organized in functional groups each residing in their own dir
                 * The output is a comma separated list of field values, e.g. `{ 25, 42 }`.
                 * If available (Clang 16+) this function prints field names `{ .first = 25, .second = 42 }`.
             * extender-struct `Streamable`: Extender that injects functionality to make an `Extend`ed type streamable. This allows the type to be used directly with `std::ostream`s.
+            * function `WithFieldNames` a format control adapter for `AbslStringify`.
         * struct `AbslStringifyOptions` which can be used to control `AbslStringify` formatting.
-        * function `WithFieldNames` a format control adapter for `AbslStringify`.
     * mbo/types:no_destruct_cc, mbo/types/no_destruct.h
         * struct `NoDestruct<T>`: Implements a type that allows to use any type as a static constant.
         * Mainly, this prevents calling the destructor and thus prevents termination issues (initialization order fiasco).

--- a/README.md
+++ b/README.md
@@ -122,10 +122,10 @@ The C++ library is organized in functional groups each residing in their own dir
             * extender-struct `Printable`:
                 * Extender that injects functionality to make an `Extend`ed type get a `std::string ToString() const` function which can be used to convert a type into a `std::string`.
                 * The output is a comma separated list of field values, e.g. `{ 25, 42 }`.
-                * If available (Clang 16+) this function prints field names `{ first = 25, second = 42 }`.
+                * If available (Clang 16+) this function prints field names `{ .first = 25, .second = 42 }`.
             * extender-struct `Streamable`: Extender that injects functionality to make an `Extend`ed type streamable. This allows the type to be used directly with `std::ostream`s.
-            * struct `AbslStringifyOptions` which can be used to control `AbslStringify` formatting.
-            * function `WithFieldNames` a format control adapter for `AbslStringify`.
+        * struct `AbslStringifyOptions` which can be used to control `AbslStringify` formatting.
+        * function `WithFieldNames` a format control adapter for `AbslStringify`.
     * mbo/types:no_destruct_cc, mbo/types/no_destruct.h
         * struct `NoDestruct<T>`: Implements a type that allows to use any type as a static constant.
         * Mainly, this prevents calling the destructor and thus prevents termination issues (initialization order fiasco).

--- a/mbo/types/BUILD.bazel
+++ b/mbo/types/BUILD.bazel
@@ -77,6 +77,7 @@ cc_test(
     ],
     deps = [
         ":extend_cc",
+        "//mbo/container:limited_vector_cc",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/hash:hash_testing",
         "@com_google_absl//absl/log:absl_check",

--- a/mbo/types/extend_stringify_test.cc
+++ b/mbo/types/extend_stringify_test.cc
@@ -30,17 +30,27 @@
 # pragma clang diagnostic push
 # pragma clang diagnostic ignored "-Wunknown-pragmas"
 # pragma clang diagnostic ignored "-Wunused-local-typedef"
+# if __APPLE_CC__
+#  // There is an issue with ADL members here.
+#  pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
+#  pragma clang diagnostic ignored "-Wunused-function"
+# endif
 #elif defined(__GNUC__)
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #endif
 
-namespace mbo::types {
+// namespace mbo::types {
 namespace {
 
 // NOLINTBEGIN(*-magic-numbers,*-named-parameter)
 
+using ::mbo::types::AbslStringifyNameHandling;
+using ::mbo::types::AbslStringifyOptions;
+using ::mbo::types::HasMboTypesExtendDoNotPrintFieldNames;
+using ::mbo::types::HasMboTypesExtendStringifyOptions;
 using ::mbo::types::types_internal::kStructNameSupport;
+using ::testing::ElementsAre;
 using ::testing::ElementsAre;
 using ::testing::IsEmpty;
 
@@ -80,24 +90,40 @@ TEST_F(ExtenderStringifyTest, SuppressFieldNames) {
   struct SuppressFieldNames : ::mbo::types::Extend<SuppressFieldNames> {
     using MboTypesExtendDoNotPrintFieldNames = void;
 
-    int first{0};
-    std::string_view second;
+    int one{0};
+    std::string_view two;
   };
 
   constexpr SuppressFieldNames kTest{
-      .first = 25,
-      .second = "42",
+      .one = 25,
+      .two = "42",
   };
-  EXPECT_THAT(kTest.ToString(), R"({25, "42"})") << "HERE no compiler should print any field name.";
+  ASSERT_THAT(HasMboTypesExtendDoNotPrintFieldNames<decltype(kTest)>, true);
+  EXPECT_THAT(kTest.ToString(), R"({25, "42"})") << "  NOTE: Here no compiler should print any field name.";
 }
 
-TEST_F(ExtenderStringifyTest, NoGetAbslStringifyOptions) {
+TEST_F(ExtenderStringifyTest, NoMboTypesExtendStringifyOptions) {
   struct TestStruct : mbo::types::Extend<TestStruct> {
     int one = 11;
   };
 
-  ASSERT_FALSE(mbo::types::HasGetAbslStringifyOptions<TestStruct>);
+  ASSERT_FALSE(HasMboTypesExtendDoNotPrintFieldNames<TestStruct>);
+  ASSERT_FALSE(HasMboTypesExtendStringifyOptions<TestStruct>);
 }
+
+struct TestStructKeyNames : mbo::types::Extend<TestStructKeyNames> {
+  int one = 11;
+  int two = 25;
+  int tre = 33;
+
+  friend AbslStringifyOptions MboTypesExtendStringifyOptions(
+      const TestStructKeyNames&,
+      std::size_t idx,
+      std::string_view name,
+      const AbslStringifyOptions& /*defaults*/) {
+    return ExtenderStringifyTest::tester->FieldOptions(idx, name);
+  }
+};
 
 TEST_F(ExtenderStringifyTest, KeyNames) {
   // Demonstrates different parameters can be routed differently.
@@ -105,21 +131,7 @@ TEST_F(ExtenderStringifyTest, KeyNames) {
   // * based on field index (or name if available) different control can be returned.
   // * fields `one` and `two` have different key control, including field name overriding.
   // * field `tre` will be fully suppressed.
-  struct TestStruct : mbo::types::Extend<TestStruct> {
-    int one = 11;
-    int two = 25;
-    int tre = 33;
-
-    static AbslStringifyOptions GetAbslStringifyOptions(
-        const Type&,
-        std::size_t idx,
-        std::string_view name,
-        const AbslStringifyOptions& /*defaults*/) {
-      return tester->FieldOptions(idx, name);
-    }
-  };
-
-  ASSERT_TRUE(mbo::types::HasGetAbslStringifyOptions<TestStruct>);
+  ASSERT_TRUE(mbo::types::HasMboTypesExtendStringifyOptions<TestStructKeyNames>);
 
   EXPECT_CALL(*tester, FieldOptions(0, HasFieldName("one")))
       .WillOnce(::testing::Return(AbslStringifyOptions{
@@ -144,188 +156,220 @@ TEST_F(ExtenderStringifyTest, KeyNames) {
           .field_suppress = true,
       }));
 
-  EXPECT_THAT(TestStruct{}.ToString(), "{__first..==11++__second..==25}");
+  EXPECT_THAT(TestStructKeyNames{}.ToString(), "{__first..==11++__second..==25}");
 }
+
+struct TestStruct : mbo::types::Extend<TestStruct> {
+  int one = 11;
+  int two = 25;
+  int tre = 33;
+
+  friend AbslStringifyOptions MboTypesExtendStringifyOptions(
+      const TestStruct& v,
+      std::size_t idx,
+      std::string_view name,
+      const AbslStringifyOptions& defaults) {
+    return WithFieldNames(
+        AbslStringifyOptions{
+            .key_prefix = "",
+            .key_value_separator = " = ",
+        },
+        {"ONE", "TWO", "three"}, AbslStringifyNameHandling::kOverwrite)(v, idx, name, defaults);
+  }
+};
 
 TEST_F(ExtenderStringifyTest, FieldNames) {
   // Field names taken from a static array.
-  struct TestStruct : mbo::types::Extend<TestStruct> {
-    int one = 11;
-    int two = 25;
-    int tre = 33;
-
-    static AbslStringifyOptions GetAbslStringifyOptions(
-        const Type& v,
-        std::size_t idx,
-        std::string_view name,
-        const AbslStringifyOptions& defaults) {
-      return WithFieldNames(
-          AbslStringifyOptions{
-              .key_prefix = "",
-              .key_value_separator = " = ",
-          },
-          {"ONE", "TWO", "three"}, AbslStringifyNameHandling::kOverwrite)(v, idx, name, defaults);
-    }
-  };
-
-  ASSERT_TRUE(mbo::types::HasGetAbslStringifyOptions<TestStruct>);
-
+  ASSERT_TRUE(mbo::types::HasMboTypesExtendStringifyOptions<TestStruct>);
   EXPECT_THAT(TestStruct{}.ToString(), "{ONE = 11, TWO = 25, three = 33}");
 }
 
+struct TestStructShorten : mbo::types::Extend<TestStructShorten> {
+  std::string_view one = "1";
+  std::string_view two = "22";
+  std::string_view three = "333";
+  std::string_view four = "4444";
+  std::string_view five;
+
+  friend AbslStringifyOptions MboTypesExtendStringifyOptions(
+      const TestStructShorten& v,
+      std::size_t idx,
+      std::string_view name,
+      const AbslStringifyOptions& defaults) {
+    return WithFieldNames(
+        AbslStringifyOptions{
+            .key_prefix = "",
+            .key_value_separator = " = ",
+            .value_max_length = idx >= 3 && idx <= 4 ? 0U : 1U,
+            .value_cutoff_suffix = idx < 2 ? AbslStringifyOptions::AsDefault().value_cutoff_suffix : "**",
+        },
+        {"one", "two", "three", "four", "five"})(v, idx, name, defaults);
+  }
+};
+
 TEST_F(ExtenderStringifyTest, Shorten) {
-  struct TestStruct : mbo::types::Extend<TestStruct> {
-    std::string_view one = "1";
-    std::string_view two = "22";
-    std::string_view three = "333";
-    std::string_view four = "4444";
-    std::string_view five;
-
-    static AbslStringifyOptions GetAbslStringifyOptions(
-        const Type& v,
-        std::size_t idx,
-        std::string_view name,
-        const AbslStringifyOptions& defaults) {
-      return WithFieldNames(
-          AbslStringifyOptions{
-              .key_prefix = "",
-              .key_value_separator = " = ",
-              .value_max_length = idx >= 3 && idx <= 4 ? 0U : 1U,
-              .value_cutoff_suffix = idx < 2 ? AbslStringifyOptions::AsDefault().value_cutoff_suffix : "**",
-          },
-          {"one", "two", "three", "four", "five"})(v, idx, name, defaults);
-    }
-  };
-
-  ASSERT_TRUE(mbo::types::HasGetAbslStringifyOptions<TestStruct>);
-
-  EXPECT_THAT(TestStruct{}.ToString(), R"({one = "1", two = "2...", three = "3**", four = "**", five = ""})");
+  ASSERT_TRUE(mbo::types::HasMboTypesExtendStringifyOptions<TestStructShorten>);
+  EXPECT_THAT(TestStructShorten{}.ToString(), R"({one = "1", two = "2...", three = "3**", four = "**", five = ""})");
 }
 
+struct TestStructValueReplacement : mbo::types::Extend<TestStructValueReplacement> {
+  int one = 1;
+  std::string_view two = "22";
+  std::vector<int> three = {331, 332, 333};
+  std::vector<std::string_view> four{"41", "42", "43"};
+
+  friend AbslStringifyOptions MboTypesExtendStringifyOptions(
+      const TestStructValueReplacement& v,
+      std::size_t idx,
+      std::string_view name,
+      const AbslStringifyOptions& defaults) {
+    return WithFieldNames(
+        AbslStringifyOptions{
+            .key_prefix = "",
+            .key_value_separator = " = ",
+            .value_replacement_str = "<XX>",
+            .value_replacement_other = "<YY>",
+        },
+        {"one", "two", "three", "four"})(v, idx, name, defaults);
+  }
+};
+
 TEST_F(ExtenderStringifyTest, ValueReplacement) {
-  struct TestStruct : mbo::types::Extend<TestStruct> {
-    int one = 1;
-    std::string_view two = "22";
-    std::vector<int> three = {331, 332, 333};
-    std::vector<std::string_view> four{"41", "42", "43"};
-
-    static AbslStringifyOptions GetAbslStringifyOptions(
-        const Type& v,
-        std::size_t idx,
-        std::string_view name,
-        const AbslStringifyOptions& defaults) {
-      return WithFieldNames(
-          AbslStringifyOptions{
-              .key_prefix = "",
-              .key_value_separator = " = ",
-              .value_replacement_str = "<XX>",
-              .value_replacement_other = "<YY>",
-          },
-          {"one", "two", "three", "four"})(v, idx, name, defaults);
-    }
-  };
-
-  ASSERT_TRUE(mbo::types::HasGetAbslStringifyOptions<TestStruct>);
-
+  ASSERT_TRUE(mbo::types::HasMboTypesExtendStringifyOptions<TestStructValueReplacement>);
   EXPECT_THAT(
-      TestStruct{}.ToString(),
+      TestStructValueReplacement{}.ToString(),
       R"({one = <YY>, two = "<XX>", three = {<YY>, <YY>, <YY>}, four = {"<XX>", "<XX>", "<XX>"}})");
 }
 
+struct TestStructContainer : mbo::types::Extend<TestStructContainer> {
+  std::vector<int> one = {1, 2, 3};
+  std::vector<int> two = {};
+  std::vector<int> tre = {1, 2, 3};
+
+  friend AbslStringifyOptions MboTypesExtendStringifyOptions(
+      const TestStructContainer& v,
+      std::size_t idx,
+      std::string_view name,
+      const AbslStringifyOptions& defaults) {
+    return WithFieldNames(
+        AbslStringifyOptions{
+            .key_prefix = "",
+            .key_value_separator = " = ",
+            .value_container_prefix = "[",
+            .value_container_suffix = "]",
+            .value_container_max_len = idx == 1 ? 0U : 2U,
+        },
+        {"one", "two", "three"}, AbslStringifyNameHandling::kOverwrite)(v, idx, name, defaults);
+  }
+};
+
 TEST_F(ExtenderStringifyTest, Container) {
-  struct TestStruct : mbo::types::Extend<TestStruct> {
-    std::vector<int> one = {1, 2, 3};
-    std::vector<int> two = {};
-    std::vector<int> tre = {1, 2, 3};
-
-    static AbslStringifyOptions GetAbslStringifyOptions(
-        const Type& v,
-        std::size_t idx,
-        std::string_view name,
-        const AbslStringifyOptions& defaults) {
-      return WithFieldNames(
-          AbslStringifyOptions{
-              .key_prefix = "",
-              .key_value_separator = " = ",
-              .value_container_prefix = "[",
-              .value_container_suffix = "]",
-              .value_container_max_len = idx == 1 ? 0U : 2U,
-          },
-          {"one", "two", "three"}, AbslStringifyNameHandling::kOverwrite)(v, idx, name, defaults);
-    }
-  };
-
-  ASSERT_TRUE(mbo::types::HasGetAbslStringifyOptions<TestStruct>);
-
-  EXPECT_THAT(TestStruct{}.ToString(), R"({one = [1, 2], two = [], three = [1, 2]})");
+  ASSERT_TRUE(mbo::types::HasMboTypesExtendStringifyOptions<TestStructContainer>);
+  EXPECT_THAT(TestStructContainer{}.ToString(), R"({one = [1, 2], two = [], three = [1, 2]})");
 }
+
+struct TestStructMoreTypes : mbo::types::Extend<TestStructMoreTypes> {
+  float one = 1.1;
+  double two = 2.2;
+  unsigned three = 3;
+  char four = '4';
+
+  friend AbslStringifyOptions MboTypesExtendStringifyOptions(
+      const TestStructMoreTypes& v,
+      std::size_t idx,
+      std::string_view name,
+      const AbslStringifyOptions& defaults) {
+    return WithFieldNames(AbslStringifyOptions::AsJson(), {"one", "two", "three", "four"})(v, idx, name, defaults);
+  }
+};
 
 TEST_F(ExtenderStringifyTest, MoreTypes) {
-  struct TestStruct : mbo::types::Extend<TestStruct> {
-    float one = 1.1;
-    double two = 2.2;
-    unsigned three = 3;
-    char four = '4';
-
-    static AbslStringifyOptions GetAbslStringifyOptions(
-        const Type& v,
-        std::size_t idx,
-        std::string_view name,
-        const AbslStringifyOptions& defaults) {
-      return WithFieldNames(AbslStringifyOptions::AsJson(), {"one", "two", "three", "four"})(v, idx, name, defaults);
-    }
-  };
-
-  ASSERT_TRUE(mbo::types::HasGetAbslStringifyOptions<TestStruct>);
-
-  EXPECT_THAT(TestStruct{}.ToString(), R"({"one": 1.1, "two": 2.2, "three": 3, "four": '4'})");
+  ASSERT_TRUE(mbo::types::HasMboTypesExtendStringifyOptions<TestStructMoreTypes>);
+  EXPECT_THAT(TestStructMoreTypes{}.ToString(), R"({"one": 1.1, "two": 2.2, "three": 3, "four": '4'})");
 }
 
-TEST_F(ExtenderStringifyTest, MoreContainers) {
-  struct TestStruct : mbo::types::Extend<TestStruct> {
-    std::set<int> one = {1, 2};
-    std::map<int, int> two = {{1, 2}, {3, 4}};
-    std::vector<std::pair<int, int>> three = {{5, 6}};
+struct TestStructMoreContainers : mbo::types::Extend<TestStructMoreContainers> {
+  std::set<int> one = {1, 2};
+  std::map<int, int> two = {{1, 2}, {3, 4}};
+  std::vector<std::pair<int, int>> three = {{5, 6}};
 
-    static AbslStringifyOptions GetAbslStringifyOptions(
-        const Type& v,
-        std::size_t idx,
-        std::string_view name,
-        const AbslStringifyOptions& defaults) {
-      auto ret =
-          WithFieldNames(AbslStringifyOptions::AsJson(), {"one", "two", "three", "four"})(v, idx, name, defaults);
-      if (idx == 2) {
-        ret.special_pair_first = "Key";
-        ret.special_pair_second = "Val";
-      }
-      return ret;
+  friend AbslStringifyOptions MboTypesExtendStringifyOptions(
+      const TestStructMoreContainers& v,
+      std::size_t idx,
+      std::string_view name,
+      const AbslStringifyOptions& defaults) {
+    auto ret = WithFieldNames(AbslStringifyOptions::AsJson(), {"one", "two", "three", "four"})(v, idx, name, defaults);
+    if (idx == 2) {
+      ret.special_pair_first = "Key";
+      ret.special_pair_second = "Val";
     }
-  };
+    return ret;
+  }
+};
 
-  ASSERT_TRUE(mbo::types::HasGetAbslStringifyOptions<TestStruct>);
-
+TEST_F(ExtenderStringifyTest, MoreContainers) {
+  ASSERT_TRUE(mbo::types::HasMboTypesExtendStringifyOptions<TestStructMoreContainers>);
   EXPECT_THAT(
-      TestStruct{}.ToString(),
+      TestStructMoreContainers{}.ToString(),
+      R"({"one": [1, 2], "two": [{.first: 1, .second: 2}, {.first: 3, .second: 4}], "three": [{.Key: 5, .Val: 6}]})")
+      << "  NOTE: Here we are not providing the defualt Json options down do the pairs. However, in `three` we have "
+         "the provided key/value names.";
+  EXPECT_THAT(
+      TestStructMoreContainers{}.ToString(AbslStringifyOptions::AsJson()),
       R"({"one": [1, 2], "two": [{"first": 1, "second": 2}, {"first": 3, "second": 4}], "three": [{"Key": 5, "Val": 6}]})");
 }
 
-TEST_F(ExtenderStringifyTest, ContainersOfPairs) {
-  struct TestStruct : mbo::types::Extend<TestStruct> {
-    std::map<std::string_view, int> one = {{"a", 1}, {"b", 2}};
-    std::vector<std::pair<std::string_view, int>> two = {{"c", 3}, {"d", 4}};
+struct TestStructMoreContainersWithDirectFieldNames : mbo::types::Extend<TestStructMoreContainersWithDirectFieldNames> {
+  std::set<int> one = {1, 2};
+  std::map<int, int> two = {{1, 2}, {3, 4}};
+  std::vector<std::pair<int, int>> three = {{5, 6}};
 
-    static AbslStringifyOptions GetAbslStringifyOptions(
-        const Type& v,
-        std::size_t idx,
-        std::string_view name,
-        const AbslStringifyOptions& defaults) {
-      return WithFieldNames(AbslStringifyOptions::AsJson(), {"one", "two", "three", "four"})(v, idx, name, defaults);
+  friend auto MboTypesExtendFieldNames(const TestStructMoreContainersWithDirectFieldNames& v) {
+    (void)v;
+    return std::array<std::string_view, 3>{"1", "2", "3"};
+  }
+
+  friend AbslStringifyOptions MboTypesExtendStringifyOptions(
+      const TestStructMoreContainersWithDirectFieldNames&,
+      std::size_t idx,
+      std::string_view,
+      const AbslStringifyOptions& defaults) {
+    AbslStringifyOptions ret = defaults;
+    if (idx == 2) {
+      ret.special_pair_first = "Key";
+      ret.special_pair_second = "Val";
     }
-  };
+    return ret;
+  }
+};
 
-  ASSERT_TRUE(mbo::types::HasGetAbslStringifyOptions<TestStruct>);
+TEST_F(ExtenderStringifyTest, MoreContainersWithDirectFieldNames) {
+  static_assert(!mbo::types::HasMboTypesExtendDoNotPrintFieldNames<TestStructMoreContainersWithDirectFieldNames>);
+  static_assert(mbo::types::HasMboTypesExtendStringifyOptions<TestStructMoreContainersWithDirectFieldNames>);
+  static_assert(mbo::types::HasMboTypesExtendFieldNames<decltype(TestStructMoreContainersWithDirectFieldNames{})>);
+  EXPECT_TRUE(mbo::types::HasMboTypesExtendFieldNames<decltype(TestStructMoreContainersWithDirectFieldNames{})>);
+  EXPECT_THAT(MboTypesExtendFieldNames(TestStructMoreContainersWithDirectFieldNames{}), ElementsAre("1", "2", "3"));
+  EXPECT_THAT(
+      TestStructMoreContainersWithDirectFieldNames{}.ToString(AbslStringifyOptions::AsJson()),
+      R"({"1": [1, 2], "2": [{"first": 1, "second": 2}, {"first": 3, "second": 4}], "3": [{"Key": 5, "Val": 6}]})");
+}
 
-  EXPECT_THAT(TestStruct{}.ToString(), R"({"one": {"a": 1, "b": 2}, "two": {"c": 3, "d": 4}})");
+struct TestStructContainersOfPairs : mbo::types::Extend<TestStructContainersOfPairs> {
+  std::map<std::string_view, int> one = {{"a", 1}, {"b", 2}};
+  std::vector<std::pair<std::string_view, int>> two = {{"c", 3}, {"d", 4}};
+
+  friend AbslStringifyOptions MboTypesExtendStringifyOptions(
+      const TestStructContainersOfPairs& v,
+      std::size_t idx,
+      std::string_view name,
+      const AbslStringifyOptions& defaults) {
+    return WithFieldNames(AbslStringifyOptions::AsJson(), {"one", "two", "three", "four"})(v, idx, name, defaults);
+  }
+};
+
+TEST_F(ExtenderStringifyTest, ContainersOfPairs) {
+  ASSERT_TRUE(mbo::types::HasMboTypesExtendStringifyOptions<TestStructContainersOfPairs>);
+  EXPECT_THAT(TestStructContainersOfPairs{}.ToString(), R"({"one": {"a": 1, "b": 2}, "two": {"c": 3, "d": 4}})");
 }
 
 TEST_F(ExtenderStringifyTest, PrintWithControl) {
@@ -334,8 +378,6 @@ TEST_F(ExtenderStringifyTest, PrintWithControl) {
   };
 
   const TestStruct v;
-  EXPECT_THAT(v.ToString(WithFieldNames(AbslStringifyOptions::AsCpp(), {"one"})), R"({.one = 25})");
-  EXPECT_THAT(v.ToString(WithFieldNames(AbslStringifyOptions::AsJson(), {"one"})), R"({"one": 25})");
   if constexpr (kStructNameSupport) {
     EXPECT_THAT(v.ToString(AbslStringifyOptions::AsCpp()), R"({.one = 25})");
     EXPECT_THAT(v.ToString(AbslStringifyOptions::AsJson()), R"({"one": 25})");
@@ -343,30 +385,6 @@ TEST_F(ExtenderStringifyTest, PrintWithControl) {
     EXPECT_THAT(v.ToString(AbslStringifyOptions::AsCpp()), R"({25})");
     EXPECT_THAT(v.ToString(AbslStringifyOptions::AsJson()), R"({25})");
   }
-}
-
-TEST_F(ExtenderStringifyTest, NonLiteralFields) {
-  struct TestStruct : mbo::types::Extend<TestStruct> {
-    std::map<int, int> one = {{1, 2}, {2, 3}};
-    std::unordered_map<int, int> two = {{3, 4}};
-    std::string three = "three";
-
-    static AbslStringifyOptions GetAbslStringifyOptions(const Type& v, std::size_t idx, std::string_view name) {
-      return WithFieldNames(AbslStringifyOptions::AsCpp(), {"one", "two", "three"})(v, idx, name);
-    }
-  };
-
-  if constexpr (kStructNameSupport) {
-    ASSERT_THAT(types_internal::SupportsFieldNames<TestStruct>, true);
-    ASSERT_THAT(types_internal::SupportsFieldNamesConstexpr<TestStruct>, false);
-    ASSERT_THAT(::mbo::types::types_internal::GetFieldNames<TestStruct>(), ElementsAre("one", "two", "three"));
-  }
-
-  ASSERT_TRUE(mbo::types::HasGetAbslStringifyOptions<TestStruct>);
-
-  EXPECT_THAT(
-      TestStruct{}.ToString(),
-      R"({.one = {{.first = 1, .second = 2}, {.first = 2, .second = 3}}, .two = {{.first = 3, .second = 4}}, .three = "three"})");
 }
 
 TEST_F(ExtenderStringifyTest, NestedDefaults) {
@@ -382,64 +400,73 @@ TEST_F(ExtenderStringifyTest, NestedDefaults) {
 
   const TestStruct v;
 
-  static constexpr std::string_view kExpectedDef = R"({.one: 11, .two: 25, .three: {.four: 42}})";
-  static constexpr std::string_view kExpectedCpp = R"({.one = 11, .two = 25, .three = {.four = 42}})";
-  static constexpr std::string_view kExpectedJson = R"({"one": 11, "two": 25, "three": {"four": 42}})";
-  EXPECT_THAT(v.ToString(), kExpectedDef);
-  EXPECT_THAT(v.ToString(AbslStringifyOptions::AsCpp()), kExpectedCpp);
-  EXPECT_THAT(v.ToString(AbslStringifyOptions::AsJson()), kExpectedJson);
-  EXPECT_THAT(v.ToJsonString(), kExpectedJson);
+  if constexpr (kStructNameSupport) {
+    static constexpr std::string_view kExpectedDef = R"({.one: 11, .two: 25, .three: {.four: 42}})";
+    static constexpr std::string_view kExpectedCpp = R"({.one = 11, .two = 25, .three = {.four = 42}})";
+    static constexpr std::string_view kExpectedJson = R"({"one": 11, "two": 25, "three": {"four": 42}})";
+    EXPECT_THAT(v.ToString(), kExpectedDef);
+    EXPECT_THAT(v.ToString(AbslStringifyOptions::AsCpp()), kExpectedCpp);
+    EXPECT_THAT(v.ToString(AbslStringifyOptions::AsJson()), kExpectedJson);
+    EXPECT_THAT(v.ToJsonString(), kExpectedJson);
+  }
 }
 
+struct TestStructCustomNestedJsonNested : mbo::types::Extend<TestStructCustomNestedJsonNested> {
+  int first = 0;
+  std::string second = "nested";
+
+  friend AbslStringifyOptions MboTypesExtendStringifyOptions(
+      const TestStructCustomNestedJsonNested& v,
+      std::size_t idx,
+      std::string_view name,
+      const AbslStringifyOptions& defaults) {
+    return WithFieldNames(
+        AbslStringifyOptions::AsJson(), {"NESTED_1", "NESTED_2"}, AbslStringifyNameHandling::kOverwrite)(
+        v, idx, name, defaults);
+  }
+};
+
+struct TestStructCustomNestedJson : mbo::types::Extend<TestStructCustomNestedJson> {
+  int one = 123;
+  std::string two = "test";
+  std::array<bool, 2> three = {false, true};
+  std::vector<TestStructCustomNestedJsonNested> four = {{.first = 25, .second = "foo"}, {.first = 42, .second = "bar"}};
+  std::pair<int, int> five = {25, 42};
+
+  friend AbslStringifyOptions MboTypesExtendStringifyOptions(
+      const TestStructCustomNestedJson& v,
+      std::size_t idx,
+      std::string_view name,
+      const AbslStringifyOptions& defaults) {
+    return WithFieldNames(AbslStringifyOptions::AsJson(), {"one", "two", "three", "four", "five"})(
+        v, idx, name, defaults);
+  }
+};
+
 TEST_F(ExtenderStringifyTest, CustomNestedJson) {
-  struct TestNested : mbo::types::Extend<TestNested> {
-    int first = 0;
-    std::string second = "nested";
-
-    static AbslStringifyOptions GetAbslStringifyOptions(
-        const Type& v,
-        std::size_t idx,
-        std::string_view name,
-        const AbslStringifyOptions& defaults) {
-      return WithFieldNames(
-          AbslStringifyOptions::AsJson(), {"NESTED_1", "NESTED_2"}, AbslStringifyNameHandling::kOverwrite)(
-          v, idx, name, defaults);
-    }
-  };
-
-  struct TestStruct : mbo::types::Extend<TestStruct> {
-    int one = 123;
-    std::string two = "test";
-    std::array<bool, 2> three = {false, true};
-    std::vector<TestNested> four = {{.first = 25, .second = "foo"}, {.first = 42, .second = "bar"}};
-    std::pair<int, int> five = {25, 42};
-
-    static AbslStringifyOptions GetAbslStringifyOptions(
-        const Type& v,
-        std::size_t idx,
-        std::string_view name,
-        const AbslStringifyOptions& defaults) {
-      return WithFieldNames(AbslStringifyOptions::AsJson(), {"one", "two", "three", "four", "five"})(
-          v, idx, name, defaults);
-    }
-  };
-
-  ASSERT_TRUE(mbo::types::HasGetAbslStringifyOptions<TestStruct>);
+  ASSERT_TRUE(mbo::types::HasMboTypesExtendStringifyOptions<TestStructCustomNestedJson>);
 
   // Keys for nested "four" should get their key names as "first" and "second" since they are not provided.
   // No handover of concrete values to defaults should occur.
-  // BUT We want to check whether the new defaults are being picked up!
+  // BUT: Five uses non JSON mode as we fallback to the default options which were not set.
   EXPECT_THAT(
-      TestStruct{}.ToString(),
+      TestStructCustomNestedJson{}.ToString(),
+      R"({"one": 123, "two": "test", "three": [false, true], "four": [{"NESTED_1": 25, "NESTED_2": "foo"}, {"NESTED_1": 42, "NESTED_2": "bar"}], "five": {.first: 25, .second: 42}})");
+  //               "{"one": 123, "two": "test", "three": [false, true], "four": [{"NESTED_1": 25, "NESTED_2": "foo"},
+  //               {"NESTED_1": 42, "NESTED_2": "bar"}], "five": {"first": 25, "second": 42}}"
+
+  //               "{"one": 123, "two": "test", "three": [false, true], "four": [{"NESTED_1": 25, "NESTED_2": "foo"},
+  //               {"NESTED_1": 42, "NESTED_2": "bar"}], "five": {.first: 25, .second: 42}}"
+  EXPECT_THAT(
+      TestStructCustomNestedJson{}.ToString(AbslStringifyOptions::AsJson()),
       R"({"one": 123, "two": "test", "three": [false, true], "four": [{"NESTED_1": 25, "NESTED_2": "foo"}, {"NESTED_1": 42, "NESTED_2": "bar"}], "five": {"first": 25, "second": 42}})");
-  //               {"one": 123, "two": "test", "three": [false, true], "four": [{"four": 25, "four": "foo"}, {"four":42,
-  //               "four": "bar"}],        "five": {"first": 25, "second": 42}}
 }
 
 // NOLINTEND(*-magic-numbers,*-named-parameter)
 
 }  // namespace
-}  // namespace mbo::types
+
+//}  // namespace mbo::types
 
 #ifdef __clang__
 # pragma clang diagnostic pop

--- a/mbo/types/extend_stringify_test.cc
+++ b/mbo/types/extend_stringify_test.cc
@@ -23,6 +23,7 @@
 #include "absl/log/absl_log.h"    // IWYU pragma: keep
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "mbo/container/limited_vector.h"
 #include "mbo/types/extend.h"
 #include "mbo/types/extender.h"
 
@@ -30,11 +31,9 @@
 # pragma clang diagnostic push
 # pragma clang diagnostic ignored "-Wunknown-pragmas"
 # pragma clang diagnostic ignored "-Wunused-local-typedef"
-# if __APPLE_CC__
-#  // There is an issue with ADL members here.
-#  pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
-#  pragma clang diagnostic ignored "-Wunused-function"
-# endif
+# // There is an issue with ADL members here.
+# pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
+# pragma clang diagnostic ignored "-Wunused-function"
 #elif defined(__GNUC__)
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wunused-local-typedefs"
@@ -47,7 +46,10 @@ namespace {
 
 using ::mbo::types::AbslStringifyNameHandling;
 using ::mbo::types::AbslStringifyOptions;
+using ::mbo::types::Extend;
+using ::mbo::types::extender::WithFieldNames;
 using ::mbo::types::HasMboTypesExtendDoNotPrintFieldNames;
+using ::mbo::types::HasMboTypesExtendFieldNames;
 using ::mbo::types::HasMboTypesExtendStringifyOptions;
 using ::mbo::types::types_internal::kStructNameSupport;
 using ::testing::ElementsAre;
@@ -66,6 +68,7 @@ MATCHER_P(HasFieldName, field_name, "") {
 
 struct ExtenderStringifyTest : ::testing::Test {
   struct Tester {
+    MOCK_METHOD(std::vector<std::string>, FieldNames, ());
     MOCK_METHOD(AbslStringifyOptions, FieldOptions, (std::size_t, std::string_view));
   };
 
@@ -86,38 +89,88 @@ struct ExtenderStringifyTest : ::testing::Test {
 
 ExtenderStringifyTest::Tester* ExtenderStringifyTest::tester = nullptr;
 
-TEST_F(ExtenderStringifyTest, SuppressFieldNames) {
-  struct SuppressFieldNames : ::mbo::types::Extend<SuppressFieldNames> {
-    using MboTypesExtendDoNotPrintFieldNames = void;
-
-    int one{0};
-    std::string_view two;
-  };
-
-  constexpr SuppressFieldNames kTest{
-      .one = 25,
-      .two = "42",
-  };
-  ASSERT_THAT(HasMboTypesExtendDoNotPrintFieldNames<decltype(kTest)>, true);
-  EXPECT_THAT(kTest.ToString(), R"({25, "42"})") << "  NOTE: Here no compiler should print any field name.";
-}
-
-TEST_F(ExtenderStringifyTest, NoMboTypesExtendStringifyOptions) {
-  struct TestStruct : mbo::types::Extend<TestStruct> {
+TEST_F(ExtenderStringifyTest, AllExtensionApiPointsAbsent) {
+  struct TestStruct : Extend<TestStruct> {
     int one = 11;
   };
 
-  ASSERT_FALSE(HasMboTypesExtendDoNotPrintFieldNames<TestStruct>);
-  ASSERT_FALSE(HasMboTypesExtendStringifyOptions<TestStruct>);
+  EXPECT_FALSE(HasMboTypesExtendDoNotPrintFieldNames<TestStruct>);
+  EXPECT_FALSE(HasMboTypesExtendFieldNames<TestStruct>);
+  EXPECT_FALSE(HasMboTypesExtendStringifyOptions<TestStruct>);
 }
 
-struct TestStructKeyNames : mbo::types::Extend<TestStructKeyNames> {
+TEST_F(ExtenderStringifyTest, SuppressFieldNames) {
+  struct SuppressFieldNames : ::Extend<SuppressFieldNames> {
+    using MboTypesExtendDoNotPrintFieldNames = void;
+
+    int one = 25;
+    std::string_view two = "42";
+  };
+
+  ASSERT_TRUE(HasMboTypesExtendDoNotPrintFieldNames<SuppressFieldNames>);
+  EXPECT_FALSE(HasMboTypesExtendFieldNames<SuppressFieldNames>);
+  EXPECT_FALSE(HasMboTypesExtendStringifyOptions<SuppressFieldNames>);
+  EXPECT_THAT(SuppressFieldNames{}.ToString(), R"({25, "42"})")
+      << "  NOTE: Here no compiler should print any field name.";
+}
+
+struct AddFieldNames : ::Extend<AddFieldNames> {
+  int one = 25;
+  std::string_view two = "42";
+
+  friend auto MboTypesExtendFieldNames(const AddFieldNames&) { return std::array<std::string_view, 2>{"1", "2"}; }
+};
+
+TEST_F(ExtenderStringifyTest, AddFieldNames) {
+  // Proves the straight forward type: a `std::array<std::string, N>` works.
+  ASSERT_FALSE(HasMboTypesExtendDoNotPrintFieldNames<AddFieldNames>);
+  ASSERT_TRUE(HasMboTypesExtendFieldNames<AddFieldNames>);
+  ASSERT_FALSE(HasMboTypesExtendStringifyOptions<AddFieldNames>);
+  EXPECT_THAT(AddFieldNames{}.ToString(), R"({.1: 25, .2: "42"})")
+      << "  NOTE: Here we inject the field names and override any possibly compiler provided names.";
+}
+
+struct AddFieldVectorOfString : ::Extend<AddFieldVectorOfString> {
+  int one = 25;
+  std::string_view two = "42";
+
+  friend auto MboTypesExtendFieldNames(const AddFieldVectorOfString&) { return std::vector<std::string>{"1", "2"}; }
+};
+
+TEST_F(ExtenderStringifyTest, AddFieldVectorOfString) {
+  // This test proves that conversion from temp strings works through lifetime extension.
+  ASSERT_FALSE(HasMboTypesExtendDoNotPrintFieldNames<AddFieldVectorOfString>);
+  ASSERT_TRUE(HasMboTypesExtendFieldNames<AddFieldVectorOfString>);
+  ASSERT_FALSE(HasMboTypesExtendStringifyOptions<AddFieldVectorOfString>);
+  EXPECT_THAT(AddFieldVectorOfString{}.ToString(), R"({.1: 25, .2: "42"})")
+      << "  NOTE: Here we inject the field names and override any possibly compiler provided names.";
+}
+
+struct AddFieldNamesLimitedVector : ::Extend<AddFieldNamesLimitedVector> {
+  int one = 25;
+  std::string_view two = "42";
+
+  friend auto MboTypesExtendFieldNames(const AddFieldNamesLimitedVector&) {
+    return mbo::container::MakeLimitedVector("1", "2");
+  }
+};
+
+TEST_F(ExtenderStringifyTest, AddFieldNamesLimitedVector) {
+  // Proves other types can be compatible.
+  ASSERT_FALSE(HasMboTypesExtendDoNotPrintFieldNames<AddFieldNamesLimitedVector>);
+  ASSERT_TRUE(HasMboTypesExtendFieldNames<AddFieldNamesLimitedVector>);
+  ASSERT_FALSE(HasMboTypesExtendStringifyOptions<AddFieldNamesLimitedVector>);
+  EXPECT_THAT(AddFieldNamesLimitedVector{}.ToString(), R"({.1: 25, .2: "42"})")
+      << "  NOTE: Here we inject the field names and override any possibly compiler provided names.";
+}
+
+struct TestStructFieldOptions : Extend<TestStructFieldOptions> {
   int one = 11;
   int two = 25;
   int tre = 33;
 
   friend AbslStringifyOptions MboTypesExtendStringifyOptions(
-      const TestStructKeyNames&,
+      const TestStructFieldOptions&,
       std::size_t idx,
       std::string_view name,
       const AbslStringifyOptions& /*defaults*/) {
@@ -125,30 +178,32 @@ struct TestStructKeyNames : mbo::types::Extend<TestStructKeyNames> {
   }
 };
 
-TEST_F(ExtenderStringifyTest, KeyNames) {
+TEST_F(ExtenderStringifyTest, FieldOptions) {
   // Demonstrates different parameters can be routed differently.
   // The test verifies that:
   // * based on field index (or name if available) different control can be returned.
   // * fields `one` and `two` have different key control, including field name overriding.
   // * field `tre` will be fully suppressed.
-  ASSERT_TRUE(mbo::types::HasMboTypesExtendStringifyOptions<TestStructKeyNames>);
+  ASSERT_FALSE(HasMboTypesExtendDoNotPrintFieldNames<TestStructFieldOptions>);
+  ASSERT_FALSE(HasMboTypesExtendFieldNames<TestStructFieldOptions>);
+  ASSERT_TRUE(HasMboTypesExtendStringifyOptions<TestStructFieldOptions>);
 
   EXPECT_CALL(*tester, FieldOptions(0, HasFieldName("one")))
       .WillOnce(::testing::Return(AbslStringifyOptions{
           .field_suppress = false,
-          .field_separator = "++",
-          .key_prefix = "__",
-          .key_suffix = "..",
-          .key_value_separator = "==",
+          .field_separator = "+1+",
+          .key_prefix = "_1_",
+          .key_suffix = ".1.",
+          .key_value_separator = "=1=",
           .key_use_name = "first",
       }));
   EXPECT_CALL(*tester, FieldOptions(1, HasFieldName("two")))
       .WillOnce(::testing::Return(AbslStringifyOptions{
           .field_suppress = false,
-          .field_separator = "++",
-          .key_prefix = "__",
-          .key_suffix = "..",
-          .key_value_separator = "==",
+          .field_separator = "+2+",
+          .key_prefix = "_2_",
+          .key_suffix = ".2.",
+          .key_value_separator = "=2=",
           .key_use_name = "second",
       }));
   EXPECT_CALL(*tester, FieldOptions(2, HasFieldName("tre")))
@@ -156,35 +211,140 @@ TEST_F(ExtenderStringifyTest, KeyNames) {
           .field_suppress = true,
       }));
 
-  EXPECT_THAT(TestStructKeyNames{}.ToString(), "{__first..==11++__second..==25}");
+  EXPECT_THAT(TestStructFieldOptions{}.ToString(), "{_1_first.1.=1=11+2+_2_second.2.=2=25}");
 }
 
-struct TestStruct : mbo::types::Extend<TestStruct> {
+struct TestStructFieldNames : Extend<TestStructFieldNames> {
   int one = 11;
   int two = 25;
   int tre = 33;
 
+  friend std::vector<std::string> MboTypesExtendFieldNames(const TestStructFieldNames&) {
+    return ExtenderStringifyTest::tester->FieldNames();
+  }
+
   friend AbslStringifyOptions MboTypesExtendStringifyOptions(
-      const TestStruct& v,
+      const TestStructFieldNames&,
       std::size_t idx,
       std::string_view name,
-      const AbslStringifyOptions& defaults) {
-    return WithFieldNames(
-        AbslStringifyOptions{
-            .key_prefix = "",
-            .key_value_separator = " = ",
-        },
-        {"ONE", "TWO", "three"}, AbslStringifyNameHandling::kOverwrite)(v, idx, name, defaults);
+      const AbslStringifyOptions& /*defaults*/) {
+    return ExtenderStringifyTest::tester->FieldOptions(idx, name);
   }
 };
 
 TEST_F(ExtenderStringifyTest, FieldNames) {
-  // Field names taken from a static array.
-  ASSERT_TRUE(mbo::types::HasMboTypesExtendStringifyOptions<TestStruct>);
-  EXPECT_THAT(TestStruct{}.ToString(), "{ONE = 11, TWO = 25, three = 33}");
+  // Demonstrates different parameters can be routed differently.
+  // Unlike test `FieldOptions` here we first fetch the field names which override compiler provided ones.
+  ASSERT_FALSE(HasMboTypesExtendDoNotPrintFieldNames<TestStructFieldNames>);
+  ASSERT_TRUE(HasMboTypesExtendFieldNames<TestStructFieldNames>);
+  ASSERT_TRUE(HasMboTypesExtendStringifyOptions<TestStructFieldNames>);
+
+  // 1st ToString call.
+  EXPECT_CALL(*tester, FieldNames()).WillOnce(::testing::Return(std::vector<std::string>{"First", "Second", "Third"}));
+  EXPECT_CALL(*tester, FieldOptions(0, "First"))
+      .WillOnce(::testing::Return(AbslStringifyOptions{
+          .field_separator = "+1+",
+          .key_prefix = "_1_",
+          .key_suffix = ".1.",
+          .key_value_separator = "=1=",
+      }));
+  EXPECT_CALL(*tester, FieldOptions(1, "Second"))
+      .WillOnce(::testing::Return(AbslStringifyOptions{
+          .field_suppress = true,
+          .field_separator = "+2+",
+          .key_prefix = "_2_",
+          .key_suffix = ".2.",
+          .key_value_separator = "=2=",
+      }));
+  EXPECT_CALL(*tester, FieldOptions(2, "Third"))
+      .WillOnce(::testing::Return(AbslStringifyOptions{
+          .field_separator = "+3+",
+          .key_prefix = "_3_",
+          .key_suffix = ".3.",
+          .key_value_separator = "=3=",
+      }));
+
+  EXPECT_THAT(TestStructFieldNames{}.ToString(), "{_1_First.1.=1=11+3+_3_Third.3.=3=33}");
+
+  // 2nd ToString call.
+  EXPECT_CALL(*tester, FieldNames()).WillOnce(::testing::Return(std::vector<std::string>{"Fourth"}));
+  EXPECT_CALL(*tester, FieldOptions(0, "Fourth"))
+      .WillOnce(::testing::Return(AbslStringifyOptions{
+          .field_separator = "+4+",
+          .key_prefix = "_4_",
+          .key_suffix = ".4.",
+          .key_value_separator = "=4=",
+      }));
+  // 2nd and 3rd field get printed. But 2nd has no key name, so related options get ignored.
+  EXPECT_CALL(*tester, FieldOptions(1, IsEmpty()))
+      .WillOnce(::testing::Return(AbslStringifyOptions{
+          .field_separator = "+5+",
+          .key_prefix = "_5_",
+          .key_suffix = ".5.",
+          .key_value_separator = "=5=",
+      }));
+  // For the 3rd field, the options provide the field name through `key_use_name`.
+  EXPECT_CALL(*tester, FieldOptions(2, IsEmpty()))
+      .WillOnce(::testing::Return(AbslStringifyOptions{
+          .field_separator = "+6+",
+          .key_prefix = "_6_",
+          .key_suffix = ".6.",
+          .key_value_separator = "=6=",
+          .key_use_name = "Sixth",
+      }));
+  EXPECT_THAT(TestStructFieldNames{}.ToString(), "{_4_Fourth.4.=4=11+5+25+6+_6_Sixth.6.=6=33}");
 }
 
-struct TestStructShorten : mbo::types::Extend<TestStructShorten> {
+struct TestStructDoNotPrintFieldNames : Extend<TestStructDoNotPrintFieldNames> {
+  int one = 11;
+  int two = 25;
+  int tre = 33;
+
+  using MboTypesExtendDoNotPrintFieldNames = void;
+
+  // It is not allowed to also have the API extension point `MboTypesExtendFieldNames`.
+
+  friend AbslStringifyOptions MboTypesExtendStringifyOptions(
+      const TestStructDoNotPrintFieldNames&,
+      std::size_t idx,
+      std::string_view name,
+      const AbslStringifyOptions& /*defaults*/) {
+    return ExtenderStringifyTest::tester->FieldOptions(idx, name);
+  }
+};
+
+TEST_F(ExtenderStringifyTest, DoNotPrintFieldNames) {
+  // Demonstrates different parameters can be routed differently.
+  // Unlike test `FieldOptions` here we first fetch the field names which override compiler provided ones.
+  ASSERT_TRUE(HasMboTypesExtendDoNotPrintFieldNames<TestStructDoNotPrintFieldNames>);
+  ASSERT_FALSE(HasMboTypesExtendFieldNames<TestStructDoNotPrintFieldNames>);
+  ASSERT_TRUE(HasMboTypesExtendStringifyOptions<TestStructDoNotPrintFieldNames>);
+
+  EXPECT_CALL(*tester, FieldOptions(0, IsEmpty()))
+      .WillOnce(::testing::Return(AbslStringifyOptions{
+          .field_suppress = false,
+          .field_separator = "++",
+          .key_prefix = "__",
+          .key_suffix = "..",
+          .key_value_separator = "==",
+      }));
+  EXPECT_CALL(*tester, FieldOptions(1, IsEmpty()))
+      .WillOnce(::testing::Return(AbslStringifyOptions{
+          .field_suppress = false,
+          .field_separator = "++",
+          .key_prefix = "__",
+          .key_suffix = "..",
+          .key_value_separator = "==",
+      }));
+  EXPECT_CALL(*tester, FieldOptions(2, IsEmpty()))
+      .WillOnce(::testing::Return(AbslStringifyOptions{
+          .field_suppress = true,
+      }));
+
+  EXPECT_THAT(TestStructDoNotPrintFieldNames{}.ToString(), "{11++25}");
+}
+
+struct TestStructShorten : Extend<TestStructShorten> {
   std::string_view one = "1";
   std::string_view two = "22";
   std::string_view three = "333";
@@ -208,11 +368,11 @@ struct TestStructShorten : mbo::types::Extend<TestStructShorten> {
 };
 
 TEST_F(ExtenderStringifyTest, Shorten) {
-  ASSERT_TRUE(mbo::types::HasMboTypesExtendStringifyOptions<TestStructShorten>);
+  ASSERT_TRUE(HasMboTypesExtendStringifyOptions<TestStructShorten>);
   EXPECT_THAT(TestStructShorten{}.ToString(), R"({one = "1", two = "2...", three = "3**", four = "**", five = ""})");
 }
 
-struct TestStructValueReplacement : mbo::types::Extend<TestStructValueReplacement> {
+struct TestStructValueReplacement : Extend<TestStructValueReplacement> {
   int one = 1;
   std::string_view two = "22";
   std::vector<int> three = {331, 332, 333};
@@ -235,13 +395,13 @@ struct TestStructValueReplacement : mbo::types::Extend<TestStructValueReplacemen
 };
 
 TEST_F(ExtenderStringifyTest, ValueReplacement) {
-  ASSERT_TRUE(mbo::types::HasMboTypesExtendStringifyOptions<TestStructValueReplacement>);
+  ASSERT_TRUE(HasMboTypesExtendStringifyOptions<TestStructValueReplacement>);
   EXPECT_THAT(
       TestStructValueReplacement{}.ToString(),
       R"({one = <YY>, two = "<XX>", three = {<YY>, <YY>, <YY>}, four = {"<XX>", "<XX>", "<XX>"}})");
 }
 
-struct TestStructContainer : mbo::types::Extend<TestStructContainer> {
+struct TestStructContainer : Extend<TestStructContainer> {
   std::vector<int> one = {1, 2, 3};
   std::vector<int> two = {};
   std::vector<int> tre = {1, 2, 3};
@@ -264,31 +424,29 @@ struct TestStructContainer : mbo::types::Extend<TestStructContainer> {
 };
 
 TEST_F(ExtenderStringifyTest, Container) {
-  ASSERT_TRUE(mbo::types::HasMboTypesExtendStringifyOptions<TestStructContainer>);
+  ASSERT_TRUE(HasMboTypesExtendStringifyOptions<TestStructContainer>);
   EXPECT_THAT(TestStructContainer{}.ToString(), R"({one = [1, 2], two = [], three = [1, 2]})");
 }
 
-struct TestStructMoreTypes : mbo::types::Extend<TestStructMoreTypes> {
+struct TestStructMoreTypes : Extend<TestStructMoreTypes> {
   float one = 1.1;
   double two = 2.2;
   unsigned three = 3;
   char four = '4';
+  unsigned char five = '5';
 
-  friend AbslStringifyOptions MboTypesExtendStringifyOptions(
-      const TestStructMoreTypes& v,
-      std::size_t idx,
-      std::string_view name,
-      const AbslStringifyOptions& defaults) {
-    return WithFieldNames(AbslStringifyOptions::AsJson(), {"one", "two", "three", "four"})(v, idx, name, defaults);
+  friend auto MboTypesExtendFieldNames(const TestStructMoreTypes&) {
+    return std::array<std::string_view, 5>{"one", "two", "three", "four", "five"};
   }
 };
 
 TEST_F(ExtenderStringifyTest, MoreTypes) {
-  ASSERT_TRUE(mbo::types::HasMboTypesExtendStringifyOptions<TestStructMoreTypes>);
-  EXPECT_THAT(TestStructMoreTypes{}.ToString(), R"({"one": 1.1, "two": 2.2, "three": 3, "four": '4'})");
+  ASSERT_TRUE(HasMboTypesExtendFieldNames<TestStructMoreTypes>);
+  ASSERT_FALSE(HasMboTypesExtendStringifyOptions<TestStructMoreTypes>);
+  EXPECT_THAT(TestStructMoreTypes{}.ToString(), R"({.one: 1.1, .two: 2.2, .three: 3, .four: '4', .five: '5'})");
 }
 
-struct TestStructMoreContainers : mbo::types::Extend<TestStructMoreContainers> {
+struct TestStructMoreContainers : Extend<TestStructMoreContainers> {
   std::set<int> one = {1, 2};
   std::map<int, int> two = {{1, 2}, {3, 4}};
   std::vector<std::pair<int, int>> three = {{5, 6}};
@@ -308,7 +466,7 @@ struct TestStructMoreContainers : mbo::types::Extend<TestStructMoreContainers> {
 };
 
 TEST_F(ExtenderStringifyTest, MoreContainers) {
-  ASSERT_TRUE(mbo::types::HasMboTypesExtendStringifyOptions<TestStructMoreContainers>);
+  ASSERT_TRUE(HasMboTypesExtendStringifyOptions<TestStructMoreContainers>);
   EXPECT_THAT(
       TestStructMoreContainers{}.ToString(),
       R"({"one": [1, 2], "two": [{.first: 1, .second: 2}, {.first: 3, .second: 4}], "three": [{.Key: 5, .Val: 6}]})")
@@ -319,13 +477,12 @@ TEST_F(ExtenderStringifyTest, MoreContainers) {
       R"({"one": [1, 2], "two": [{"first": 1, "second": 2}, {"first": 3, "second": 4}], "three": [{"Key": 5, "Val": 6}]})");
 }
 
-struct TestStructMoreContainersWithDirectFieldNames : mbo::types::Extend<TestStructMoreContainersWithDirectFieldNames> {
+struct TestStructMoreContainersWithDirectFieldNames : Extend<TestStructMoreContainersWithDirectFieldNames> {
   std::set<int> one = {1, 2};
   std::map<int, int> two = {{1, 2}, {3, 4}};
   std::vector<std::pair<int, int>> three = {{5, 6}};
 
-  friend auto MboTypesExtendFieldNames(const TestStructMoreContainersWithDirectFieldNames& v) {
-    (void)v;
+  friend auto MboTypesExtendFieldNames(const TestStructMoreContainersWithDirectFieldNames&) {
     return std::array<std::string_view, 3>{"1", "2", "3"};
   }
 
@@ -344,17 +501,17 @@ struct TestStructMoreContainersWithDirectFieldNames : mbo::types::Extend<TestStr
 };
 
 TEST_F(ExtenderStringifyTest, MoreContainersWithDirectFieldNames) {
-  static_assert(!mbo::types::HasMboTypesExtendDoNotPrintFieldNames<TestStructMoreContainersWithDirectFieldNames>);
-  static_assert(mbo::types::HasMboTypesExtendStringifyOptions<TestStructMoreContainersWithDirectFieldNames>);
-  static_assert(mbo::types::HasMboTypesExtendFieldNames<decltype(TestStructMoreContainersWithDirectFieldNames{})>);
-  EXPECT_TRUE(mbo::types::HasMboTypesExtendFieldNames<decltype(TestStructMoreContainersWithDirectFieldNames{})>);
+  static_assert(!HasMboTypesExtendDoNotPrintFieldNames<TestStructMoreContainersWithDirectFieldNames>);
+  static_assert(HasMboTypesExtendStringifyOptions<TestStructMoreContainersWithDirectFieldNames>);
+  static_assert(HasMboTypesExtendFieldNames<decltype(TestStructMoreContainersWithDirectFieldNames{})>);
+  EXPECT_TRUE(HasMboTypesExtendFieldNames<decltype(TestStructMoreContainersWithDirectFieldNames{})>);
   EXPECT_THAT(MboTypesExtendFieldNames(TestStructMoreContainersWithDirectFieldNames{}), ElementsAre("1", "2", "3"));
   EXPECT_THAT(
       TestStructMoreContainersWithDirectFieldNames{}.ToString(AbslStringifyOptions::AsJson()),
       R"({"1": [1, 2], "2": [{"first": 1, "second": 2}, {"first": 3, "second": 4}], "3": [{"Key": 5, "Val": 6}]})");
 }
 
-struct TestStructContainersOfPairs : mbo::types::Extend<TestStructContainersOfPairs> {
+struct TestStructContainersOfPairs : Extend<TestStructContainersOfPairs> {
   std::map<std::string_view, int> one = {{"a", 1}, {"b", 2}};
   std::vector<std::pair<std::string_view, int>> two = {{"c", 3}, {"d", 4}};
 
@@ -368,12 +525,12 @@ struct TestStructContainersOfPairs : mbo::types::Extend<TestStructContainersOfPa
 };
 
 TEST_F(ExtenderStringifyTest, ContainersOfPairs) {
-  ASSERT_TRUE(mbo::types::HasMboTypesExtendStringifyOptions<TestStructContainersOfPairs>);
+  ASSERT_TRUE(HasMboTypesExtendStringifyOptions<TestStructContainersOfPairs>);
   EXPECT_THAT(TestStructContainersOfPairs{}.ToString(), R"({"one": {"a": 1, "b": 2}, "two": {"c": 3, "d": 4}})");
 }
 
 TEST_F(ExtenderStringifyTest, PrintWithControl) {
-  struct TestStruct : mbo::types::Extend<TestStruct> {
+  struct TestStruct : Extend<TestStruct> {
     int one = 25;
   };
 
@@ -388,11 +545,11 @@ TEST_F(ExtenderStringifyTest, PrintWithControl) {
 }
 
 TEST_F(ExtenderStringifyTest, NestedDefaults) {
-  struct TestSub : mbo::types::Extend<TestSub> {
+  struct TestSub : Extend<TestSub> {
     int four = 42;
   };
 
-  struct TestStruct : mbo::types::Extend<TestStruct> {
+  struct TestStruct : Extend<TestStruct> {
     int one = 11;
     int two = 25;
     TestSub three = {.four = 42};
@@ -411,7 +568,7 @@ TEST_F(ExtenderStringifyTest, NestedDefaults) {
   }
 }
 
-struct TestStructCustomNestedJsonNested : mbo::types::Extend<TestStructCustomNestedJsonNested> {
+struct TestStructCustomNestedJsonNested : Extend<TestStructCustomNestedJsonNested> {
   int first = 0;
   std::string second = "nested";
 
@@ -426,7 +583,7 @@ struct TestStructCustomNestedJsonNested : mbo::types::Extend<TestStructCustomNes
   }
 };
 
-struct TestStructCustomNestedJson : mbo::types::Extend<TestStructCustomNestedJson> {
+struct TestStructCustomNestedJson : Extend<TestStructCustomNestedJson> {
   int one = 123;
   std::string two = "test";
   std::array<bool, 2> three = {false, true};
@@ -444,7 +601,7 @@ struct TestStructCustomNestedJson : mbo::types::Extend<TestStructCustomNestedJso
 };
 
 TEST_F(ExtenderStringifyTest, CustomNestedJson) {
-  ASSERT_TRUE(mbo::types::HasMboTypesExtendStringifyOptions<TestStructCustomNestedJson>);
+  ASSERT_TRUE(HasMboTypesExtendStringifyOptions<TestStructCustomNestedJson>);
 
   // Keys for nested "four" should get their key names as "first" and "second" since they are not provided.
   // No handover of concrete values to defaults should occur.

--- a/mbo/types/extender.h
+++ b/mbo/types/extender.h
@@ -421,6 +421,7 @@ struct AbslStringify_ : ExtenderBase {  // NOLINT(readability-identifier-naming)
     } else if constexpr (HasMboTypesExtendFieldNames<T>) {
       return MboTypesExtendFieldNames(value);
     } else {
+      // Works for both constexpr and static/const aka compile-time and run-time cases.
       return ::mbo::types::types_internal::GetFieldNames<T>();  // T not Type
     }
   }

--- a/mbo/types/internal/extend.h
+++ b/mbo/types/internal/extend.h
@@ -26,8 +26,8 @@
 
 #include "mbo/types/extender.h"
 #include "mbo/types/internal/extender.h"
-#include "mbo/types/traits.h"
-#include "mbo/types/tuple.h"  // IWYU pragma: keep
+#include "mbo/types/traits.h"  // IWYU pragma: keep
+#include "mbo/types/tuple.h"   // IWYU pragma: keep
 
 namespace mbo::types::types_internal {
 


### PR DESCRIPTION
Full nesting support

* Added `AbslStringify` ADL API extension entry points `MboTypesExtendStringifyOptions` and `MboTypesExtendStringifyOptions`.
