### PR TITLE
Implement OverloadSet solution for Clang.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.0.a1
+
+* Changed: `DecomposeCount` to never return 0 (an empty aggregate cannot be decomposed using structured bindings).
+
 # 0.2.30
 
 * Added class `Stringify` which can turn arbitrary structs into strings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-# 0.3.0.a1
-
-* Changed: `DecomposeCount` to never return 0 (an empty aggregate cannot be decomposed using structured bindings).
-
 # 0.2.30
 
 * Added class `Stringify` which can turn arbitrary structs into strings.
@@ -16,6 +12,8 @@
 * Added static constructors `Extend::ConstructFromTuple` and `Extend::ConstructFromArgs`.
 * Fixed a bug where Mope did not correctly enable and disable sections.
 * Added documentation and tests on how to use a mope's `--set` flag to enable/disable sections.
+* Fixed a bug with `DecomposeCount`. It must never return 0 (an empty aggregate cannot be decomposed using structured bindings).
+* Changed Clang to use more reliable overload sets (they cannot be used in GCC).
 
 # 0.2.29
 

--- a/mbo/mope/mope_main.cc
+++ b/mbo/mope/mope_main.cc
@@ -27,6 +27,7 @@
 #include "absl/log/globals.h"
 #include "absl/log/initialize.h"
 #include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/str_split.h"
 #include "mbo/file/artefact.h"
 #include "mbo/file/file.h"

--- a/mbo/types/extend_test.cc
+++ b/mbo/types/extend_test.cc
@@ -165,21 +165,19 @@ struct Person : Extend<Person> {
 
 class ExtendTest : public ::testing::Test {};
 
-#if !defined(__clang__)
 TEST_F(ExtendTest, TestDecomposeInfo) {
   using ::mbo::types::types_internal::DecomposeInfo;
-# define DEBUG_AND_TEST(Type, kExpected)                            \
-   ABSL_LOG(INFO) << #Type << ": " << DecomposeInfo<Type>::Debug(); \
-   EXPECT_THAT(DecomposeInfo<Type>::kDecomposeCount, kExpected)
+#define DEBUG_AND_TEST(Type, kExpected)                            \
+  ABSL_LOG(INFO) << #Type << ": " << DecomposeInfo<Type>::Debug(); \
+  EXPECT_THAT(DecomposeInfo<Type>::kDecomposeCount, kExpected)
 
   DEBUG_AND_TEST(Extend4, 4);
   DEBUG_AND_TEST(SimpleName, 2);
   DEBUG_AND_TEST(SimplePerson, 2);
   DEBUG_AND_TEST(Name, 2);
   DEBUG_AND_TEST(Person, 2);
-# undef DEBUG_AND_TEST
+#undef DEBUG_AND_TEST
 }
-#endif
 
 #if defined(__clang__)
 static_assert(kStructNameSupport);
@@ -783,11 +781,9 @@ static_assert(IsDecomposable<UseCrtp1>);
 static_assert(IsDecomposable<UseCrtp2>);
 static_assert(IsDecomposable<UseBoth>);
 
-#ifndef __clang__
 TEST_F(ExtendTest, NoDefaultConstructor) {
   ABSL_LOG(ERROR) << types_internal::DecomposeInfo<UseBoth>::Debug();
 }
-#endif
 
 struct AbslFlatHashMapUser : Extend<AbslFlatHashMapUser> {
   using MboTypesStringifyDoNotPrintFieldNames = void;

--- a/mbo/types/extend_test.cc
+++ b/mbo/types/extend_test.cc
@@ -380,6 +380,7 @@ struct WithUnion : mbo::types::Extend<WithUnion> {
 static_assert(!HasUnionMember<int>);
 
 // NOLINTBEGIN(*-magic-numbers)
+#ifndef __clang__
 static_assert(types_internal::AggregateInitializeTest<WithUnion>::IsInitializable<0>::value);
 static_assert(types_internal::AggregateInitializeTest<WithUnion>::IsInitializable<1>::value);
 static_assert(types_internal::AggregateInitializeTest<WithUnion>::IsInitializable<2>::value);
@@ -393,6 +394,7 @@ static_assert(types_internal::DecomposeInfo<WithUnion>::kFieldCount == 4);
 static_assert(types_internal::DecomposeInfo<WithUnion>::kCountBases == 0);
 static_assert(types_internal::DecomposeInfo<WithUnion>::kCountEmptyBases == 1);
 static_assert(types_internal::DecomposeCountImpl<WithUnion>::value == 3);
+#endif
 // NOLINTEND(*-magic-numbers)
 
 static_assert(HasUnionMember<WithUnion>);
@@ -709,6 +711,7 @@ struct UseCrtp1 : Extend<UseCrtp1> {
   Crtp1 crtp;
 };
 
+#ifndef __clang__
 // NOLINTBEGIN(*-magic-numbers)
 static_assert(!types_internal::AggregateInitializeTest<UseCrtp1>::IsInitializable<0>::value);
 static_assert(!types_internal::AggregateInitializeTest<UseCrtp1>::IsInitializable<1>::value);
@@ -733,6 +736,7 @@ static_assert(types_internal::DecomposeInfo<UseCrtp1>::kOnlyEmptyBases);
 static_assert(!types_internal::DecomposeInfo<UseCrtp1>::kOneNonEmptyBasePlusFields);
 
 static_assert(types_internal::DecomposeInfo<UseCrtp1>::kDecomposeCount == 1);
+#endif
 
 struct UseCrtp2 : Extend<UseCrtp2> {
   Crtp2 crtp;
@@ -745,6 +749,7 @@ struct UseBoth : Extend<UseBoth> {
 
 static_assert(IsAggregate<UseBoth>);
 
+#ifndef __clang__
 // NOLINTBEGIN(*-magic-numbers)
 static_assert(!types_internal::AggregateInitializeTest<UseBoth>::IsInitializable<0>::value);
 static_assert(!types_internal::AggregateInitializeTest<UseBoth>::IsInitializable<1>::value);
@@ -770,6 +775,7 @@ static_assert(types_internal::DecomposeInfo<UseBoth>::kOnlyEmptyBases);
 static_assert(!types_internal::DecomposeInfo<UseBoth>::kOneNonEmptyBasePlusFields);
 
 static_assert(types_internal::DecomposeInfo<UseBoth>::kDecomposeCount == 2);
+#endif
 
 static_assert(!IsDecomposable<Crtp1>);
 static_assert(!IsDecomposable<Crtp2>);
@@ -777,9 +783,11 @@ static_assert(IsDecomposable<UseCrtp1>);
 static_assert(IsDecomposable<UseCrtp2>);
 static_assert(IsDecomposable<UseBoth>);
 
+#ifndef __clang__
 TEST_F(ExtendTest, NoDefaultConstructor) {
   ABSL_LOG(ERROR) << types_internal::DecomposeInfo<UseBoth>::Debug();
 }
+#endif
 
 struct AbslFlatHashMapUser : Extend<AbslFlatHashMapUser> {
   using MboTypesStringifyDoNotPrintFieldNames = void;

--- a/mbo/types/extend_test.cc
+++ b/mbo/types/extend_test.cc
@@ -952,6 +952,14 @@ TEST_F(ExtendTest, MoveOnlyFromTuple) {
   }
 }
 
+TEST_F(ExtendTest, EmptyExtend) {
+  struct Empty : Extend<Empty> {};
+
+  ASSERT_TRUE((std::same_as<decltype(StructToTuple(Empty{})), std::tuple<>>));
+  ASSERT_TRUE(CanCreateTuple<Empty>);
+  ASSERT_FALSE(CanCreateTuple<Empty&>);
+}
+
 }  // namespace
 }  // namespace mbo::types
 

--- a/mbo/types/extend_test.cc
+++ b/mbo/types/extend_test.cc
@@ -378,7 +378,7 @@ struct WithUnion : mbo::types::Extend<WithUnion> {
 static_assert(!HasUnionMember<int>);
 
 // NOLINTBEGIN(*-magic-numbers)
-#ifndef __clang__
+#ifndef MBO_TYPES_DECOMPOSE_COUNT_USE_OVERLOADSET
 static_assert(types_internal::AggregateInitializeTest<WithUnion>::IsInitializable<0>::value);
 static_assert(types_internal::AggregateInitializeTest<WithUnion>::IsInitializable<1>::value);
 static_assert(types_internal::AggregateInitializeTest<WithUnion>::IsInitializable<2>::value);
@@ -392,7 +392,7 @@ static_assert(types_internal::DecomposeInfo<WithUnion>::kFieldCount == 4);
 static_assert(types_internal::DecomposeInfo<WithUnion>::kCountBases == 0);
 static_assert(types_internal::DecomposeInfo<WithUnion>::kCountEmptyBases == 1);
 static_assert(types_internal::DecomposeCountImpl<WithUnion>::value == 3);
-#endif
+#endif  // MBO_TYPES_DECOMPOSE_COUNT_USE_OVERLOADSET
 // NOLINTEND(*-magic-numbers)
 
 static_assert(HasUnionMember<WithUnion>);
@@ -709,7 +709,7 @@ struct UseCrtp1 : Extend<UseCrtp1> {
   Crtp1 crtp;
 };
 
-#ifndef __clang__
+#ifndef MBO_TYPES_DECOMPOSE_COUNT_USE_OVERLOADSET
 // NOLINTBEGIN(*-magic-numbers)
 static_assert(!types_internal::AggregateInitializeTest<UseCrtp1>::IsInitializable<0>::value);
 static_assert(!types_internal::AggregateInitializeTest<UseCrtp1>::IsInitializable<1>::value);
@@ -734,7 +734,7 @@ static_assert(types_internal::DecomposeInfo<UseCrtp1>::kOnlyEmptyBases);
 static_assert(!types_internal::DecomposeInfo<UseCrtp1>::kOneNonEmptyBasePlusFields);
 
 static_assert(types_internal::DecomposeInfo<UseCrtp1>::kDecomposeCount == 1);
-#endif
+#endif  // MBO_TYPES_DECOMPOSE_COUNT_USE_OVERLOADSET
 
 struct UseCrtp2 : Extend<UseCrtp2> {
   Crtp2 crtp;
@@ -747,7 +747,7 @@ struct UseBoth : Extend<UseBoth> {
 
 static_assert(IsAggregate<UseBoth>);
 
-#ifndef __clang__
+#ifndef MBO_TYPES_DECOMPOSE_COUNT_USE_OVERLOADSET
 // NOLINTBEGIN(*-magic-numbers)
 static_assert(!types_internal::AggregateInitializeTest<UseBoth>::IsInitializable<0>::value);
 static_assert(!types_internal::AggregateInitializeTest<UseBoth>::IsInitializable<1>::value);
@@ -773,7 +773,7 @@ static_assert(types_internal::DecomposeInfo<UseBoth>::kOnlyEmptyBases);
 static_assert(!types_internal::DecomposeInfo<UseBoth>::kOneNonEmptyBasePlusFields);
 
 static_assert(types_internal::DecomposeInfo<UseBoth>::kDecomposeCount == 2);
-#endif
+#endif  // MBO_TYPES_DECOMPOSE_COUNT_USE_OVERLOADSET
 
 static_assert(!IsDecomposable<Crtp1>);
 static_assert(!IsDecomposable<Crtp2>);

--- a/mbo/types/internal/BUILD.bazel
+++ b/mbo/types/internal/BUILD.bazel
@@ -90,7 +90,11 @@ mope_test(
     srcs = ["decompose_count.h.mope"],
     outs = ["decompose_count.h"],
     args = [
-      #"--set=clang_pre_17=x",
+        # For Clang we can enable OverloadSets. For GCC we have to disable it.
+        # We can identifify the compiler with a `#if...` but decide here whether
+        # we want to add the Clang specific part at all.
+        # See details in mbo/types/internal/decompose_count.h.mope
+        "--set=use_clang=enable",
     ],
     clang_format = True,
 )

--- a/mbo/types/internal/BUILD.bazel
+++ b/mbo/types/internal/BUILD.bazel
@@ -94,7 +94,7 @@ mope_test(
         # We can identifify the compiler with a `#if...` but decide here whether
         # we want to add the Clang specific part at all.
         # See details in mbo/types/internal/decompose_count.h.mope
-        "--set=use_clang=enable",
+        "--set=use_clang:enabled,:max_fields=40"
     ],
     clang_format = True,
 )

--- a/mbo/types/internal/decompose_count.h
+++ b/mbo/types/internal/decompose_count.h
@@ -40,7 +40,7 @@ concept IsAggregate = std::is_aggregate_v<std::remove_cvref_t<T>>;
 
 struct NotDecomposableImpl : std::integral_constant<std::size_t, std::numeric_limits<std::size_t>::max()> {};
 
-constexpr std::size_t kDecomposeCountUndef = NotDecomposableImpl::value;
+constexpr std::size_t kNotDecomposableValue = NotDecomposableImpl::value;
 
 inline constexpr std::size_t kMaxSupportedFieldCount = 50;
 
@@ -90,6 +90,9 @@ template<typename T>
 concept AggregateHasNonEmptyBase = AggregateHasNonEmptyBaseImpl<T>::value;
 
 #if defined(__clang__)
+
+# define MBO_TYPES_DECOMPOSE_COUNT_USE_OVERLOADSET 1
+
 // ----------------------------------------------------
 // This version implements the somewhat known Overloadset solution with additioanl identification of
 // non admissible types. This works well for Clang compilers but fails to compile (even) in GCC 14.
@@ -311,7 +314,7 @@ auto DecomposeCountFunc(T&& v) {
   } else {
     // Note that we could enable `std::is_aggregate_v<T> && std::is_empty_v<T>` to return 0 for
     // empty, but we are not returning field counts here. We are retuning decompose counts here.
-    return std::integral_constant<std::size_t, kDecomposeCountUndef>{};
+    return std::integral_constant<std::size_t, kNotDecomposableValue>{};
   }
 }
 
@@ -319,10 +322,10 @@ template<typename T>
 struct DecomposeCountImpl : decltype(DecomposeCountFunc(std::declval<T>())) {};
 
 template<>
-struct DecomposeCountImpl<void> : std::integral_constant<std::size_t, kDecomposeCountUndef> {};
+struct DecomposeCountImpl<void> : std::integral_constant<std::size_t, kNotDecomposableValue> {};
 
 template<typename T>
-concept DecomposeCondition = (DecomposeCountImpl<T>::value != kDecomposeCountUndef);
+concept DecomposeCondition = (DecomposeCountImpl<T>::value != kNotDecomposableValue);
 
 // Put all into once struct.
 template<typename T>
@@ -332,7 +335,7 @@ struct DecomposeInfo final {
   static constexpr bool kIsEmpty = std::is_empty_v<Type>;
   static constexpr std::size_t kFieldCount = std::is_empty_v<Type> ? 0 : DecomposeCountImpl<Type>::value;
   static constexpr std::size_t kDecomposeCount = DecomposeCountImpl<Type>::value;
-  static constexpr bool kDecomposable = (kIsAggregate && !kIsEmpty) && (kDecomposeCount != kDecomposeCountUndef);
+  static constexpr bool kDecomposable = (kIsAggregate && !kIsEmpty) && (kDecomposeCount != kNotDecomposableValue);
 
   static std::string Debug(std::string_view separator = ", ") {
     std::string str;

--- a/mbo/types/internal/decompose_count.h
+++ b/mbo/types/internal/decompose_count.h
@@ -92,7 +92,7 @@ concept AggregateHasNonEmptyBase = AggregateHasNonEmptyBaseImpl<T>::value;
 // This version implements the somewhat known Overloadset solution with additioanl identification of
 // non admissible types. This works well for Clang compilers but fails to compile (even) in GCC 14.
 // For the GCC issue refer to: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=92402
-// For the basic mechanism see: https://godbolt.org/z/j4bosjjWY
+// For the basic mechanism see: https://godbolt.org/z/Ejada5YEE
 
 template<typename... Ts>
 struct OverloadSet : Ts... {

--- a/mbo/types/internal/decompose_count.h
+++ b/mbo/types/internal/decompose_count.h
@@ -85,6 +85,247 @@ struct AggregateHasNonEmptyBaseImpl : AggregateHasNonEmptyBaseRaw<std::remove_cv
 template<typename T>
 concept AggregateHasNonEmptyBase = AggregateHasNonEmptyBaseImpl<T>::value;
 
+#if defined(__clang__)
+// ----------------------------------------------------
+// This version implements the somewhat known Overloadset solution with additioanl identification of
+// non admissible types. This works well for Clang compilers but fails to compile (even) in GCC 14.
+// For the GCC issue refer to: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=92402
+// For the basic mechanism see: https://godbolt.org/z/j4bosjjWY
+
+template<typename... Ts>
+struct OverloadSet : Ts... {
+  explicit OverloadSet(Ts&&... v) : Ts(std::move(v))... {}
+
+  using Ts::operator()...;
+  // Unfortunately we cannot use an alternative fallback using `...` arg here:
+  // auto operator()(...) const { return std::integral_constant<std::size_t, 0>{}; };
+  // but in the below we can use further `constexpr if ...`.
+};
+
+template<typename... Ts>
+auto MakeOverloadedSet(Ts&&... v) {
+  return OverloadSet<Ts...>(std::forward<Ts>(v)...);
+}
+
+constexpr std::size_t kDecomposeCountUndef = std::numeric_limits<std::size_t>::max();
+
+template<typename T>
+auto DecomposeCountFunc(T&& v) {
+  auto fn1 = [](auto&& v) -> decltype(({
+    auto&& [a1] = std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 1>{};
+  })) { return {}; };
+  auto fn2 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2] = std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 2>{};
+  })) { return {}; };
+  auto fn3 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3] = std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 3>{};
+  })) { return {}; };
+  auto fn4 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4] = std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 4>{};
+  })) { return {}; };
+  auto fn5 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4, a5] = std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 5>{};
+  })) { return {}; };
+  auto fn6 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4, a5, a6] = std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 6>{};
+  })) { return {}; };
+  auto fn7 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4, a5, a6, a7] = std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 7>{};
+  })) { return {}; };
+  auto fn8 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4, a5, a6, a7, a8] = std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 8>{};
+  })) { return {}; };
+  auto fn9 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4, a5, a6, a7, a8, a9] = std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 9>{};
+  })) { return {}; };
+  auto fn10 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10] = std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 10>{};
+  })) { return {}; };
+  auto fn11 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11] = std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 11>{};
+  })) { return {}; };
+  auto fn12 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12] = std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 12>{};
+  })) { return {}; };
+  auto fn13 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13] = std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 13>{};
+  })) { return {}; };
+  auto fn14 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14] = std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 14>{};
+  })) { return {}; };
+  auto fn15 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15] = std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 15>{};
+  })) { return {}; };
+  auto fn16 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16] = std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 16>{};
+  })) { return {}; };
+  auto fn17 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17] = std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 17>{};
+  })) { return {}; };
+  auto fn18 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18] =
+        std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 18>{};
+  })) { return {}; };
+  auto fn19 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19] =
+        std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 19>{};
+  })) { return {}; };
+  auto fn20 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20] =
+        std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 20>{};
+  })) { return {}; };
+  auto fn21 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21] =
+        std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 21>{};
+  })) { return {}; };
+  auto fn22 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22] =
+        std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 22>{};
+  })) { return {}; };
+  auto fn23 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23] =
+        std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 23>{};
+  })) { return {}; };
+  auto fn24 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24] =
+        std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 24>{};
+  })) { return {}; };
+  auto fn25 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25] =
+        std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 25>{};
+  })) { return {}; };
+  auto fn26 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26] =
+        std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 26>{};
+  })) { return {}; };
+  auto fn27 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27] =
+        std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 27>{};
+  })) { return {}; };
+  auto fn28 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28] =
+        std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 28>{};
+  })) { return {}; };
+  auto fn29 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29] =
+        std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 29>{};
+  })) { return {}; };
+  auto fn30 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30] =
+        std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 30>{};
+  })) { return {}; };
+  auto fn31 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31] =
+        std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 31>{};
+  })) { return {}; };
+  auto fn32 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32] =
+        std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 32>{};
+  })) { return {}; };
+  auto fn33 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33] =
+        std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 33>{};
+  })) { return {}; };
+  auto fn34 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34] =
+        std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 34>{};
+  })) { return {}; };
+  auto fn35 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35] =
+        std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 35>{};
+  })) { return {}; };
+  auto fn36 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36] =
+        std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 36>{};
+  })) { return {}; };
+  auto fn37 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37] =
+        std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 37>{};
+  })) { return {}; };
+  auto fn38 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38] =
+        std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 38>{};
+  })) { return {}; };
+  auto fn39 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39] =
+        std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 39>{};
+  })) { return {}; };
+  auto fn40 = [](auto&& v) -> decltype(({
+    auto&& [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40] =
+        std::forward<decltype(v)>(v);
+    std::integral_constant<std::size_t, 40>{};
+  })) { return {}; };
+  auto overload_set = MakeOverloadedSet(
+      std::move(fn1), std::move(fn2), std::move(fn3), std::move(fn4), std::move(fn5), std::move(fn6), std::move(fn7),
+      std::move(fn8), std::move(fn9), std::move(fn10), std::move(fn11), std::move(fn12), std::move(fn13),
+      std::move(fn14), std::move(fn15), std::move(fn16), std::move(fn17), std::move(fn18), std::move(fn19),
+      std::move(fn20), std::move(fn21), std::move(fn22), std::move(fn23), std::move(fn24), std::move(fn25),
+      std::move(fn26), std::move(fn27), std::move(fn28), std::move(fn29), std::move(fn30), std::move(fn31),
+      std::move(fn32), std::move(fn33), std::move(fn34), std::move(fn35), std::move(fn36), std::move(fn37),
+      std::move(fn38), std::move(fn39), std::move(fn40));
+  if constexpr (requires {
+                  { overload_set(std::declval<T>()) };
+                }) {
+    return overload_set(std::forward<T>(v));
+  } else if constexpr (std::is_aggregate_v<T>) {
+    return std::integral_constant<std::size_t, 0>{};
+  } else {
+    return std::integral_constant<std::size_t, std::numeric_limits<std::size_t>::max()>{};
+  }
+}
+
+template<typename T>
+using DecomposeCountT = decltype(DecomposeCountFunc(std::declval<T>()));
+
+template<typename T>
+constexpr std::size_t DecomposeCountV = DecomposeCountT<T>::value;
+
+template<typename T>
+concept DecomposeCondition = (DecomposeCountV<T> != kDecomposeCountUndef);
+
+template<typename T>
+struct DecomposeCountImpl : DecomposeCountT<T> {};
+
+#else  // defined(__clang__)
 // ----------------------------------------------------
 
 // From
@@ -374,15 +615,15 @@ struct DecomposeInfo final {
   static std::string Debug(std::string_view separator = ", ") {  // NOLINT(readability-function-cognitive-complexity)
     std::string str;
     std::string_view sep;
-#define DEBUG_ADD(f)                                                                             \
-  str += std::string(sep) + #f + ": "                                                            \
-         + (std::same_as<std::remove_cvref_t<decltype(DecomposeInfo<T>::f)>, bool>               \
-                ? std::string(DecomposeInfo<T>::f ? "Yes" : "No")                                \
-                : (std::same_as<std::remove_cvref_t<decltype(DecomposeInfo<T>::f)>, std::size_t> \
-                           && DecomposeInfo<T>::f == NotDecomposableImpl::value                  \
-                       ? std::string("N/A")                                                      \
-                       : std::to_string(DecomposeInfo<T>::f)));                                  \
-  sep = separator
+# define DEBUG_ADD(f)                                                                             \
+   str += std::string(sep) + #f + ": "                                                            \
+          + (std::same_as<std::remove_cvref_t<decltype(DecomposeInfo<T>::f)>, bool>               \
+                 ? std::string(DecomposeInfo<T>::f ? "Yes" : "No")                                \
+                 : (std::same_as<std::remove_cvref_t<decltype(DecomposeInfo<T>::f)>, std::size_t> \
+                            && DecomposeInfo<T>::f == NotDecomposableImpl::value                  \
+                        ? std::string("N/A")                                                      \
+                        : std::to_string(DecomposeInfo<T>::f)));                                  \
+   sep = separator
     DEBUG_ADD(kIsAggregate);
     DEBUG_ADD(kIsEmpty);
     DEBUG_ADD(kInitializerCount);
@@ -395,7 +636,7 @@ struct DecomposeInfo final {
     DEBUG_ADD(kCountBases);
     DEBUG_ADD(kCountEmptyBases);
     DEBUG_ADD(kDecomposeCount);
-#undef DEBUG_ADD
+# undef DEBUG_ADD
     return str;
   }
 };
@@ -419,15 +660,15 @@ struct DecomposeInfo<T, false> final {
   static std::string Debug(std::string_view separator = ", ") {  // NOLINT(readability-function-cognitive-complexity)
     std::string str;
     std::string_view sep;
-#define DEBUG_ADD(f)                                                                             \
-  str += std::string(sep) + #f + ": "                                                            \
-         + (std::same_as<std::remove_cvref_t<decltype(DecomposeInfo<T>::f)>, bool>               \
-                ? std::string(DecomposeInfo<T>::f ? "Yes" : "No")                                \
-                : (std::same_as<std::remove_cvref_t<decltype(DecomposeInfo<T>::f)>, std::size_t> \
-                           && DecomposeInfo<T>::f == NotDecomposableImpl::value                  \
-                       ? std::string("N/A")                                                      \
-                       : std::to_string(DecomposeInfo<T>::f)));                                  \
-  sep = separator
+# define DEBUG_ADD(f)                                                                             \
+   str += std::string(sep) + #f + ": "                                                            \
+          + (std::same_as<std::remove_cvref_t<decltype(DecomposeInfo<T>::f)>, bool>               \
+                 ? std::string(DecomposeInfo<T>::f ? "Yes" : "No")                                \
+                 : (std::same_as<std::remove_cvref_t<decltype(DecomposeInfo<T>::f)>, std::size_t> \
+                            && DecomposeInfo<T>::f == NotDecomposableImpl::value                  \
+                        ? std::string("N/A")                                                      \
+                        : std::to_string(DecomposeInfo<T>::f)));                                  \
+   sep = separator
     DEBUG_ADD(kIsAggregate);
     DEBUG_ADD(kIsEmpty);
     // DEBUG_ADD(kInitializerCount);
@@ -440,7 +681,7 @@ struct DecomposeInfo<T, false> final {
     // DEBUG_ADD(kCountBases);
     // DEBUG_ADD(kCountEmptyBases);
     DEBUG_ADD(kDecomposeCount);
-#undef DEBUG_ADD
+# undef DEBUG_ADD
     return str;
   }
 };
@@ -453,6 +694,7 @@ concept DecomposeCondition = DecomposeInfo<T>::kDecomposable;
 template<typename T>
 struct DecomposeCountImpl : std::integral_constant<std::size_t, DecomposeInfo<T>::kDecomposeCount> {};
 
+#endif  // defined(__clang__)
 // ----------------------------------------------------
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)

--- a/mbo/types/internal/decompose_count.h
+++ b/mbo/types/internal/decompose_count.h
@@ -16,6 +16,8 @@
 #ifndef MBO_TYPES_INTERNAL_DECOMPOSE_COUNT_H_
 #define MBO_TYPES_INTERNAL_DECOMPOSE_COUNT_H_
 
+// Max fields: 40
+
 // IWYU pragma private, include "mbo/types/traits.h"
 
 #include <limits>
@@ -362,6 +364,8 @@ struct DecomposeInfo final {
 //
 // Unlike Clang 16, GCC does not understand `decltype` of a lmbda performing
 // structured-bindings, e.g.: `decltype([]() { const auto& [a0] = T(); }`.
+// GCC further has a bug with primary lamda expressions in a decltype:
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=92402
 //
 // Thus GCC needs to count initializers and fields and base classes.
 // The core idea of identifying the actual number of values a struct

--- a/mbo/types/internal/decompose_count.h.mope
+++ b/mbo/types/internal/decompose_count.h.mope
@@ -40,7 +40,7 @@ concept IsAggregate = std::is_aggregate_v<std::remove_cvref_t<T>>;
 
 struct NotDecomposableImpl : std::integral_constant<std::size_t, std::numeric_limits<std::size_t>::max()> {};
 
-constexpr std::size_t kDecomposeCountUndef = NotDecomposableImpl::value;
+constexpr std::size_t kNotDecomposableValue = NotDecomposableImpl::value;
 
 inline constexpr std::size_t kMaxSupportedFieldCount = 50;
 
@@ -91,6 +91,9 @@ concept AggregateHasNonEmptyBase = AggregateHasNonEmptyBaseImpl<T>::value;
 
 {{#use_clang}}
 #if defined(__clang__)
+
+#define MBO_TYPES_DECOMPOSE_COUNT_USE_OVERLOADSET 1
+
 // ----------------------------------------------------
 // This version implements the somewhat known Overloadset solution with additioanl identification of
 // non admissible types. This works well for Clang compilers but fails to compile (even) in GCC 14.
@@ -122,7 +125,7 @@ auto DecomposeCountFunc(T&& v) {
     } else {
         // Note that we could enable `std::is_aggregate_v<T> && std::is_empty_v<T>` to return 0 for
         // empty, but we are not returning field counts here. We are retuning decompose counts here.
-        return std::integral_constant<std::size_t, kDecomposeCountUndef>{};
+        return std::integral_constant<std::size_t, kNotDecomposableValue>{};
     }
 };
 
@@ -130,10 +133,10 @@ template<typename T>
 struct DecomposeCountImpl: decltype(DecomposeCountFunc(std::declval<T>())) {};
 
 template<>
-struct DecomposeCountImpl<void>: std::integral_constant<std::size_t, kDecomposeCountUndef> {};
+struct DecomposeCountImpl<void>: std::integral_constant<std::size_t, kNotDecomposableValue> {};
 
 template<typename T>
-concept DecomposeCondition = (DecomposeCountImpl<T>::value != kDecomposeCountUndef);
+concept DecomposeCondition = (DecomposeCountImpl<T>::value != kNotDecomposableValue);
 
 // Put all into once struct.
 template<typename T>
@@ -143,7 +146,7 @@ struct DecomposeInfo final {
   static constexpr bool kIsEmpty = std::is_empty_v<Type>;
   static constexpr std::size_t kFieldCount = std::is_empty_v<Type> ? 0 : DecomposeCountImpl<Type>::value;
   static constexpr std::size_t kDecomposeCount = DecomposeCountImpl<Type>::value;
-  static constexpr bool kDecomposable = (kIsAggregate && !kIsEmpty) && (kDecomposeCount != kDecomposeCountUndef);
+  static constexpr bool kDecomposable = (kIsAggregate && !kIsEmpty) && (kDecomposeCount != kNotDecomposableValue);
 
   static std::string Debug(std::string_view separator = ", ") {
     std::string str;

--- a/mbo/types/internal/decompose_count.h.mope
+++ b/mbo/types/internal/decompose_count.h.mope
@@ -39,6 +39,8 @@ concept IsAggregate = std::is_aggregate_v<std::remove_cvref_t<T>>;
 
 struct NotDecomposableImpl : std::integral_constant<std::size_t, std::numeric_limits<std::size_t>::max()> {};
 
+constexpr std::size_t kDecomposeCountUndef = NotDecomposableImpl::value;
+
 inline constexpr std::size_t kMaxSupportedFieldCount = 50;
 
 template<typename T, std::size_t MaxArgs, typename... Args>
@@ -108,8 +110,6 @@ auto MakeOverloadedSet(Ts&&... v) {
     return OverloadSet<Ts...>(std::forward<Ts>(v)...);
 }
 
-constexpr std::size_t kDecomposeCountUndef = std::numeric_limits<std::size_t>::max();
-
 template <typename T>
 auto DecomposeCountFunc(T&& v) {
 {{#num_fields=1;max_fields}}
@@ -118,24 +118,27 @@ auto DecomposeCountFunc(T&& v) {
     auto overload_set = MakeOverloadedSet({{#field=1;max_fields;;', '}}std::move(fn{{field}}){{/field}});
     if constexpr (requires{ {overload_set(std::declval<T>())};}) {
         return overload_set(std::forward<T>(v));
-    } else if constexpr (std::is_aggregate_v<T>) {
+    } else if constexpr (std::is_aggregate_v<T> && std::is_empty_v<T>) {
         return std::integral_constant<std::size_t, 0>{};
     } else {
-        return std::integral_constant<std::size_t, std::numeric_limits<std::size_t>::max()>{};
+        return std::integral_constant<std::size_t, kDecomposeCountUndef>{};
     }
 };
 
 template<typename T>
-using DecomposeCountT = decltype(DecomposeCountFunc(std::declval<T>()));
+struct DecomposeCountImpl: decltype(DecomposeCountFunc(std::declval<T>())) {};
+
+template<>
+struct DecomposeCountImpl<void>: std::integral_constant<std::size_t, kDecomposeCountUndef> {};
+
+//template<typename T>
+//constexpr std::size_t DecomposeCountV = DecomposeCountImpl<T>::value;
 
 template<typename T>
-constexpr std::size_t DecomposeCountV = DecomposeCountT<T>::value;
+concept DecomposeCondition = (DecomposeCountImpl<T>::value != kDecomposeCountUndef);
 
-template<typename T>
-concept DecomposeCondition = (DecomposeCountV<T> != kDecomposeCountUndef);
-
-template<typename T>
-struct DecomposeCountImpl : DecomposeCountT<T> {};
+//template<typename T>
+//struct DecomposeCountImpl : DecomposeCountT<T> {};
 
 #else  // defined(__clang__)
 {{/use_clang}}

--- a/mbo/types/internal/decompose_count.h.mope
+++ b/mbo/types/internal/decompose_count.h.mope
@@ -12,10 +12,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-{{max_fields=40}}
 
 #ifndef MBO_TYPES_INTERNAL_DECOMPOSE_COUNT_H_
 #define MBO_TYPES_INTERNAL_DECOMPOSE_COUNT_H_
+
+// Max fields: {{max_fields}}
 
 // IWYU pragma private, include "mbo/types/traits.h"
 
@@ -175,6 +176,8 @@ struct DecomposeInfo final {
 //
 // Unlike Clang 16, GCC does not understand `decltype` of a lmbda performing
 // structured-bindings, e.g.: `decltype([]() { const auto& [a0] = T(); }`.
+// GCC further has a bug with primary lamda expressions in a decltype:
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=92402
 //
 // Thus GCC needs to count initializers and fields and base classes.
 // The core idea of identifying the actual number of values a struct

--- a/mbo/types/internal/decompose_count.h.mope
+++ b/mbo/types/internal/decompose_count.h.mope
@@ -94,7 +94,7 @@ concept AggregateHasNonEmptyBase = AggregateHasNonEmptyBaseImpl<T>::value;
 // This version implements the somewhat known Overloadset solution with additioanl identification of
 // non admissible types. This works well for Clang compilers but fails to compile (even) in GCC 14.
 // For the GCC issue refer to: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=92402
-// For the basic mechanism see: https://godbolt.org/z/j4bosjjWY
+// For the basic mechanism see: https://godbolt.org/z/Ejada5YEE
 
 template<typename... Ts>
 struct OverloadSet : Ts... {

--- a/mbo/types/internal/decompose_count.h.mope
+++ b/mbo/types/internal/decompose_count.h.mope
@@ -118,9 +118,9 @@ auto DecomposeCountFunc(T&& v) {
     auto overload_set = MakeOverloadedSet({{#field=1;max_fields;;', '}}std::move(fn{{field}}){{/field}});
     if constexpr (requires{ {overload_set(std::declval<T>())};}) {
         return overload_set(std::forward<T>(v));
-    } else if constexpr (std::is_aggregate_v<T> && std::is_empty_v<T>) {
-        return std::integral_constant<std::size_t, 0>{};
     } else {
+        // Note that we could enable `std::is_aggregate_v<T> && std::is_empty_v<T>` to return 0 for
+        // empty, but we are not returning field counts here. We are retuning decompose counts here.
         return std::integral_constant<std::size_t, kDecomposeCountUndef>{};
     }
 };
@@ -131,14 +131,40 @@ struct DecomposeCountImpl: decltype(DecomposeCountFunc(std::declval<T>())) {};
 template<>
 struct DecomposeCountImpl<void>: std::integral_constant<std::size_t, kDecomposeCountUndef> {};
 
-//template<typename T>
-//constexpr std::size_t DecomposeCountV = DecomposeCountImpl<T>::value;
-
 template<typename T>
 concept DecomposeCondition = (DecomposeCountImpl<T>::value != kDecomposeCountUndef);
 
-//template<typename T>
-//struct DecomposeCountImpl : DecomposeCountT<T> {};
+// Put all into once struct.
+template<typename T>
+struct DecomposeInfo final {
+  using Type = std::remove_cvref_t<T>;
+  static constexpr bool kIsAggregate = std::is_aggregate_v<Type>;
+  static constexpr bool kIsEmpty = std::is_empty_v<Type>;
+  static constexpr std::size_t kFieldCount = std::is_empty_v<Type> ? 0 : DecomposeCountImpl<Type>::value;
+  static constexpr std::size_t kDecomposeCount = DecomposeCountImpl<Type>::value;
+  static constexpr bool kDecomposable = (kIsAggregate && !kIsEmpty) && (kDecomposeCount != kDecomposeCountUndef);
+
+  static std::string Debug(std::string_view separator = ", ") {
+    std::string str;
+    std::string_view sep;
+# define DEBUG_ADD(f)                                                                             \
+   str += std::string(sep) + #f + ": "                                                            \
+          + (std::same_as<std::remove_cvref_t<decltype(DecomposeInfo<T>::f)>, bool>               \
+                 ? std::string(DecomposeInfo<T>::f ? "Yes" : "No")                                \
+                 : (std::same_as<std::remove_cvref_t<decltype(DecomposeInfo<T>::f)>, std::size_t> \
+                            && DecomposeInfo<T>::f == NotDecomposableImpl::value                  \
+                        ? std::string("N/A")                                                      \
+                        : std::to_string(DecomposeInfo<T>::f)));                                  \
+   sep = separator
+    DEBUG_ADD(kIsAggregate);
+    DEBUG_ADD(kIsEmpty);
+    DEBUG_ADD(kFieldCount);
+    DEBUG_ADD(kDecomposable);
+    DEBUG_ADD(kDecomposeCount);
+# undef DEBUG_ADD
+    return str;
+  }
+};
 
 #else  // defined(__clang__)
 {{/use_clang}}
@@ -419,8 +445,8 @@ struct DecomposeInfo final {
   static constexpr std::size_t kCountEmptyBases = kBadFieldCount ? 0 : CountBases<Type, true>::value;
   static constexpr bool kOnlyEmptyBases = kCountBases <= kCountEmptyBases;
   static constexpr bool kDecomposable =
-      !kBadFieldCount && kIsAggregate
-      && (kIsEmpty || ((kOneNonEmptyBase || kOnlyEmptyBases) && !kOneNonEmptyBasePlusFields));
+      !kBadFieldCount && kIsAggregate && !kIsEmpty &&
+      ((kOneNonEmptyBase || kOnlyEmptyBases) && !kOneNonEmptyBasePlusFields);
   static constexpr std::size_t kDecomposeCount =  // First check whether T is composable
       kDecomposable
           ? (kCountBases + kCountEmptyBases == 0  // If it is, then check whether there are any bases.
@@ -470,7 +496,7 @@ struct DecomposeInfo<T, false> final {
   static constexpr std::size_t kCountBases = 0;
   static constexpr std::size_t kCountEmptyBases = 0;
   static constexpr bool kOnlyEmptyBases = true;
-  static constexpr bool kDecomposable = kIsAggregate || kIsEmpty;
+  static constexpr bool kDecomposable = kIsAggregate && !kIsEmpty;
   static constexpr std::size_t kDecomposeCount = kDecomposable ? 0 : NotDecomposableImpl::value;
 
   static std::string Debug(std::string_view separator = ", ") {  // NOLINT(readability-function-cognitive-complexity)
@@ -522,7 +548,8 @@ struct DecomposeHelper final {
 
   template<typename U>
   static constexpr auto ToTuple(U&& data) noexcept {
-    constexpr auto kNumFields = DecomposeCountImpl<U>::value;
+    constexpr bool kIsEmptyAggregate = std::is_aggregate_v<U> && std::is_empty_v<U>;
+    constexpr std::size_t kNumFields = kIsEmptyAggregate ? 0 : DecomposeCountImpl<U>::value;
     if constexpr (kNumFields == 0) {
       return std::make_tuple();
     {{#num_fields=1;max_fields}}
@@ -535,7 +562,8 @@ struct DecomposeHelper final {
 
   template<typename U>
   static constexpr auto ToTuple(U& data) noexcept {
-    constexpr auto kNumFields = DecomposeCountImpl<U>::value;
+    constexpr bool kIsEmptyAggregate = std::is_aggregate_v<U> && std::is_empty_v<U>;
+    constexpr std::size_t kNumFields = kIsEmptyAggregate ? 0 : DecomposeCountImpl<U>::value;
     if constexpr (kNumFields == 0) {
       return std::make_tuple();
     {{#num_fields=1;max_fields}}
@@ -548,7 +576,8 @@ struct DecomposeHelper final {
 
   template<typename U>
   static constexpr auto ToTuple(const U& data) noexcept {
-    constexpr auto kNumFields = DecomposeCountImpl<U>::value;
+    constexpr bool kIsEmptyAggregate = std::is_aggregate_v<U> && std::is_empty_v<U>;
+    constexpr std::size_t kNumFields = kIsEmptyAggregate ? 0 : DecomposeCountImpl<U>::value;
     if constexpr (kNumFields == 0) {
       return std::make_tuple();
     {{#num_fields=1;max_fields}}

--- a/mbo/types/internal/decompose_count.h.mope
+++ b/mbo/types/internal/decompose_count.h.mope
@@ -86,41 +86,59 @@ struct AggregateHasNonEmptyBaseImpl : AggregateHasNonEmptyBaseRaw<std::remove_cv
 template<typename T>
 concept AggregateHasNonEmptyBase = AggregateHasNonEmptyBaseImpl<T>::value;
 
-{{#clang_pre_17=}}
-#if defined(__clang__) && __clang_major__ < 17
+{{#use_clang}}
+#if defined(__clang__)
 // ----------------------------------------------------
+// This version implements the somewhat known Overloadset solution with additioanl identification of
+// non admissible types. This works well for Clang compilers but fails to compile (even) in GCC 14.
+// For the GCC issue refer to: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=92402
+// For the basic mechanism see: https://godbolt.org/z/j4bosjjWY
 
-template<typename T, size_t N, typename = void>
-struct DecomposeCount final : std::false_type {};
+template<typename... Ts>
+struct OverloadSet : Ts... {
+    explicit OverloadSet(Ts&&... v) : Ts(std::move(v))... {}
+    using Ts::operator()...;
+    // Unfortunately we cannot use an alternative fallback using `...` arg here:
+    // auto operator()(...) const { return std::integral_constant<std::size_t, 0>{}; };
+    // but in the below we can use further `constexpr if ...`.
+};
 
+template<typename... Ts>
+auto MakeOverloadedSet(Ts&&... v) {
+    return OverloadSet<Ts...>(std::forward<Ts>(v)...);
+}
+
+constexpr std::size_t kDecomposeCountUndef = std::numeric_limits<std::size_t>::max();
+
+template <typename T>
+auto DecomposeCountFunc(T&& v) {
 {{#num_fields=1;max_fields}}
-template<typename T>
-struct DecomposeCount<T, {{num_fields}}, std::void_t<decltype([]() { const auto& [{{#field=1;num_fields;;', '}}a{{field}}{{/field}}] = T(); })>> final : std::true_type {};
-
+    auto fn{{num_fields}} = [](auto&& v) -> decltype(({auto&& [{{#field=1;num_fields;;', '}}a{{field}}{{/field}}] = std::forward<decltype(v)>(v); std::integral_constant<std::size_t, {{num_fields}}>{};})){ return {}; };
 {{/num_fields}}
-template<typename T>
-struct DecomposeCountnImpl
-    : std::integral_constant<
-          std::size_t,
-          CaseIndexImpl<
-              {{#num_fields=1;max_fields;;', '}}
-              DecomposeCount<T, {{num_fields}}>
-              {{/num_fields}}>::index> {};
+    auto overload_set = MakeOverloadedSet({{#field=1;max_fields;;', '}}std::move(fn{{field}}){{/field}});
+    if constexpr (requires{ {overload_set(std::declval<T>())};}) {
+        return overload_set(std::forward<T>(v));
+    } else if constexpr (std::is_aggregate_v<T>) {
+        return std::integral_constant<std::size_t, 0>{};
+    } else {
+        return std::integral_constant<std::size_t, std::numeric_limits<std::size_t>::max()>{};
+    }
+};
 
 template<typename T>
-concept DecomposeConditionRaw = std::is_aggregate_v<T> && (std::is_empty_v<T> || DecomposeCountnImpl<T>::value != 0);
+using DecomposeCountT = decltype(DecomposeCountFunc(std::declval<T>()));
 
 template<typename T>
-concept DecomposeCondition = DecomposeConditionRaw<std::remove_cvref_t<T>>;
+constexpr std::size_t DecomposeCountV = DecomposeCountT<T>::value;
 
 template<typename T>
-struct DecomposeCountraw : std::conditional_t<DecomposeCondition<T>, DecomposeCountnImpl<T>, NotDecomposableImpl> {};
+concept DecomposeCondition = (DecomposeCountV<T> != kDecomposeCountUndef);
 
 template<typename T>
-struct DecomposeCountImpl : DecomposeCountraw<std::remove_cvref_t<T>> {};
+struct DecomposeCountImpl : DecomposeCountT<T> {};
 
-#else  // defined(__clang__) && __clang_major__ < 17
-{{/clang_pre_17}}
+#else  // defined(__clang__)
+{{/use_clang}}
 // ----------------------------------------------------
 
 // From
@@ -489,9 +507,9 @@ concept DecomposeCondition = DecomposeInfo<T>::kDecomposable;
 template<typename T>
 struct DecomposeCountImpl : std::integral_constant<std::size_t, DecomposeInfo<T>::kDecomposeCount> {};
 
-{{#clang_pre_17=}}
-#endif  // defined(__clang__) && __clang_major__ < 17
-{{/clang_pre_17}}
+{{#use_clang}}
+#endif  // defined(__clang__)
+{{/use_clang}}
 // ----------------------------------------------------
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)

--- a/mbo/types/stringify_test.cc
+++ b/mbo/types/stringify_test.cc
@@ -92,11 +92,7 @@ struct StringifyTest : ::testing::Test {
 
   template<typename T>
   static std::string DecomposeInfo() {
-#ifdef __clang__
-    return "";
-#else
     return absl::StrCat("  DecomposeInfo: {\n", mbo::types::types_internal::DecomposeInfo<T>::Debug("\n    "), "  \n}");
-#endif
   }
 
   static Tester* tester;

--- a/mbo/types/stringify_test.cc
+++ b/mbo/types/stringify_test.cc
@@ -92,7 +92,11 @@ struct StringifyTest : ::testing::Test {
 
   template<typename T>
   static std::string DecomposeInfo() {
+#ifdef __clang__
+    return "";
+#else
     return absl::StrCat("  DecomposeInfo: {\n", mbo::types::types_internal::DecomposeInfo<T>::Debug("\n    "), "  \n}");
+#endif
   }
 
   static Tester* tester;

--- a/mbo/types/traits.h
+++ b/mbo/types/traits.h
@@ -36,6 +36,13 @@ concept IsAggregate = types_internal::IsAggregate<T>;
 // Requirements:
 // * T is an aggregate.
 // * T has no or only empty base classes.
+// * Has at least one field.
+//
+// This templated constant does not answer whether a tuple can be constructed,
+// because en empty tuple can be created for an empty aggregate, but the latter
+// cannot be decomposed with structured bindings.
+//
+// The empty aggregate to empty tuple can be checked with `CanCreateTuple`.
 template<typename T>
 inline constexpr std::size_t DecomposeCountV = types_internal::DecomposeCountImpl<T>::value;
 

--- a/mbo/types/traits_test.cc
+++ b/mbo/types/traits_test.cc
@@ -37,11 +37,7 @@ using namespace ::mbo::types::types_internal::test_types;
 struct TraitsTest : ::testing::Test {
   template<typename T>
   static std::string DecomposeInfo() {
-#ifdef __clang__
-    return "";
-#else
     return absl::StrCat("  DecomposeInfo: {\n", mbo::types::types_internal::DecomposeInfo<T>::Debug("\n    "), "  \n}");
-#endif
   }
 };
 
@@ -169,13 +165,13 @@ TEST_F(TraitsTest, StructWithStrings) {
   using namespace ::mbo::types::types_internal;  // NOLINT(*-build-using-namespace)
   using T = StructWithStrings;
   EXPECT_THAT(DecomposeCountV<T>, 5) << DecomposeInfo<T>();
-#ifndef __clang__
+#ifndef MBO_TYPES_DECOMPOSE_COUNT_USE_OVERLOADSET
   EXPECT_THAT((AggregateFieldInitializerCount<T, 0>::value), 2);
   EXPECT_THAT((AggregateFieldInitializerCount<T, 1>::value), 2);
   EXPECT_THAT((AggregateFieldInitializerCount<T, 2>::value), 2);
   EXPECT_THAT((DetectSpecial<AggregateFieldInitializerCount<T, 0>::value, 5 - 0>::value), 2);
   EXPECT_THAT((DetectSpecial<AggregateFieldInitializerCount<T, 1>::value, 5 - 1>::value), 2);
-#endif
+#endif  // MBO_TYPES_DECOMPOSE_COUNT_USE_OVERLOADSET
 }
 
 TYPED_TEST(GenTraitsTest, DecomposeCountV) {

--- a/mbo/types/traits_test.cc
+++ b/mbo/types/traits_test.cc
@@ -107,20 +107,20 @@ TEST_F(TraitsTest, DecomposeCountV) {
 
   ASSERT_THAT(IsAggregate<CtorDefault>, false);
   EXPECT_THAT(IsDecomposable<CtorDefault>, false);
-  EXPECT_THAT(DecomposeCountV<CtorDefault>, AnyOf(0, NotDecomposableV));  // TODO(helly25): Fix: NotDecomposableV);
+  EXPECT_THAT(DecomposeCountV<CtorDefault>, NotDecomposableV);
 
   ASSERT_THAT(IsAggregate<CtorUser>, false);
   EXPECT_THAT(IsDecomposable<CtorUser>, false);
-  EXPECT_THAT(DecomposeCountV<CtorUser>, AnyOf(0, NotDecomposableV));  // TODO(helly25): Fix: NotDecomposableV);
+  EXPECT_THAT(DecomposeCountV<CtorUser>, NotDecomposableV);
 
   ASSERT_THAT(types_internal::AggregateHasNonEmptyBase<CtorBase>, false);
   ASSERT_THAT(IsAggregate<CtorBase>, true);
   EXPECT_THAT(IsDecomposable<CtorBase>, false);
-  EXPECT_THAT(DecomposeCountV<CtorBase>, 0);
+  EXPECT_THAT(DecomposeCountV<CtorBase>, NotDecomposableV);
 
   ASSERT_THAT(types_internal::AggregateHasNonEmptyBase<CtorBase>, false);
   EXPECT_THAT(IsDecomposable<Empty>, false);
-  EXPECT_THAT(DecomposeCountV<Empty>, AnyOf(0, NotDecomposableV));
+  EXPECT_THAT(DecomposeCountV<Empty>, NotDecomposableV);
 
   ASSERT_THAT(types_internal::AggregateHasNonEmptyBase<CtorBase>, false);
   EXPECT_THAT(IsDecomposable<Base1>, true);
@@ -182,7 +182,8 @@ TYPED_TEST(GenTraitsTest, DecomposeCountV) {
   using Type = TypeParam;
   constexpr std::size_t kBase = TestFixture::kBaseFieldCount;
   constexpr std::size_t kDerived = TestFixture::kDerivedFieldCount;
-  EXPECT_THAT(DecomposeCountV<Type>, kBase && kDerived ? NotDecomposableV : kBase + kDerived);
+  EXPECT_THAT(
+      DecomposeCountV<Type>, (kBase && kDerived) || (kBase + kDerived == 0) ? NotDecomposableV : kBase + kDerived);
 }
 
 TEST_F(TraitsTest, IsBracesContructible) {

--- a/mbo/types/tuple_extras.h
+++ b/mbo/types/tuple_extras.h
@@ -39,7 +39,7 @@ concept CanCreateTuple = types_internal::DecomposeCondition<T> || (std::is_aggre
 //
 // The resulting tuple is made up of references!
 template<typename T>
-requires CanCreateTuple<T>
+requires CanCreateTuple<std::remove_cvref_t<T>>
 inline constexpr auto StructToTuple(T&& v) {
   return types_internal::DecomposeHelper::ToTuple(std::forward<T>(v));
 }

--- a/mbo/types/tuple_extras.h
+++ b/mbo/types/tuple_extras.h
@@ -29,8 +29,11 @@ namespace mbo::types {
 // There could be additional requirements:
 // - on `std::default_initializable<T>`: but that is technically not necessary.
 // - on `!types_internal::StructHasNonEmptyBase<T>`:
+//
+// Note that we also consider empty aggregates here as we are able to create an
+// empty tuple for them.
 template<typename T>
-concept CanCreateTuple = types_internal::DecomposeCondition<T>;
+concept CanCreateTuple = types_internal::DecomposeCondition<T> || (std::is_aggregate_v<T> && std::is_empty_v<T>);
 
 // Constructs a tuple from any eligible struct `T`
 //


### PR DESCRIPTION
Implement OverloadSet solution for Clang:

Unlike the original Clang <17 specific solution this one works one abstraction level higher where primary expression can be used in dcltype. That way we can use structured binadings as the actual test in an unevaluated context which is where clang 17 breaks the older implementaiton.

The new implementation still does not work for GCC. That compiler still after years has a parser bug with the necessary code.