### PR TITLE
Feat/improve_create_from_tuple_20241001

### DIFF
--- a/mbo/types/extend.h
+++ b/mbo/types/extend.h
@@ -18,9 +18,9 @@
 
 #include <type_traits>
 
-#include "mbo/types/extender.h"         // IWYU pragma: export
-#include "mbo/types/internal/extend.h"  // IWYU pragma: export
-#include "mbo/types/internal/extender.h"
+#include "mbo/types/extender.h"           // IWYU pragma: export
+#include "mbo/types/internal/extend.h"    // IWYU pragma: export
+#include "mbo/types/internal/extender.h"  // IWYU pragma: export
 
 namespace mbo::types {
 
@@ -42,11 +42,24 @@ namespace mbo::types {
 // std::cout << Name{.first = "First", .last = "Last"} << std::endl;
 // ```
 //
-// The struct `Name` automatically gains the ability to print, stream and
-// compare itself. In the above example `{"First", "Last"}` will be printed.
+// The struct `Name` automatically gains the ability to print, stream, compare
+// and hash itself. In the above example `{"First", "Last"}` will be printed.
 // If compiled on Clang it will print `{first: "First", last: "Last"}` (see
-// AbslStringify for restrictions). Also, the field names can be suppressed
-// by adding `using MboTypesStringifyDoNotPrintFieldNames = void;` to the type.
+// Stringify and AbslStringify for restrictions). Also, the field names can be
+// suppressed by adding `using MboTypesStringifyDoNotPrintFieldNames = void;`
+// to the type.
+//
+// Additional base operations:
+// * `static ConstructFromArgs`:  Construct the type from an argument list.
+// * `static ConstructFromTuple`: Construct the type from a tuple.
+//
+// Additional API extension points, common to all `Extend`ed types:
+// * type `MboTypesStringifyDoNotPrintFieldNames,
+// * function `MboTypesStringifyFieldNames`, and
+// * function `MboTypesStringifyOptions`.
+//
+// NOTE: The `Stringify` extension API point `MboTypesStringifySupport` is not
+// allowed here.
 //
 // NOTE: No member may be an anonymous union or struct.
 template<typename T, typename... Extender>

--- a/mbo/types/extend_test.cc
+++ b/mbo/types/extend_test.cc
@@ -895,7 +895,7 @@ TEST_F(ExtendTest, FromTupleToVariants) {
     EXPECT_THAT(val3.two, kStr2);
   }
   {
-    const auto val4 = TestStruct::ConstructFromTuple(std::make_tuple(kStr1, kInt2));
+    const auto val4 = TestStruct::ConstructFromArgs(kStr1, kInt2);
     static_assert((std::same_as<std::remove_cvref_t<decltype(val4)>, TestStruct>));
     EXPECT_THAT(val4.one, kStr1);
     EXPECT_THAT(val4.two, kInt2);

--- a/mbo/types/internal/BUILD.bazel
+++ b/mbo/types/internal/BUILD.bazel
@@ -25,6 +25,9 @@ cc_library(
 cc_library(
     name = "extender_cc",
     hdrs = ["extender.h"],
+    deps = [
+        "//mbo/types:traits_cc",
+    ],
 )
 
 cc_library(

--- a/mbo/types/internal/extend.h
+++ b/mbo/types/internal/extend.h
@@ -19,7 +19,7 @@
 // IWYU pragma private, include "mbo/types/extend.h"
 
 #include <array>
-#include <concepts>
+#include <concepts>  // IWYU pragma: keep
 #include <string_view>
 #include <tuple>
 #include <type_traits>

--- a/mbo/types/internal/extender.h
+++ b/mbo/types/internal/extender.h
@@ -31,7 +31,11 @@
 namespace mbo::types {
 
 // Base Extender implementation for CRTP functionality injection.
-// This must always be present.
+//
+// This must be the base of every `Extend`ed struct's CRTP chain.
+//
+// This is only not in the internal namespace `types_internal` to shorten the
+// resulting type names.
 template<typename ActualType>
 struct ExtendBase {
   using Type = ActualType;  // Used for type chaining in `UseExtender`
@@ -53,7 +57,9 @@ struct ExtendBase {
   }
 
  protected:  // DO NOT expose anything publicly.
-  auto ToTuple() const { return StructToTuple(static_cast<const ActualType&>(*this)); }
+  auto ToTuple() const & { return StructToTuple(static_cast<const ActualType&>(*this)); }
+
+  auto ToTuple() && { return StructToTuple(std::move(*this)); }
 
  private:  // DO NOT expose anything publicly.
   template<typename U, typename Extender>

--- a/mbo/types/traits.h
+++ b/mbo/types/traits.h
@@ -327,8 +327,19 @@ struct IsVariantImpl<std::variant<Args...>> : std::true_type {};
 
 }  // namespace types_internal
 
+// Determine whether `T` is a `std::variant<...>` type.
 template<typename T>
 concept IsVariant = types_internal::IsVariantImpl<T>::value;
+
+// Determines whether `T` can be constructed from an empty base and `Args`.
+//
+// This is used in mbo::types::Extend<...>::ConstructFrom{Tuple|Args}.
+//
+// See: https://godbolt.org/z/Wjq38PP6n
+template<typename T, typename... Args>
+concept IsConstructibleWithEmptyBaseAndArgs = requires(Args&&... args) {
+  { T{{}, {std::forward<Args>(args)}...} };
+};
 
 }  // namespace mbo::types
 

--- a/mbo/types/traits.h
+++ b/mbo/types/traits.h
@@ -335,7 +335,7 @@ concept IsVariant = types_internal::IsVariantImpl<T>::value;
 //
 // This is used in mbo::types::Extend<...>::ConstructFrom{Tuple|Args}.
 //
-// See: https://godbolt.org/z/Wjq38PP6n
+// See: https://godbolt.org/z/3nnsG6bEb
 template<typename T, typename... Args>
 concept IsConstructibleWithEmptyBaseAndArgs = requires(Args&&... args) {
   { T{{}, {std::forward<Args>(args)}...} };


### PR DESCRIPTION
* Improve `mbo::types::Extend<...>::ConstructFrom{Tuple|Args|` and make it work for older Clang (<16.0.0).
* Add `ToTuple` for `&&` case, distinguishd from `const&`.
* Add more docu.