### PR TITLE
Disable OverloadSet solution in ClangD

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,6 +1,8 @@
 Diagnostics:
     UnusedIncludes: Strict
 
+CompileFlags:
+  Add: -DIS_CLANGD
 ---
 If:
     PathMatch: .*_test.cc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.31
+
+* Prevent clangd indexing issues with ``DecomposeCount` implementation.
+
 # 0.2.30
 
 * Added class `Stringify` which can turn arbitrary structs into strings.

--- a/mbo/types/extend_test.cc
+++ b/mbo/types/extend_test.cc
@@ -32,7 +32,7 @@
 #include "mbo/types/internal/decompose_count.h"
 #include "mbo/types/internal/extend.h"  // IWYU pragma: keep
 #include "mbo/types/traits.h"           // IWYU pragma: keep
-#include "mbo/types/tuple.h"
+#include "mbo/types/tuple.h"            // IWYU pragma: keep
 
 #ifdef __clang__
 # pragma clang diagnostic push
@@ -59,6 +59,8 @@ void AbslStringify(Sink& sink, const std::variant<Args...>& val) {  // NOLINT(ce
 
 namespace mbo::types {
 namespace {
+
+// NOLINTBEGIN(*-magic-numbers)
 
 using ::mbo::types::extender::AbslHashable;
 using ::mbo::types::extender::AbslStringify;
@@ -330,7 +332,7 @@ struct PersonData : Extend<PersonData> {
 TEST_F(ExtendTest, StreamableComplexFields) {
   const std::set<std::string> data{"foo", "bar"};
   PersonData person{
-      .index = 25,  // NOLINT(*-magic-numbers)
+      .index = 25,
       .person =
           {
               .name =
@@ -338,7 +340,7 @@ TEST_F(ExtendTest, StreamableComplexFields) {
                       .first = "Hugo",
                       .last = "Meyer",
                   },
-              .age = 42,  // NOLINT(*-magic-numbers)
+              .age = 42,
           },
       .data = &data,
   };
@@ -375,27 +377,26 @@ struct WithUnion : mbo::types::Extend<WithUnion> {
   int third{3};
 };
 
-static_assert(!HasUnionMember<int>);
+TEST_F(ExtendTest, StaticTests) {
+  static_assert(!HasUnionMember<int>);
+  static_assert(HasUnionMember<WithUnion>);
 
-// NOLINTBEGIN(*-magic-numbers)
-#ifndef MBO_TYPES_DECOMPOSE_COUNT_USE_OVERLOADSET
-static_assert(types_internal::AggregateInitializeTest<WithUnion>::IsInitializable<0>::value);
-static_assert(types_internal::AggregateInitializeTest<WithUnion>::IsInitializable<1>::value);
-static_assert(types_internal::AggregateInitializeTest<WithUnion>::IsInitializable<2>::value);
-static_assert(types_internal::AggregateInitializeTest<WithUnion>::IsInitializable<3>::value);
-static_assert(types_internal::AggregateInitializeTest<WithUnion>::IsInitializable<4>::value);
-static_assert(!types_internal::AggregateInitializeTest<WithUnion>::IsInitializable<5>::value);
-static_assert(!types_internal::AggregateInitializeTest<WithUnion>::IsInitializable<6>::value);
-static_assert(!types_internal::AggregateInitializeTest<WithUnion>::IsInitializable<7>::value);
-static_assert(types_internal::DecomposeInfo<WithUnion>::kInitializerCount == 4);
-static_assert(types_internal::DecomposeInfo<WithUnion>::kFieldCount == 4);
-static_assert(types_internal::DecomposeInfo<WithUnion>::kCountBases == 0);
-static_assert(types_internal::DecomposeInfo<WithUnion>::kCountEmptyBases == 1);
-static_assert(types_internal::DecomposeCountImpl<WithUnion>::value == 3);
-#endif  // MBO_TYPES_DECOMPOSE_COUNT_USE_OVERLOADSET
-// NOLINTEND(*-magic-numbers)
-
-static_assert(HasUnionMember<WithUnion>);
+#if !MBO_TYPES_DECOMPOSE_COUNT_USE_OVERLOAD_SET
+  static_assert(types_internal::AggregateInitializeTest<WithUnion>::IsInitializable<0>::value);
+  static_assert(types_internal::AggregateInitializeTest<WithUnion>::IsInitializable<1>::value);
+  static_assert(types_internal::AggregateInitializeTest<WithUnion>::IsInitializable<2>::value);
+  static_assert(types_internal::AggregateInitializeTest<WithUnion>::IsInitializable<3>::value);
+  static_assert(types_internal::AggregateInitializeTest<WithUnion>::IsInitializable<4>::value);
+  static_assert(!types_internal::AggregateInitializeTest<WithUnion>::IsInitializable<5>::value);
+  static_assert(!types_internal::AggregateInitializeTest<WithUnion>::IsInitializable<6>::value);
+  static_assert(!types_internal::AggregateInitializeTest<WithUnion>::IsInitializable<7>::value);
+  static_assert(types_internal::DecomposeInfo<WithUnion>::kInitializerCount == 4);
+  static_assert(types_internal::DecomposeInfo<WithUnion>::kFieldCount == 4);
+  static_assert(types_internal::DecomposeInfo<WithUnion>::kCountBases == 0);
+  static_assert(types_internal::DecomposeInfo<WithUnion>::kCountEmptyBases == 1);
+  static_assert(types_internal::DecomposeCountImpl<WithUnion>::value == 3);
+#endif  // !MBO_TYPES_DECOMPOSE_COUNT_USE_OVERLOAD_SET
+}
 
 struct WithAnonymousUnion {  // Cannot extend due to anonymous union
   int first{1};
@@ -709,33 +710,6 @@ struct UseCrtp1 : Extend<UseCrtp1> {
   Crtp1 crtp;
 };
 
-#ifndef MBO_TYPES_DECOMPOSE_COUNT_USE_OVERLOADSET
-// NOLINTBEGIN(*-magic-numbers)
-static_assert(!types_internal::AggregateInitializeTest<UseCrtp1>::IsInitializable<0>::value);
-static_assert(!types_internal::AggregateInitializeTest<UseCrtp1>::IsInitializable<1>::value);
-static_assert(types_internal::AggregateInitializeTest<UseCrtp1>::IsInitializable<2>::value);
-static_assert(!types_internal::AggregateInitializeTest<UseCrtp1>::IsInitializable<3>::value);
-static_assert(!types_internal::AggregateInitializeTest<UseCrtp1>::IsInitializable<4>::value);
-static_assert(!types_internal::AggregateInitializeTest<UseCrtp1>::IsInitializable<5>::value);
-static_assert(!types_internal::AggregateInitializeTest<UseCrtp1>::IsInitializable<6>::value);
-static_assert(!types_internal::AggregateInitializeTest<UseCrtp1>::IsInitializable<7>::value);
-// NOLINTEND(*-magic-numbers)
-
-static_assert(types_internal::AggregateInitializerCount<UseCrtp1>::value == 2);
-static_assert(types_internal::DecomposeInfo<UseCrtp1>::kInitializerCount == 2);
-
-static_assert(types_internal::DecomposeInfo<UseCrtp1>::kFieldCount == 2);
-static_assert(types_internal::DecomposeInfo<UseCrtp1>::kDecomposeCount == 1);
-static_assert(!types_internal::DecomposeInfo<UseCrtp1>::kBadFieldCount);
-static_assert(types_internal::DecomposeInfo<UseCrtp1>::kIsAggregate);
-static_assert(!types_internal::DecomposeInfo<UseCrtp1>::kIsEmpty);
-static_assert(!types_internal::DecomposeInfo<UseCrtp1>::kOneNonEmptyBase);
-static_assert(types_internal::DecomposeInfo<UseCrtp1>::kOnlyEmptyBases);
-static_assert(!types_internal::DecomposeInfo<UseCrtp1>::kOneNonEmptyBasePlusFields);
-
-static_assert(types_internal::DecomposeInfo<UseCrtp1>::kDecomposeCount == 1);
-#endif  // MBO_TYPES_DECOMPOSE_COUNT_USE_OVERLOADSET
-
 struct UseCrtp2 : Extend<UseCrtp2> {
   Crtp2 crtp;
 };
@@ -747,39 +721,62 @@ struct UseBoth : Extend<UseBoth> {
 
 static_assert(IsAggregate<UseBoth>);
 
-#ifndef MBO_TYPES_DECOMPOSE_COUNT_USE_OVERLOADSET
-// NOLINTBEGIN(*-magic-numbers)
-static_assert(!types_internal::AggregateInitializeTest<UseBoth>::IsInitializable<0>::value);
-static_assert(!types_internal::AggregateInitializeTest<UseBoth>::IsInitializable<1>::value);
-static_assert(!types_internal::AggregateInitializeTest<UseBoth>::IsInitializable<2>::value);
-static_assert(types_internal::AggregateInitializeTest<UseBoth>::IsInitializable<3>::value);
-static_assert(!types_internal::AggregateInitializeTest<UseBoth>::IsInitializable<4>::value);
-static_assert(!types_internal::AggregateInitializeTest<UseBoth>::IsInitializable<5>::value);
-static_assert(!types_internal::AggregateInitializeTest<UseBoth>::IsInitializable<6>::value);
-static_assert(!types_internal::AggregateInitializeTest<UseBoth>::IsInitializable<7>::value);
-// NOLINTEND(*-magic-numbers)
+TEST_F(ExtendTest, StaticTestsCrtpInCrtp) {
+#if !MBO_TYPES_DECOMPOSE_COUNT_USE_OVERLOAD_SET
+  static_assert(!types_internal::AggregateInitializeTest<UseCrtp1>::IsInitializable<0>::value);
+  static_assert(!types_internal::AggregateInitializeTest<UseCrtp1>::IsInitializable<1>::value);
+  static_assert(types_internal::AggregateInitializeTest<UseCrtp1>::IsInitializable<2>::value);
+  static_assert(!types_internal::AggregateInitializeTest<UseCrtp1>::IsInitializable<3>::value);
+  static_assert(!types_internal::AggregateInitializeTest<UseCrtp1>::IsInitializable<4>::value);
+  static_assert(!types_internal::AggregateInitializeTest<UseCrtp1>::IsInitializable<5>::value);
+  static_assert(!types_internal::AggregateInitializeTest<UseCrtp1>::IsInitializable<6>::value);
+  static_assert(!types_internal::AggregateInitializeTest<UseCrtp1>::IsInitializable<7>::value);
 
-static_assert(types_internal::IsAggregateInitializableWithNumArgs<UseBoth, 3>);
-static_assert(types_internal::AggregateInitializeTest<UseBoth>::IsInitializable<3>::value);
-static_assert(types_internal::AggregateInitializerCount<UseBoth>::value == 3);
-static_assert(types_internal::DecomposeInfo<UseBoth>::kInitializerCount == 3);
+  static_assert(types_internal::AggregateInitializerCount<UseCrtp1>::value == 2);
+  static_assert(types_internal::DecomposeInfo<UseCrtp1>::kInitializerCount == 2);
 
-static_assert(types_internal::DecomposeInfo<UseBoth>::kFieldCount == 3);
-static_assert(!types_internal::DecomposeInfo<UseBoth>::kBadFieldCount);
-static_assert(types_internal::DecomposeInfo<UseBoth>::kIsAggregate);
-static_assert(!types_internal::DecomposeInfo<UseBoth>::kIsEmpty);
-static_assert(!types_internal::DecomposeInfo<UseBoth>::kOneNonEmptyBase);
-static_assert(types_internal::DecomposeInfo<UseBoth>::kOnlyEmptyBases);
-static_assert(!types_internal::DecomposeInfo<UseBoth>::kOneNonEmptyBasePlusFields);
+  static_assert(types_internal::DecomposeInfo<UseCrtp1>::kFieldCount == 2);
+  static_assert(types_internal::DecomposeInfo<UseCrtp1>::kDecomposeCount == 1);
+  static_assert(!types_internal::DecomposeInfo<UseCrtp1>::kBadFieldCount);
+  static_assert(types_internal::DecomposeInfo<UseCrtp1>::kIsAggregate);
+  static_assert(!types_internal::DecomposeInfo<UseCrtp1>::kIsEmpty);
+  static_assert(!types_internal::DecomposeInfo<UseCrtp1>::kOneNonEmptyBase);
+  static_assert(types_internal::DecomposeInfo<UseCrtp1>::kOnlyEmptyBases);
+  static_assert(!types_internal::DecomposeInfo<UseCrtp1>::kOneNonEmptyBasePlusFields);
 
-static_assert(types_internal::DecomposeInfo<UseBoth>::kDecomposeCount == 2);
-#endif  // MBO_TYPES_DECOMPOSE_COUNT_USE_OVERLOADSET
+  static_assert(types_internal::DecomposeInfo<UseCrtp1>::kDecomposeCount == 1);
 
-static_assert(!IsDecomposable<Crtp1>);
-static_assert(!IsDecomposable<Crtp2>);
-static_assert(IsDecomposable<UseCrtp1>);
-static_assert(IsDecomposable<UseCrtp2>);
-static_assert(IsDecomposable<UseBoth>);
+  static_assert(!types_internal::AggregateInitializeTest<UseBoth>::IsInitializable<0>::value);
+  static_assert(!types_internal::AggregateInitializeTest<UseBoth>::IsInitializable<1>::value);
+  static_assert(!types_internal::AggregateInitializeTest<UseBoth>::IsInitializable<2>::value);
+  static_assert(types_internal::AggregateInitializeTest<UseBoth>::IsInitializable<3>::value);
+  static_assert(!types_internal::AggregateInitializeTest<UseBoth>::IsInitializable<4>::value);
+  static_assert(!types_internal::AggregateInitializeTest<UseBoth>::IsInitializable<5>::value);
+  static_assert(!types_internal::AggregateInitializeTest<UseBoth>::IsInitializable<6>::value);
+  static_assert(!types_internal::AggregateInitializeTest<UseBoth>::IsInitializable<7>::value);
+
+  static_assert(types_internal::IsAggregateInitializableWithNumArgs<UseBoth, 3>);
+  static_assert(types_internal::AggregateInitializeTest<UseBoth>::IsInitializable<3>::value);
+  static_assert(types_internal::AggregateInitializerCount<UseBoth>::value == 3);
+  static_assert(types_internal::DecomposeInfo<UseBoth>::kInitializerCount == 3);
+
+  static_assert(types_internal::DecomposeInfo<UseBoth>::kFieldCount == 3);
+  static_assert(!types_internal::DecomposeInfo<UseBoth>::kBadFieldCount);
+  static_assert(types_internal::DecomposeInfo<UseBoth>::kIsAggregate);
+  static_assert(!types_internal::DecomposeInfo<UseBoth>::kIsEmpty);
+  static_assert(!types_internal::DecomposeInfo<UseBoth>::kOneNonEmptyBase);
+  static_assert(types_internal::DecomposeInfo<UseBoth>::kOnlyEmptyBases);
+  static_assert(!types_internal::DecomposeInfo<UseBoth>::kOneNonEmptyBasePlusFields);
+
+  static_assert(types_internal::DecomposeInfo<UseBoth>::kDecomposeCount == 2);
+#endif  // !MBO_TYPES_DECOMPOSE_COUNT_USE_OVERLOAD_SET
+
+  static_assert(!IsDecomposable<Crtp1>);
+  static_assert(!IsDecomposable<Crtp2>);
+  static_assert(IsDecomposable<UseCrtp1>);
+  static_assert(IsDecomposable<UseCrtp2>);
+  static_assert(IsDecomposable<UseBoth>);
+}
 
 TEST_F(ExtendTest, NoDefaultConstructor) {
   ABSL_LOG(ERROR) << types_internal::DecomposeInfo<UseBoth>::Debug();
@@ -959,6 +956,8 @@ TEST_F(ExtendTest, EmptyExtend) {
   ASSERT_TRUE(CanCreateTuple<Empty>);
   ASSERT_FALSE(CanCreateTuple<Empty&>);
 }
+
+// NOLINTEND(*-magic-numbers)
 
 }  // namespace
 }  // namespace mbo::types

--- a/mbo/types/internal/decompose_count.h.mope
+++ b/mbo/types/internal/decompose_count.h.mope
@@ -90,9 +90,12 @@ template<typename T>
 concept AggregateHasNonEmptyBase = AggregateHasNonEmptyBaseImpl<T>::value;
 
 {{#use_clang}}
-#if defined(__clang__)
+// OverloadSets (see below) are the preferred solution but it requires Clang and can confuse ClangD.
+#if defined(__clang__) && !defined(IS_CLANGD)
 
-#define MBO_TYPES_DECOMPOSE_COUNT_USE_OVERLOADSET 1
+constexpr bool kMboTypesDecomposeCountUseOverloadSet = true;
+
+#define MBO_TYPES_DECOMPOSE_COUNT_USE_OVERLOAD_SET 1
 
 // ----------------------------------------------------
 // This version implements the somewhat known Overloadset solution with additioanl identification of
@@ -172,6 +175,7 @@ struct DecomposeInfo final {
 
 #else  // defined(__clang__)
 {{/use_clang}}
+constexpr bool kMboTypesDecomposeCountUseOverloadSet = false;
 // ----------------------------------------------------
 
 // From
@@ -554,8 +558,10 @@ struct DecomposeHelper final {
 
   template<typename U>
   static constexpr auto ToTuple(U&& data) noexcept {
-    constexpr bool kIsEmptyAggregate = std::is_aggregate_v<U> && std::is_empty_v<U>;
-    constexpr std::size_t kNumFields = kIsEmptyAggregate ? 0 : DecomposeCountImpl<U>::value;
+    using UR = std::remove_cvref_t<U>;
+    constexpr bool kIsEmptyAggregate = std::is_aggregate_v<UR> && std::is_empty_v<UR>;
+    constexpr std::size_t kNumFields = kIsEmptyAggregate ? 0 : DecomposeCountImpl<UR>::value;
+    static_assert(kNumFields != kNotDecomposableValue);
     if constexpr (kNumFields == 0) {
       return std::make_tuple();
     {{#num_fields=1;max_fields}}
@@ -568,8 +574,10 @@ struct DecomposeHelper final {
 
   template<typename U>
   static constexpr auto ToTuple(U& data) noexcept {
-    constexpr bool kIsEmptyAggregate = std::is_aggregate_v<U> && std::is_empty_v<U>;
-    constexpr std::size_t kNumFields = kIsEmptyAggregate ? 0 : DecomposeCountImpl<U>::value;
+    using UR = std::remove_cvref_t<U>;
+    constexpr bool kIsEmptyAggregate = std::is_aggregate_v<UR> && std::is_empty_v<UR>;
+    constexpr std::size_t kNumFields = kIsEmptyAggregate ? 0 : DecomposeCountImpl<UR>::value;
+    static_assert(kNumFields != kNotDecomposableValue);
     if constexpr (kNumFields == 0) {
       return std::make_tuple();
     {{#num_fields=1;max_fields}}
@@ -582,8 +590,10 @@ struct DecomposeHelper final {
 
   template<typename U>
   static constexpr auto ToTuple(const U& data) noexcept {
-    constexpr bool kIsEmptyAggregate = std::is_aggregate_v<U> && std::is_empty_v<U>;
-    constexpr std::size_t kNumFields = kIsEmptyAggregate ? 0 : DecomposeCountImpl<U>::value;
+    using UR = std::remove_cvref_t<U>;
+    constexpr bool kIsEmptyAggregate = std::is_aggregate_v<UR> && std::is_empty_v<UR>;
+    constexpr std::size_t kNumFields = kIsEmptyAggregate ? 0 : DecomposeCountImpl<UR>::value;
+    static_assert(kNumFields != kNotDecomposableValue);
     if constexpr (kNumFields == 0) {
       return std::make_tuple();
     {{#num_fields=1;max_fields}}

--- a/mbo/types/traits_test.cc
+++ b/mbo/types/traits_test.cc
@@ -28,7 +28,6 @@ namespace {
 
 using ::mbo::types::types_internal::AnyBaseType;
 using ::mbo::types::types_internal::AnyType;
-using ::testing::AnyOf;
 using ::testing::Ne;
 
 // NOLINTNEXTLINE(google-build-using-namespace)
@@ -165,13 +164,13 @@ TEST_F(TraitsTest, StructWithStrings) {
   using namespace ::mbo::types::types_internal;  // NOLINT(*-build-using-namespace)
   using T = StructWithStrings;
   EXPECT_THAT(DecomposeCountV<T>, 5) << DecomposeInfo<T>();
-#ifndef MBO_TYPES_DECOMPOSE_COUNT_USE_OVERLOADSET
+#if !MBO_TYPES_DECOMPOSE_COUNT_USE_OVERLOAD_SET
   EXPECT_THAT((AggregateFieldInitializerCount<T, 0>::value), 2);
   EXPECT_THAT((AggregateFieldInitializerCount<T, 1>::value), 2);
   EXPECT_THAT((AggregateFieldInitializerCount<T, 2>::value), 2);
   EXPECT_THAT((DetectSpecial<AggregateFieldInitializerCount<T, 0>::value, 5 - 0>::value), 2);
   EXPECT_THAT((DetectSpecial<AggregateFieldInitializerCount<T, 1>::value, 5 - 1>::value), 2);
-#endif  // MBO_TYPES_DECOMPOSE_COUNT_USE_OVERLOADSET
+#endif  // !MBO_TYPES_DECOMPOSE_COUNT_USE_OVERLOAD_SET
 }
 
 TYPED_TEST(GenTraitsTest, DecomposeCountV) {


### PR DESCRIPTION
* Add `MBO_TYPES_DECOMPOSE_COUNT_USE_OVERLOAD_SET` to identify decompose using OverloadSet solution.
* Add `-DIS_CLANGD` for clangd compilation. In that mode disable OverloadSet solution for decompose.
* Additional cleanup.