### PR TITLE
Make `IsExtended` public

### DIFF
--- a/mbo/types/extend.h
+++ b/mbo/types/extend.h
@@ -18,6 +18,7 @@
 
 #include "mbo/types/extender.h"         // IWYU pragma: export
 #include "mbo/types/internal/extend.h"  // IWYU pragma: export
+#include "mbo/types/internal/extender.h"
 
 namespace mbo::types {
 
@@ -85,6 +86,10 @@ struct ExtendNoDefault : ::mbo::extender::Extend<T, Extender...> {};
 // NOTE: No member may be an anonymous union or struct.
 template<typename T, typename... Extender>
 struct ExtendNoPrint : ::mbo::extender::Extend<T, ::mbo::types::extender::NoPrint, Extender...> {};
+
+// Determine whether type `Extended` is an `Extend`ed type.
+template<typename Extended>
+concept IsExtended = types_internal::IsExtended<Extended>;
 
 }  // namespace mbo::types
 

--- a/mbo/types/extend_test.cc
+++ b/mbo/types/extend_test.cc
@@ -646,6 +646,7 @@ TEST_F(ExtendTest, NoPrint) {
   };
 
   ASSERT_THAT((::mbo::types::IsExtended<NameNoPrint>), true);
+  static_assert(::mbo::types::IsExtended<NameNoPrint>);
   EXPECT_THAT(
       NameNoPrint::RegisteredExtenderNames(), UnorderedElementsAre("AbslHashable", "AbslStringify", "Comparable"));
   EXPECT_THAT((::mbo::types::types_internal::HasExtender<NameNoPrint, Printable>), false);

--- a/mbo/types/extend_test.cc
+++ b/mbo/types/extend_test.cc
@@ -594,10 +594,10 @@ TEST_F(ExtendTest, Hashable) {
 
   EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly({person, Person{}}));
 
-  ASSERT_THAT((::mbo::types::types_internal::IsExtended<Name>), true);
-  ASSERT_THAT((::mbo::types::types_internal::IsExtended<Person>), true);
-  ASSERT_THAT((::mbo::types::types_internal::IsExtended<PlainName>), false);
-  ASSERT_THAT((::mbo::types::types_internal::IsExtended<PlainPerson>), false);
+  ASSERT_THAT((::mbo::types::IsExtended<Name>), true);
+  ASSERT_THAT((::mbo::types::IsExtended<Person>), true);
+  ASSERT_THAT((::mbo::types::IsExtended<PlainName>), false);
+  ASSERT_THAT((::mbo::types::IsExtended<PlainPerson>), false);
   ASSERT_THAT(Person::RegisteredExtenderNames(), Contains("AbslHashable"));
   ASSERT_THAT(Person::RegisteredExtenderNames().size(), std::tuple_size_v<Person::RegisteredExtenders>);
   ASSERT_THAT((::mbo::types::types_internal::HasExtender<Person, AbslHashable>), true);
@@ -613,7 +613,7 @@ TEST_F(ExtendTest, Default) {
     std::string last;
   };
 
-  ASSERT_THAT((::mbo::types::types_internal::IsExtended<NameDefault>), true);
+  ASSERT_THAT((::mbo::types::IsExtended<NameDefault>), true);
   EXPECT_THAT(
       NameDefault::RegisteredExtenderNames(),
       UnorderedElementsAre("AbslHashable", "AbslStringify", "Comparable", "Printable", "Streamable"));
@@ -630,7 +630,7 @@ TEST_F(ExtendTest, NoDefault) {
     std::string last;
   };
 
-  ASSERT_THAT((::mbo::types::types_internal::IsExtended<NameNoDefault>), true);
+  ASSERT_THAT((::mbo::types::IsExtended<NameNoDefault>), true);
   EXPECT_THAT(NameNoDefault::RegisteredExtenderNames(), IsEmpty());
   EXPECT_THAT((::mbo::types::types_internal::HasExtender<NameNoDefault, Printable>), false);
   EXPECT_THAT((::mbo::types::types_internal::HasExtender<NameNoDefault, Streamable>), false);
@@ -645,7 +645,7 @@ TEST_F(ExtendTest, NoPrint) {
     std::string last;
   };
 
-  ASSERT_THAT((::mbo::types::types_internal::IsExtended<NameNoPrint>), true);
+  ASSERT_THAT((::mbo::types::IsExtended<NameNoPrint>), true);
   EXPECT_THAT(
       NameNoPrint::RegisteredExtenderNames(), UnorderedElementsAre("AbslHashable", "AbslStringify", "Comparable"));
   EXPECT_THAT((::mbo::types::types_internal::HasExtender<NameNoPrint, Printable>), false);

--- a/mbo/types/extend_test.cc
+++ b/mbo/types/extend_test.cc
@@ -355,9 +355,9 @@ TEST_F(ExtendTest, StreamableComplexFields) {
           R"({25, {{"Hugo", "Meyer"}, 42}, *{{"bar", "foo"}}})"));
 #ifdef __clang__
   std::cout << "Person:\n";
-  EXPECT_THAT(debug::Print(&person), SizeIs(Le(201)));
+  EXPECT_THAT(debug::Print(&person), SizeIs(Le(198)));
   std::cout << "Person::person.name:\n";
-  EXPECT_THAT(debug::Print(&person.person.name), SizeIs(Le(195)));
+  EXPECT_THAT(debug::Print(&person.person.name), SizeIs(Le(192)));
 #endif  // __clang__
 }
 

--- a/mbo/types/internal/extend.h
+++ b/mbo/types/internal/extend.h
@@ -196,7 +196,7 @@ template<typename T, typename... ExtenderList>
 requires(ExtenderListValid<ExtenderList...>)
 struct Extend<T, std::tuple<ExtenderList...>>
     : ::mbo::types::types_internal::ExtendBuildChain<
-          mbo::types::types_internal::ExtendBase<T>,  // CRTP functionality injection.
+          mbo::types::ExtendBase<T>,  // CRTP functionality injection.
           ExtenderList...,  // NOT extended, so that shorthand forms `Default` and `NoPrint` result in short names.
           void /* Sentinel to stop `ExtendBuildChain` */> {
   using RegisteredExtenders = mbo::types::types_internal::ExtendExtenderTupleT<std::tuple<ExtenderList...>>;

--- a/mbo/types/internal/extend.h
+++ b/mbo/types/internal/extend.h
@@ -187,54 +187,13 @@ struct ExtendBuildChain<T, void> : T {};
 
 namespace mbo::extender {
 
-// Base Extender implementation for CRTP functionality injection.
-// This must always be present.
-template<typename ActualType>
-struct ExtendBase {
- private:
-  // Struct `AnyBaseExtender` is a private member as it can confuse conversions throughout the code.
-  struct AnyBaseExtender {
-    template<typename U>
-    operator U() const noexcept {  // NOLINT(*-explicit-con*)
-      return {};
-    }
-  };
-
- public:
-  using Type = ActualType;  // Used for type chaining in `UseExtender`
-
-  // Construct from tuple.
-  // The tuple elements must match the field types or the field types must allow conversion.
-  template<typename... Args>
-  requires std::constructible_from<Type, AnyBaseExtender, Args...>
-  static Type ConstructFromTuple(std::tuple<Args...>&& args) {  // NOLINT(*-param-not-moved)
-    return std::apply(ConstructFromArgs<Args...>, std::forward<std::tuple<Args...>>(args));
-  }
-
-  // Construct from separate arguments.
-  // The arguments must match the field types or the field types must allow conversion.
-  template<typename... Args>
-  requires std::constructible_from<Type, AnyBaseExtender, Args...>
-  static Type ConstructFromArgs(Args&&... args) {
-    return Type{AnyBaseExtender{}, std::forward<Args>(args)...};
-  }
-
- protected:  // DO NOT expose anything publicly.
-  auto ToTuple() const { return StructToTuple(static_cast<const ActualType&>(*this)); }
-
- private:  // DO NOT expose anything publicly.
-  template<typename U, typename Extender>
-  friend struct UseExtender;
-  friend class mbo::types::Stringify;
-};
-
 using types::types_internal::ExtenderListValid;
 
 template<typename T, typename... ExtenderList>
 requires(ExtenderListValid<ExtenderList...>)
 struct Extend
     : ::mbo::types::types_internal::ExtendBuildChain<
-          ExtendBase<T>,    // CRTP functionality injection.
+          mbo::types::types_internal::ExtendBase<T>,  // CRTP functionality injection.
           ExtenderList...,  // NOT extended, so that shorthand forms `Default` and `NoPrint` result in short names.
           void /* Sentinel to stop `ExtendBuildChain` */> {
   using RegisteredExtenders = mbo::types::types_internal::ExtendExtenderTupleT<std::tuple<ExtenderList...>>;

--- a/mbo/types/internal/extend.h
+++ b/mbo/types/internal/extend.h
@@ -189,14 +189,18 @@ namespace mbo::extender {
 
 using types::types_internal::ExtenderListValid;
 
+template<typename T, typename ExtenderList>
+struct Extend;
+
 template<typename T, typename... ExtenderList>
 requires(ExtenderListValid<ExtenderList...>)
-struct Extend
+struct Extend<T, std::tuple<ExtenderList...>>
     : ::mbo::types::types_internal::ExtendBuildChain<
           mbo::types::types_internal::ExtendBase<T>,  // CRTP functionality injection.
           ExtenderList...,  // NOT extended, so that shorthand forms `Default` and `NoPrint` result in short names.
           void /* Sentinel to stop `ExtendBuildChain` */> {
   using RegisteredExtenders = mbo::types::types_internal::ExtendExtenderTupleT<std::tuple<ExtenderList...>>;
+  using UnexpandedExtenders = std::tuple<ExtenderList...>;
 
   static constexpr std::array<std::string_view, std::tuple_size_v<RegisteredExtenders>> RegisteredExtenderNames() {
     return RegisteredExtenderNamesIS(std::make_index_sequence<std::tuple_size_v<RegisteredExtenders>>{});

--- a/mbo/types/internal/extender.h
+++ b/mbo/types/internal/extender.h
@@ -75,12 +75,16 @@ struct ExtendBase {
 };
 
 // Determine whether type `Extended` is an `Extend`ed type.
+//
+// This is an incomplete concept and the public version `mbo::types::IsExtended` should be used.
 template<typename Extended>
 concept IsExtended = requires {
   typename Extended::Type;
   typename Extended::RegisteredExtenders;
+  typename Extended::UnexpandedExtenders;
   requires std::is_base_of_v<ExtendBase<typename Extended::Type>, Extended>;
   requires mbo::types::IsTuple<typename Extended::RegisteredExtenders>;
+  requires mbo::types::IsTuple<typename Extended::UnexpandedExtenders>;
   {
     Extended::RegisteredExtenderNames()
   } -> std::same_as<std::array<std::string_view, std::tuple_size_v<typename Extended::RegisteredExtenders>>>;

--- a/mbo/types/internal/extender.h
+++ b/mbo/types/internal/extender.h
@@ -29,10 +29,6 @@
 
 namespace mbo::types {
 
-class Stringify;
-
-namespace types_internal {
-
 // Base Extender implementation for CRTP functionality injection.
 // This must always be present.
 template<typename ActualType>
@@ -71,8 +67,10 @@ struct ExtendBase {
  private:  // DO NOT expose anything publicly.
   template<typename U, typename Extender>
   friend struct UseExtender;
-  friend class mbo::types::Stringify;
+  friend class Stringify;
 };
+
+namespace types_internal {
 
 // Determine whether type `Extended` is an `Extend`ed type.
 //


### PR DESCRIPTION
Make `IsExtended` publicly available and make it stricter.