### PR TITLE
Numeric field name (aka key) support for Json output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Added `AbslStringify` ADL API extension entry points `MboTypesExtendStringifyOptions` and `MboTypesExtendStringifyOptions`.
 * Added function `extender::WithFieldNames` a format control adapter for `AbslStringify`.
 * Added field name support for non literal types in Clang.
+* Added numeric field name (aka key) support and enforced for Json output.
 
 # 0.2.29
 

--- a/mbo/types/extend_stringify_test.cc
+++ b/mbo/types/extend_stringify_test.cc
@@ -541,7 +541,7 @@ TEST_F(ExtenderStringifyTest, PrintWithControl) {
     EXPECT_THAT(v.ToString(AbslStringifyOptions::AsJson()), R"({"one": 25})");
   } else {
     EXPECT_THAT(v.ToString(AbslStringifyOptions::AsCpp()), R"({25})");
-    EXPECT_THAT(v.ToString(AbslStringifyOptions::AsJson()), R"({"0", 25})");
+    EXPECT_THAT(v.ToString(AbslStringifyOptions::AsJson()), R"({"0": 25})");
   }
 }
 

--- a/mbo/types/extend_stringify_test.cc
+++ b/mbo/types/extend_stringify_test.cc
@@ -569,6 +569,28 @@ TEST_F(ExtenderStringifyTest, NestedDefaults) {
   }
 }
 
+TEST_F(ExtenderStringifyTest, NestedJsonNumericFallback) {
+  struct TestSub : Extend<TestSub> {
+    int four = 42;
+
+    using MboTypesExtendDoNotPrintFieldNames = void;
+  };
+
+  struct TestStruct : Extend<TestStruct> {
+    int one = 11;
+    int two = 25;
+    TestSub three = {.four = 42};
+
+    using MboTypesExtendDoNotPrintFieldNames = void;
+  };
+
+  static constexpr std::string_view kExpectedCpp = R"({11, 25, {42}})";
+  static constexpr std::string_view kExpectedJson = R"({"0": 11, "1": 25, "2": {"0": 42}})";
+  EXPECT_THAT(TestStruct{}.ToString(AbslStringifyOptions::AsCpp()), kExpectedCpp);
+  EXPECT_THAT(TestStruct{}.ToString(AbslStringifyOptions::AsJson()), kExpectedJson);
+  EXPECT_THAT(TestStruct{}.ToJsonString(), kExpectedJson);
+}
+
 struct TestStructCustomNestedJsonNested : Extend<TestStructCustomNestedJsonNested> {
   int first = 0;
   std::string second = "nested";

--- a/mbo/types/extend_stringify_test.cc
+++ b/mbo/types/extend_stringify_test.cc
@@ -541,7 +541,7 @@ TEST_F(ExtenderStringifyTest, PrintWithControl) {
     EXPECT_THAT(v.ToString(AbslStringifyOptions::AsJson()), R"({"one": 25})");
   } else {
     EXPECT_THAT(v.ToString(AbslStringifyOptions::AsCpp()), R"({25})");
-    EXPECT_THAT(v.ToString(AbslStringifyOptions::AsJson()), R"({25})");
+    EXPECT_THAT(v.ToString(AbslStringifyOptions::AsJson()), R"({"0", 25})");
   }
 }
 


### PR DESCRIPTION
* Added numeric field name (aka key) support and enforced for Json output.