### PR TITLE
Add static constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Added field name support for non literal types in Clang.
 * Added numeric field name (aka key) support and enforced for Json output.
 * Added rule `mbo/types:stringify_ostream_cc` and header `mbo/types/stringify_ostream.h` for automatic ostream support using `Stringify`.
+* Added static constructors `Extend::ConstructFromTuple` and `Extend::ConstructFromArgs`.
 
 # 0.2.29
 

--- a/mbo/types/BUILD.bazel
+++ b/mbo/types/BUILD.bazel
@@ -139,6 +139,7 @@ cc_test(
 
 cc_library(
     name = "stringify_cc",
+    srcs = ["stringify.cc"],
     hdrs = ["stringify.h"],
     deps = [
         ":traits_cc",

--- a/mbo/types/internal/decompose_count.h
+++ b/mbo/types/internal/decompose_count.h
@@ -457,7 +457,6 @@ struct DecomposeCountImpl : std::integral_constant<std::size_t, DecomposeInfo<T>
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 
-template<typename T>
 struct DecomposeHelper final {
   DecomposeHelper() = delete;
 

--- a/mbo/types/internal/decompose_count.h.mope
+++ b/mbo/types/internal/decompose_count.h.mope
@@ -496,7 +496,6 @@ struct DecomposeCountImpl : std::integral_constant<std::size_t, DecomposeInfo<T>
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 
-template<typename T>
 struct DecomposeHelper final {
   DecomposeHelper() = delete;
 

--- a/mbo/types/internal/extend.h
+++ b/mbo/types/internal/extend.h
@@ -19,6 +19,7 @@
 // IWYU pragma private, include "mbo/types/extend.h"
 
 #include <array>
+#include <concepts>
 #include <string_view>
 #include <tuple>
 #include <type_traits>
@@ -190,8 +191,33 @@ namespace mbo::extender {
 // This must always be present.
 template<typename ActualType>
 struct ExtendBase {
+ private:
+  // Struct `AnyBaseExtender` is a private member as it can confuse conversions throughout the code.
+  struct AnyBaseExtender {
+    template<typename U>
+    operator U() const noexcept {  // NOLINT(*-explicit-con*)
+      return {};
+    }
+  };
+
  public:
   using Type = ActualType;  // Used for type chaining in `UseExtender`
+
+  // Construct from tuple.
+  // The tuple elements must match the field types or the field types must allow conversion.
+  template<typename... Args>
+  requires std::constructible_from<Type, AnyBaseExtender, Args...>
+  static Type ConstructFromTuple(std::tuple<Args...>&& args) {  // NOLINT(*-param-not-moved)
+    return std::apply(ConstructFromArgs<Args...>, std::forward<std::tuple<Args...>>(args));
+  }
+
+  // Construct from separate arguments.
+  // The arguments must match the field types or the field types must allow conversion.
+  template<typename... Args>
+  requires std::constructible_from<Type, AnyBaseExtender, Args...>
+  static Type ConstructFromArgs(Args&&... args) {
+    return Type{AnyBaseExtender{}, std::forward<Args>(args)...};
+  }
 
  protected:  // DO NOT expose anything publicly.
   auto ToTuple() const { return StructToTuple(static_cast<const ActualType&>(*this)); }

--- a/mbo/types/stringify.cc
+++ b/mbo/types/stringify.cc
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mbo/types/stringify.h"
+
+namespace mbo::types {
+
+const StringifyOptions& StringifyOptions::AsDefault() noexcept {
+  static constexpr StringifyOptions kDefault{};
+  return kDefault;
+}
+
+const StringifyOptions& StringifyOptions::AsCpp() noexcept {
+  static constexpr StringifyOptions kCpp{
+      .output_mode = OutputMode::kCpp,
+      .key_prefix = ".",
+      .key_value_separator = " = ",
+      .value_pointer_prefix = "",
+      .value_pointer_suffix = "",
+      .value_nullptr_t = "nullptr",
+      .value_nullptr = "nullptr",
+  };
+  return kCpp;
+}
+
+const StringifyOptions& StringifyOptions::AsJson() noexcept {
+  static constexpr StringifyOptions kJson{
+      .output_mode = OutputMode::kJson,
+      .key_mode = KeyMode::kNumericFallback,
+      .key_prefix = "\"",
+      .key_suffix = "\"",
+      .key_value_separator = ": ",
+      .value_pointer_prefix = "",
+      .value_pointer_suffix = "",
+      .value_nullptr_t = "0",
+      .value_nullptr = "0",
+      .value_container_prefix = "[",
+      .value_container_suffix = "]",
+      .special_pair_first_is_name = true,
+  };
+  return kJson;
+}
+
+}  // namespace mbo::types

--- a/mbo/types/stringify.h
+++ b/mbo/types/stringify.h
@@ -528,7 +528,7 @@ class Stringify {
     }
   }
 
-  const StringifyOptions& default_options_;
+  const StringifyOptions default_options_;
 };
 
 // Adapter (not Extender) that injects field names into field control.

--- a/mbo/types/stringify.h
+++ b/mbo/types/stringify.h
@@ -135,44 +135,21 @@ struct StringifyOptions {
   std::string_view special_pair_second = "second";
 
   // Arbirary default value.
-  static constexpr StringifyOptions AsDefault() { return {}; }
+  static const StringifyOptions& AsDefault() noexcept;
 
   // Formatting control that mostly produces C++ code.
-  static constexpr StringifyOptions AsCpp() {
-    // TODO(helly25): These should probably return static constexpr& in C++23.
-    return {
-        .output_mode = OutputMode::kCpp,
-        .key_prefix = ".",
-        .key_value_separator = " = ",
-        .value_pointer_prefix = "",
-        .value_pointer_suffix = "",
-        .value_nullptr_t = "nullptr",
-        .value_nullptr = "nullptr",
-    };
-  }
+  static const StringifyOptions& AsCpp() noexcept;
 
   // Formatting control that mostly produces JSON data.
   //
   // NOTE: JSON data requires field names. So unless Clang is used only with
-  // types that support field names, the `StringifyWithFieldNames` adapter must be used.
-  static constexpr StringifyOptions AsJson() {
-    return {
-        .output_mode = OutputMode::kJson,
-        .key_mode = KeyMode::kNumericFallback,
-        .key_prefix = "\"",
-        .key_suffix = "\"",
-        .key_value_separator = ": ",
-        .value_pointer_prefix = "",
-        .value_pointer_suffix = "",
-        .value_nullptr_t = "0",
-        .value_nullptr = "0",
-        .value_container_prefix = "[",
-        .value_container_suffix = "]",
-        .special_pair_first_is_name = true,
-    };
-  }
+  // types that support field names, they must be provided by an extension API
+  // point: `MboTypesStringifyFieldNames` or `MboTypesStringifyOptions`, the
+  // latter possibly with the `StringifyWithFieldNames` adapter. Alternatively,
+  // numeric field names will be generated as a last resort.
+  static const StringifyOptions& AsJson() noexcept;
 
-  static constexpr StringifyOptions As(OutputMode mode) {
+  static const StringifyOptions& As(OutputMode mode) noexcept {
     switch (mode) {
       case OutputMode::kDefault: break;
       case OutputMode::kCpp: return AsCpp();
@@ -201,7 +178,7 @@ concept HasMboTypesStringifyDoNotPrintFieldNames = Has_DEPRECATED_MboTypesExtend
 };
 
 // This breaks `MboTypesStringifyOptions` lookup within this namespace.
-void MboTypesStringifyOptions();
+void MboTypesStringifyOptions();  // Has no implementation!
 
 // Identify presence for `AbslStringify` extender API extension point
 // `MboTypesStringifyOptions`.
@@ -220,7 +197,7 @@ concept HasMboTypesStringifyOptions = requires(const T& v) {
 };
 
 // This breaks `MboTypesStringifyFieldNames` lookup within this namespace.
-void MboTypesStringifyFieldNames();
+void MboTypesStringifyFieldNames();  // Has no implementation!
 
 // Identify presence for `AbslStringify` extender API extension point
 // `MboTypesStringifyFieldNames`.
@@ -283,11 +260,12 @@ template<typename T, typename ObjectType = mbo::types::types_internal::AnyType>
 concept IsOrCanProduceStringifyOptions =
     std::is_convertible_v<T, StringifyOptions> || CanProduceStringifyOptions<T, ObjectType>;
 
+// Class `Stringify` implements the conversion of any aggregate into a string.
 class Stringify {
  public:
-  static Stringify AsCpp() { return Stringify(StringifyOptions::AsCpp()); }
+  static Stringify AsCpp() noexcept { return Stringify(StringifyOptions::AsCpp()); }
 
-  static Stringify AsJson() { return Stringify(StringifyOptions::AsJson()); }
+  static Stringify AsJson() noexcept { return Stringify(StringifyOptions::AsJson()); }
 
   explicit Stringify(const StringifyOptions& default_options = {}) : default_options_(default_options) {}
 
@@ -296,7 +274,7 @@ class Stringify {
 
   template<typename T>
   requires(std::is_aggregate_v<T>)
-  std::string ToString(const T& value) {
+  std::string ToString(const T& value) const {
     std::ostringstream os;
     Stream<T>(os, value);
     return os.str();
@@ -304,7 +282,7 @@ class Stringify {
 
   template<typename T>
   requires(std::is_aggregate_v<T>)
-  void Stream(std::ostream& os, const T& value) {
+  void Stream(std::ostream& os, const T& value) const {
     // It is not allowed to deny field name printing but provide filed names.
     static_assert(!(HasMboTypesStringifyDoNotPrintFieldNames<T> && HasMboTypesStringifyFieldNames<T>));
 
@@ -316,10 +294,10 @@ class Stringify {
   void StreamFieldsImpl(
       std::ostream& os,
       const T& value,
-      bool allow_field_names = !HasMboTypesStringifyDoNotPrintFieldNames<T>) {
+      bool allow_field_names = !HasMboTypesStringifyDoNotPrintFieldNames<T>) const {
     allow_field_names |= default_options_.key_mode == StringifyOptions::KeyMode::kNumericFallback;
     bool use_seperator = false;
-    const auto& field_names = StreamFieldNames(value);
+    const auto& field_names = GetFieldNames(value);
     std::apply(
         [&](const auto&... fields) {
           os << '{';
@@ -339,7 +317,7 @@ class Stringify {
   }
 
   template<typename T>
-  auto StreamFieldNames(const T& value) {
+  static auto GetFieldNames(const T& value) {
     if constexpr (HasMboTypesStringifyDoNotPrintFieldNames<T>) {
       return std::array<std::string_view, 0>{};
     } else if constexpr (HasMboTypesStringifyFieldNames<T>) {
@@ -358,7 +336,7 @@ class Stringify {
       const Field& field,
       std::size_t idx,
       const FieldNames& field_names,
-      bool allow_field_names) {
+      bool allow_field_names) const {
     std::string_view field_name;
     if (allow_field_names && idx < std::size(field_names)) {
       field_name = std::data(field_names)[idx];
@@ -419,7 +397,7 @@ class Stringify {
 
   template<typename C>
   requires(::mbo::types::ContainerIsForwardIteratable<C> && !std::convertible_to<C, std::string_view>)
-  void StreamValue(std::ostream& os, const C& vs, const StringifyOptions& field_options, bool allow_field_names) {
+  void StreamValue(std::ostream& os, const C& vs, const StringifyOptions& field_options, bool allow_field_names) const {
     if constexpr (mbo::types::IsPairFirstStr<typename C::value_type>) {
       if (field_options.special_pair_first_is_name) {
         // Each pair element of the container `vs` is an element whose key is the `first` member and
@@ -462,7 +440,7 @@ class Stringify {
                                         || (std::is_aggregate_v<T> && !absl::HasAbslStringify<T>::value);
 
   template<typename V>
-  void StreamValue(std::ostream& os, const V& v, const StringifyOptions& field_options, bool allow_field_names) {
+  void StreamValue(std::ostream& os, const V& v, const StringifyOptions& field_options, bool allow_field_names) const {
     using RawV = std::remove_cvref_t<V>;
     // IMPORTANT: ALL if-clauses must be `if constexpr`.
     if constexpr (kUseStringify<RawV>) {
@@ -550,7 +528,7 @@ class Stringify {
     }
   }
 
-  const StringifyOptions default_options_;
+  const StringifyOptions& default_options_;
 };
 
 // Adapter (not Extender) that injects field names into field control.

--- a/mbo/types/stringify.h
+++ b/mbo/types/stringify.h
@@ -267,7 +267,8 @@ class Stringify {
 
   static Stringify AsJson() noexcept { return Stringify(StringifyOptions::AsJson()); }
 
-  explicit Stringify(const StringifyOptions& default_options = {}) : default_options_(default_options) {}
+  explicit Stringify(const StringifyOptions& default_options = StringifyOptions::AsDefault())
+      : default_options_(default_options) {}
 
   explicit Stringify(const StringifyOptions::OutputMode output_mode)
       : default_options_(StringifyOptions::As(output_mode)) {}
@@ -528,7 +529,7 @@ class Stringify {
     }
   }
 
-  const StringifyOptions default_options_;
+  const StringifyOptions& default_options_;
 };
 
 // Adapter (not Extender) that injects field names into field control.

--- a/mbo/types/tuple_extras.h
+++ b/mbo/types/tuple_extras.h
@@ -38,7 +38,7 @@ concept CanCreateTuple = types_internal::DecomposeCondition<T>;
 template<typename T>
 requires CanCreateTuple<T>
 inline constexpr auto StructToTuple(T&& v) {
-  return types_internal::DecomposeHelper<T>::ToTuple(std::forward<T>(v));
+  return types_internal::DecomposeHelper::ToTuple(std::forward<T>(v));
 }
 
 namespace types_internal {


### PR DESCRIPTION
* Add static constructors `Extend::ConstructFromTuple` and `Extend::ConstructFromArgs`.
* Change `DecomposeHelper` to not be a tmeplate.
* Change `Stringify::As*()` to return by const ref.
* Change `Stringify` methods to be either static or const.
* Change `Stingify::StringifyOptions` to const reference.
* Add mroe tests.