### PR TITLE
Improved absl::Status related functionality.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,22 @@
 # 0.2.33
 
-* Improve `MBO_RETURN_IF_ERROR` to correctly accept StatusOr expressions independently of their implementation.
+* Improved `MBO_RETURN_IF_ERROR` to correctly accept `absl::StatusOr` expressions independently of their implementation.
+* Added `mbo::status::StatusBuilder` which allows to modify the message of an `absl::Status`.
+* Added `mbo::status::GetStatus` which allows to convert its argument to an `absl::Status` if supported.
+* Added macro `MBO_MOVE_TO_OR_RETURN` which can assign to structured binadings and other complex types.
+* Added macro `MBO_ASSERT_OK_AND_ASSIGN_TO` which can assign to structured binadings and other complex types.
+* Added matcher `mbo::testing::StatusHasPayload` that matches presence of any, a specific payload url, or a payload url with specific content.
+* Added matcher `mbo::testing::StatusPayloads` that matches against `Status`/`StatusOr<>` payload maps.
 
 # 0.2.32
 
-* Add support for smart pointer types in `Stringify`.
-* Add support for std::optional in `Stringify`.
-* Add builtin ability to suppress `nullptr` and `nullopt` field values (in particular for Json output).
-* Add support for move only decomposing in `StructToTuple`.
-* Add (extendable) concept `IsSmartPtr`.
-* Add concept `IsOptional`.
-* Add extension API type `MboTypesStringifyDisable` which can be used to suppress printing.
+* Added support for smart pointer types in `Stringify`.
+* Added support for std::optional in `Stringify`.
+* Added builtin ability to suppress `nullptr` and `nullopt` field values (in particular for Json output).
+* Added support for move only decomposing in `StructToTuple`.
+* Added (extendable) concept `IsSmartPtr`.
+* Added concept `IsOptional`.
+* Added extension API type `MboTypesStringifyDisable` which can be used to suppress printing.
 
 # 0.2.31
 

--- a/README.md
+++ b/README.md
@@ -69,13 +69,18 @@ The C++ library is organized in functional groups each residing in their own dir
         * function `ReadIniToTemplate`: Helper to initialize a mope Template from an INI file.
     * mbo/mope:mope_bzl, mbo/mope/mope.bzl
         * bzl-rule `mope`: A rule that expands a mope template file.
-        * bazl-macro `mope_test`: A test rule that compares mope template expansion against golden files. This
+        * bzl-macro `mope_test`: A test rule that compares mope template expansion against golden files. This
           supports `clang-format` and thus can be used for source-code generation and verification.
 * Status
     * `namespace mbo::status`
+    * mbo/status:status_builder_cc, mbo/status/status_builder.h
+        * class `StatusBuilder` which allows to extend the message of an `absl::Status`.
+    * mbo/status:status_cc, mbo/status/status.h
+        * function `GetStatus` allows to convert types to an `absl::Status`.
     * mbo/status:status_macros_cc, mbo/status/status_macros.h
-        * macro `MBO_RETURN_IF_ERROR`: Macro that simplifies handling functions returning `absl::Status`.
         * macro `MBO_ASSIGN_OR_RETURN`: Macro that simplifies handling functions returning `absl::StatusOr<T>`.
+        * macro `MBO_MOVE_TO_OR_RETURN`: Macro that simplifies handling functions returning `absl::StatusOr<T>` where the result requires commas, in particular structured bindings.
+        * macro `MBO_RETURN_IF_ERROR`: Macro that simplifies handling functions returning `absl::Status` or `absl::StausOr<T>`.
 * Strings
     * `namespace mbo::strings`
     * mbo/strings:indent_cc, mbo/strings/indent.h
@@ -96,10 +101,13 @@ The C++ library is organized in functional groups each residing in their own dir
     * mbo/testing:matchers_cc, mbo/testing/matchers.h
         * gMock-Matcher `CapacityIs` which checks the capacity of a container.
     * mbo/testing:status_cc, mbo/testing/status.h
-        * gMock-matcher `IsOk`: Tests whether an absl::Status or absl::StatusOr is absl::OkStatus.
-        * gMock-matcher `IsOkAndHolds`: Tests an absl::StatusOr for absl::OkStatus and contents.
-        * gMock-Matcher `StatusIs`: Tests an absl::Status or absl::StatusOr against a specific status code and message.
+        * gMock-matcher `IsOk`: Tests whether an `absl::Status` or `absl::StatusOr` is `absl::OkStatus`.
+        * gMock-matcher `IsOkAndHolds`: Tests an `absl::StatusOr` for `absl::OkStatus` and contents.
+        * gMock-matcher `StatusIs`: Tests an `absl::Status` or `absl::StatusOr` against a specific status code and message.
+        * gmock-matcher `StatusHasPayload`: Tests whether an `absl::Status` or `absl::StatusOr` payload map has any payload, a specific payload url, or a payload url with specific content.
+        * gmock-matcher `StatusPayloads` Tests whether an `absl::Status` or `absl::StatusOr` payload map matches.
         * macro `MBO_ASSERT_OK_AND_ASSIGN`: Simplifies testing with functions that return `absl::StatusOr<T>`.
+        * macro `MBO_ASSERT_OK_AND_ASSIGN_TO`: Simplifies testing with functions that return `absl::StatusOr<T>` where the result requires commas, in particular structured bindings.
 * Types
     * `namespace mbo::types`
     * mbo/types:cases_cc, mbo/types/cases.h
@@ -116,7 +124,7 @@ The C++ library is organized in functional groups each residing in their own dir
         * crtp-struct `ExtendNoDefault` Like `Extend` but without default extender functionality.
         * crtp-struct `ExtendNoPrint` Like `Extend` but without `Printable` and `Streamable` extender functionality.
         * `namespace extender`
-            * extender-struct `AbslStringify`: Extender that injects functionality to make an `Extend`ed type work with abseil format/print functions.
+            * extender-struct `AbslStringify`: Extender that injects functionality to make an `Extend`ed type work with abseil format/print functions. See `Stringify` for various API extension points.
             * extender-struct `AbslHashable`: Extender that injects functionality to make an `Extend`ed type work with abseil hashing (and also `std::hash`).
             * extender-struct `Comparable`: Extender that injects functionality to make an `Extend`ed type comparable. All comparators will be injected: `<=>`, `==`, `!=`, `<`, `<=`, `>`, `>=`.
             * extender-struct `Printable`:
@@ -139,6 +147,8 @@ The C++ library is organized in functional groups each residing in their own dir
         * function `StringifyWithFieldNames` a format control adapter for `Stringify`.
         * struct `StringifyOptions` which can be used to control `Stringify` formatting.
         * API extension point type `MboTypesStringifySupport` which enables `Stringify` support even if not otherwise enabled (disables Abseil stringify support in `Stringify`).
+        * API extension point type `MboTypesStringifyDisable` which disables `Stringify` support. This allows to prevent
+        complex classes (and more importantly fields of complex types) from being printed/streamed using `Stringify`
         * API extension point type `MboTypesStringifyDoNotPrintFieldNames` which if present disables field names in `Stringify`.
         * API extension point function `MboTypesStringifyFieldNames` which adds field names to `Stringify`.
         * API extension point function `MboTypesStringifyOptions` which adds full format control to `Stringify`.

--- a/RULES.md
+++ b/RULES.md
@@ -5,6 +5,7 @@ Some rules for the code layout and its development.
   * Lines end in {LF}.
   * The files are either empty or end in {LF}.
 * This library uses C++20 and is intended to be compiled with `clang`.
+  * Reasonable effort is performed to ensure compilation with GCC is functional.
 * All code must be formatted using `clang-format` with '.clang-format'.
   * This provides consistent formatting.
   * The choices are meant to enable fast structural reading by humans.
@@ -19,11 +20,12 @@ Some rules for the code layout and its development.
   * has all its code in a namespace: "mbo::{dir}"
   * there may be functional sub-namespace, e.g.: "mbo::{dir}::{sub}"
   * internal code goes into special sub-namespace:
-    * Code in these namespace is not allowed to be used outside this library
+    * Code in these namespace is not allowed to be used outside their library
     * "mbo::{dir}::{dir}_internal
     * "mbo::{dir}::{sub}_internal
     * "mbo::{dir}::{sub}::{sub}_internal
     * This ensures that "internal" namespace do not conflict.
+    * No namespace component `internal` is otherwise allowed.
   * Sub namespaces 'detail' are allowed.
     * Such sub-namespaces imply usable (exported) functionality
     * "mbo::{dir}::detail
@@ -38,15 +40,16 @@ Some rules for the code layout and its development.
 * All public / exported code must:
   * be tested,
   * have a documentaion.
-* All headers must have macro-guards: "{path}_{file}_" with '/' becoming '_'.
-  * A '__' betwenn {path} and {file} would be better, but C++ does not allow it.
+* All headers must have macro-guards: "{PATH}_{FILE}_". That is path and filename in all caps, with all non alphanumeric chars replaced with '_' and followed by a final '_'.
+  * A '__' betwen {PATH} and {FILE} would be better, but C++ does not allow it.
   * Filnames may not start with the basename of any directory in their same
     directory followed by an '_' as that would lead to conflicting macro guards.
     E.g.: "foo/bar.h" and "foo_bar.h" would have macro guard "FOO_BAR_H_".
 * Macros are to be avoided at all costs, or prefixed by 'MBO_'.
   * Macros for local application must be undefined as close after the last use
     as possible.
-  * Where possible macros should be named "{path}_{file}_{usecase}".
+  * Where possible macros should be named "{PATH}_{FILE}_{USECASE}". As a minimum they should have the prefix `MBO_`.
+  * Private macro implementation details should be named "MBO_PRIVATE_{PATH}_{FILE}_{USECASE}_". That is, prefix `MBO_PRIVATE_` followed by all caps path/filename with all non alphanumeric chars replaced with `_`, followed by a final `_`.
 * Use `std::size_t` as `size_t` **ONLY** in CC files with `using std::size_t`.
 * Flags in libraries should be prefixed with their path/namespace. E.g. the flag
   `--mbo_log_timing_min_duration` has the prefix `mbo_log` as it is defined in

--- a/mbo/status/BUILD.bazel
+++ b/mbo/status/BUILD.bazel
@@ -16,6 +16,30 @@
 package(default_visibility = ["//visibility:private"])
 
 cc_library(
+    name = "status_builder_cc",
+    srcs = ["status_builder.cc"],
+    hdrs = ["status_builder.h"],
+    deps = [
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_test(
+    name = "status_builder_test",
+    srcs = ["status_builder_test.cc"],
+    deps = [
+        ":status_builder_cc",
+        "//mbo/testing:status_cc",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
     name = "status_cc",
     hdrs = ["status.h"],
     deps = [
@@ -41,6 +65,7 @@ cc_library(
     name = "status_macros_cc",
     hdrs = ["status_macros.h"],
     deps = [
+        ":status_builder_cc",
         ":status_cc",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",

--- a/mbo/status/status.h
+++ b/mbo/status/status.h
@@ -23,18 +23,25 @@
 
 namespace mbo::status {
 
-inline absl::Status ToStatus(absl::Status v) {
+// Conversion of any `absl::Status` or `absl::StatusOr<T>` to an `absl::Status`.
+inline absl::Status GetStatus(absl::Status v) {
   return v;
 }
 
 template<typename T>
-inline absl::Status ToStatus(const absl::StatusOr<T>& v) {
+inline absl::Status GetStatus(const absl::StatusOr<T>& v) {
   return v.status();
 }
 
 template<typename T>
-inline absl::Status ToStatus(absl::StatusOr<T>&& v) {
+inline absl::Status GetStatus(absl::StatusOr<T>&& v) {
   return std::move(v).status();
+}
+
+template<typename T>
+requires(std::constructible_from<::absl::Status, T> || std::convertible_to<T, absl::Status>)
+inline ::absl::Status GetStatus(T&& status) {
+  return absl::Status(std::forward<decltype(status)>(status));
 }
 
 }  // namespace mbo::status

--- a/mbo/status/status_builder.cc
+++ b/mbo/status/status_builder.cc
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mbo/status/status_builder.h"
+
+#include "absl/strings/str_cat.h"
+
+namespace mbo::status {
+
+StatusBuilder& StatusBuilder::SetPrepend() & {
+  return *this;
+}
+
+StatusBuilder&& StatusBuilder::SetPrepend() && {
+  this->SetPrepend();
+  return std::move(*this);
+}
+
+StatusBuilder& StatusBuilder::SetAppend() & {
+  if (data_) {
+    if (!data_->appended) {
+      data_->stream << data_->status.message();
+    }
+    data_->appended = true;
+  }
+  return *this;
+}
+
+StatusBuilder&& StatusBuilder::SetAppend() && {
+  this->SetAppend();
+  return std::move(*this);
+}
+
+StatusBuilder::operator absl::Status() const & {
+  if (!data_) {
+    return absl::OkStatus();
+  }
+  absl::Status result(
+      data_->status.code(),
+      data_->appended ? data_->stream.str() : absl::StrCat(data_->status.message(), data_->stream.str()));
+  data_->status.ForEachPayload(
+      [&result](absl::string_view url, const absl::Cord& payload) { result.SetPayload(url, payload); });
+  return result;
+}
+
+}  // namespace mbo::status

--- a/mbo/status/status_builder.h
+++ b/mbo/status/status_builder.h
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MBO_STATUS_STATUS_BUILDER_H_
+#define MBO_STATUS_STATUS_BUILDER_H_
+
+#include <concepts>  // IWYU pragma: keep
+#include <memory>
+#include <sstream>
+#include <string_view>
+#include <utility>
+
+#include "absl/status/status.h"    // IWYU pragma: keep
+#include "absl/status/statusor.h"  // IWYU pragma: keep
+#include "absl/strings/cord.h"
+
+namespace mbo::status {
+
+// Helper to construct modified `absl::Status`.
+// Mainly this allows to stream text onto the message of a satus.
+//
+// Example:
+// ```
+// absl::Status extended =
+//     StatusBuilder(status).Prepend() << "Prefix:" << StatusBuilder::Append << "Suffix";
+// ```
+class StatusBuilder final {
+ public:
+  ~StatusBuilder() noexcept = default;
+  StatusBuilder() noexcept = default;
+
+  explicit StatusBuilder(absl::Status status)
+      : data_(status.ok() ? nullptr : std::make_unique<Data>(std::move(status))) {}
+
+  template<typename T>
+  explicit StatusBuilder(const absl::StatusOr<T>& status) : StatusBuilder(status.status()) {}
+
+  template<typename T>
+  explicit StatusBuilder(absl::StatusOr<T>&& status) : StatusBuilder(std::move(status).status()) {}
+
+  StatusBuilder(const StatusBuilder&) = delete;
+  StatusBuilder& operator=(const StatusBuilder&) = delete;
+  StatusBuilder(StatusBuilder&&) noexcept = default;
+  StatusBuilder& operator=(StatusBuilder&&) noexcept = default;
+
+  bool ok() const noexcept { return data_ == nullptr; }  // NOLINT(*-identifier-naming)
+
+  template<typename T>
+  StatusBuilder& operator<<(const T& msg) & {
+    if (data_) {
+      data_->stream << msg;
+    }
+    return *this;
+  }
+
+  template<typename T>
+  StatusBuilder&& operator<<(const T& msg) && {
+    *this << msg;
+    return std::move(*this);
+  }
+
+  // Switching the builder to append mode.
+  enum Append { Append };  // NOLINT(*-identifier-naming)
+
+  StatusBuilder& operator<<(enum Append /* unused */) & { return SetAppend(); }
+
+  StatusBuilder&& operator<<(enum Append /* unused */) && { return std::move(*this).SetAppend(); }
+
+  // Allows the builder to stream message parts in front of the message provided
+  // by the status. This can only be used once. calling `SetAppend` later works.
+  StatusBuilder& SetPrepend() &;
+  StatusBuilder&& SetPrepend() &&;
+
+  // Ensures the message from the original status has been streamed and thus all
+  // new streamed messages will be appended. Once this is called `SetPrepend`
+  // no longer works.
+  StatusBuilder& SetAppend() &;
+  StatusBuilder&& SetAppend() &&;
+
+  StatusBuilder& SetPayload(std::string_view type_url, std::constructible_from<absl::Cord> auto&& payload) & {
+    if (data_) {
+      data_->status.SetPayload(type_url, absl::Cord(std::forward<decltype(payload)>(payload)));
+    }
+    return *this;
+  }
+
+  StatusBuilder& SetPayload(std::string_view type_url, std::string_view payload) & {
+    return SetPayload(type_url, absl::Cord(payload));
+  }
+
+  StatusBuilder&& SetPayload(std::string_view type_url, auto&& payload) && {
+    return std::move(this->SetPayload(type_url, std::forward<decltype(payload)>(payload)));
+  }
+
+  explicit operator absl::Status() const &;
+
+  operator absl::Status() && {  // NOLINT(*-explicit-*)
+    return absl::Status{*this};
+  }
+
+ private:
+  struct Data {
+    absl::Status status;
+    std::stringstream stream;
+    bool appended = false;
+  };
+
+  std::unique_ptr<Data> data_;
+};
+
+}  // namespace mbo::status
+
+#endif  // MBO_STATUS_STATUS_BUILDER_H_

--- a/mbo/status/status_builder_test.cc
+++ b/mbo/status/status_builder_test.cc
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mbo/status/status_builder.h"
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "mbo/testing/status.h"
+
+namespace mbo::status {
+namespace {
+
+using ::mbo::testing::IsOk;
+using ::mbo::testing::IsOkAndHolds;
+using ::mbo::testing::StatusHasPayload;
+using ::mbo::testing::StatusIs;
+
+struct StatusBuilderTest : ::testing::Test {};
+
+TEST_F(StatusBuilderTest, Status) {
+  EXPECT_THAT(StatusBuilder(), IsOk());
+  EXPECT_TRUE(StatusBuilder().ok());
+  EXPECT_THAT(StatusBuilder(absl::OkStatus()), IsOk());
+  EXPECT_TRUE(StatusBuilder(absl::OkStatus()).ok());
+  EXPECT_THAT(StatusBuilder(absl::CancelledError()), StatusIs(absl::StatusCode::kCancelled));
+  EXPECT_FALSE(StatusBuilder(absl::CancelledError()).ok());
+}
+
+TEST_F(StatusBuilderTest, StatusOr) {
+  using StatusOr = absl::StatusOr<int>;
+  EXPECT_THAT(StatusBuilder(StatusOr(1)), IsOk());
+  EXPECT_TRUE(StatusBuilder(StatusOr(1)).ok());
+  EXPECT_THAT(StatusBuilder(StatusOr(absl::CancelledError())), StatusIs(absl::StatusCode::kCancelled));
+  EXPECT_FALSE(StatusBuilder(StatusOr(absl::CancelledError())).ok());
+}
+
+TEST_F(StatusBuilderTest, Message) {
+  auto error = StatusBuilder(absl::CancelledError("<Error>")) << "<Message>";
+  EXPECT_THAT(error, StatusIs(absl::StatusCode::kCancelled, "<Error><Message>"));
+}
+
+TEST_F(StatusBuilderTest, SetAppend) {
+  auto error = StatusBuilder(absl::CancelledError("<Error>")).SetAppend() << "<Message>";
+  EXPECT_THAT(error, StatusIs(absl::StatusCode::kCancelled, "<Error><Message>"));
+}
+
+TEST_F(StatusBuilderTest, SetPrepend) {
+  auto error = StatusBuilder(absl::CancelledError("<Error>")).SetPrepend()
+               << "<Prefix>" << StatusBuilder::Append << "<Suffix>";
+  EXPECT_THAT(error, StatusIs(absl::StatusCode::kCancelled, "<Prefix><Error><Suffix>"));
+}
+
+TEST_F(StatusBuilderTest, SetPayload) {
+  auto error = StatusBuilder(absl::CancelledError()).SetPayload("url", "content");
+  absl::Status status(error);
+  EXPECT_THAT(status, StatusHasPayload("url", "content"));
+}
+
+}  // namespace
+}  // namespace mbo::status

--- a/mbo/status/status_test.cc
+++ b/mbo/status/status_test.cc
@@ -33,12 +33,12 @@ TEST_F(StatusTest, StatusToStatus) {
   {
     const absl::Status status;
     EXPECT_THAT(status, IsOk());
-    EXPECT_THAT(ToStatus(status), IsOk());
+    EXPECT_THAT(GetStatus(status), IsOk());
   }
   {
     const absl::Status status = absl::CancelledError();
     EXPECT_THAT(status, StatusIs(absl::StatusCode::kCancelled));
-    EXPECT_THAT(ToStatus(status), StatusIs(absl::StatusCode::kCancelled));
+    EXPECT_THAT(GetStatus(status), StatusIs(absl::StatusCode::kCancelled));
   }
 }
 
@@ -46,12 +46,12 @@ TEST_F(StatusTest, StatusMoveToStatus) {
   {
     absl::Status status;
     EXPECT_THAT(status, IsOk());
-    EXPECT_THAT(ToStatus(std::move(status)), IsOk());
+    EXPECT_THAT(GetStatus(std::move(status)), IsOk());
   }
   {
     absl::Status status = absl::CancelledError();
     EXPECT_THAT(status, StatusIs(absl::StatusCode::kCancelled));
-    EXPECT_THAT(ToStatus(std::move(status)), StatusIs(absl::StatusCode::kCancelled));
+    EXPECT_THAT(GetStatus(std::move(status)), StatusIs(absl::StatusCode::kCancelled));
   }
 }
 
@@ -59,12 +59,12 @@ TEST_F(StatusTest, StatusOrToStatus) {
   {
     const absl::StatusOr<int> status_or(1);
     EXPECT_THAT(status_or, IsOk());
-    EXPECT_THAT(ToStatus(status_or), IsOk());
+    EXPECT_THAT(GetStatus(status_or), IsOk());
   }
   {
     const absl::StatusOr<int> status_or = absl::CancelledError();
     EXPECT_THAT(status_or, StatusIs(absl::StatusCode::kCancelled));
-    EXPECT_THAT(ToStatus(status_or), StatusIs(absl::StatusCode::kCancelled));
+    EXPECT_THAT(GetStatus(status_or), StatusIs(absl::StatusCode::kCancelled));
   }
 }
 
@@ -72,12 +72,12 @@ TEST_F(StatusTest, StatusOrMoveToStatus) {
   {
     absl::StatusOr<int> status_or(1);
     EXPECT_THAT(status_or, IsOk());
-    EXPECT_THAT(ToStatus(std::move(status_or)), IsOk());
+    EXPECT_THAT(GetStatus(std::move(status_or)), IsOk());
   }
   {
     absl::StatusOr<int> status_or = absl::CancelledError();
     EXPECT_THAT(status_or, StatusIs(absl::StatusCode::kCancelled));
-    EXPECT_THAT(ToStatus(std::move(status_or)), StatusIs(absl::StatusCode::kCancelled));
+    EXPECT_THAT(GetStatus(std::move(status_or)), StatusIs(absl::StatusCode::kCancelled));
   }
 }
 }  // namespace

--- a/mbo/testing/BUILD.bazel
+++ b/mbo/testing/BUILD.bazel
@@ -44,6 +44,7 @@ cc_library(
     name = "status_cc",
     hdrs = ["status.h"],
     deps = [
+        "//mbo/status:status_cc",
         "//mbo/status:status_macros_cc",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",

--- a/mbo/testing/status.h
+++ b/mbo/testing/status.h
@@ -16,29 +16,21 @@
 #ifndef MBO_TESTING_STATUS_H_
 #define MBO_TESTING_STATUS_H_
 
+#include <optional>
 #include <ostream>
 #include <string>
 #include <type_traits>
 #include <utility>
 
 #include "absl/status/status.h"
-#include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "mbo/status/status.h"
 #include "mbo/status/status_macros.h"
 
 namespace mbo::testing {
 namespace testing_internal {
-
-inline const ::absl::Status& GetStatus(const ::absl::Status& status) {
-  return status;
-}
-
-template<typename T>
-inline const ::absl::Status& GetStatus(const ::absl::StatusOr<T>& status) {
-  return status.status();
-}
 
 inline std::string DescribeStatus(absl::Status status) {
   std::string code = ::testing::PrintToString(status.code());
@@ -61,7 +53,7 @@ class MonoIsOkMatcherImpl : public ::testing::MatcherInterface<T> {
   void DescribeNegationTo(std::ostream* os) const override { *os << "is not OK"; }
 
   bool MatchAndExplain(T actual_value, ::testing::MatchResultListener* result) const override {
-    const absl::Status status = testing_internal::GetStatus(actual_value);
+    const absl::Status status = ::mbo::status::GetStatus(actual_value);
     if (!status.ok()) {
       *result << "which has status " << DescribeStatus(status);
     }
@@ -169,7 +161,7 @@ class StatusIsMatcher {
 
   template<typename StatusType>
   bool MatchAndExplain(const StatusType& actual, ::testing::MatchResultListener* listener) const {
-    const absl::Status& actual_status = testing_internal::GetStatus(actual);
+    const absl::Status& actual_status = ::mbo::status::GetStatus(actual);
     const bool code_match = actual_status.code() == status_code_;
     if (status_code_ == absl::StatusCode::kOk && code_match) {
       return true;
@@ -211,6 +203,151 @@ class StatusIsMatcher {
   const ::testing::Matcher<const std::string&> message_matcher_;
 };
 
+// Implementation of `StatusHasPayload` matcher.
+class StatusHasPayload {
+ public:
+  StatusHasPayload() : type_url_(std::nullopt), payload_matcher_(std::nullopt) {}
+
+  explicit StatusHasPayload(std::string_view type_url) : type_url_(type_url), payload_matcher_(std::nullopt) {}
+
+  StatusHasPayload(std::string_view type_url, const ::testing::Matcher<const std::string&>& payload_matcher)
+      : type_url_(type_url), payload_matcher_(payload_matcher) {}
+
+  void DescribeTo(std::ostream* os) const {
+    if (type_url_.has_value()) {
+      *os << "has a payload at url '" << *type_url_ << "'";
+      if (payload_matcher_.has_value()) {
+        *os << " that ";
+        payload_matcher_->DescribeTo(os);
+      }
+    } else {
+      *os << "has any payload";
+    }
+  }
+
+  void DescribeNegationTo(std::ostream* os) const {
+    if (type_url_.has_value()) {
+      if (payload_matcher_.has_value()) {
+        *os << "has no payload at url '" << *type_url_ << "' or one that ";
+        payload_matcher_->DescribeNegationTo(os);
+      } else {
+        *os << "has no payload at url '" << *type_url_ << "'";
+      }
+    } else {
+      *os << "has no payload";
+    }
+  }
+
+  template<typename StatusType>
+  bool MatchAndExplain(const StatusType& actual, ::testing::MatchResultListener* listener) const {
+    const absl::Status& actual_status = ::mbo::status::GetStatus(actual);
+    if (actual_status.ok()) {
+      *listener << "which has OK status (and no payload)";
+      return false;
+    }
+    PayloadInfo info;
+    actual_status.ForEachPayload([this, &info, listener](absl::string_view type_url, const absl::Cord& payload) {
+      ++info.count;
+      if (info.messaged) {
+        return;
+      }
+      if (!type_url_.has_value()) {
+        info.match = true;
+      } else if (*type_url_ == type_url) {
+        if (payload_matcher_.has_value()) {
+          ::testing::StringMatchResultListener inner;
+          info.match = payload_matcher_->MatchAndExplain(std::string{payload}, &inner);
+          info.messaged = true;
+          if (info.match) {
+            *listener << "which has a matching payload at url '" << type_url << "'";
+          } else {
+            *listener << "which has a non-matching payload at url '" << type_url << "'";
+          }
+          if (!inner.str().empty()) {
+            *listener << " that " << inner.str();
+          }
+        } else {
+          info.match = true;
+          info.messaged = true;
+          *listener << "which has a payload at url '" << type_url << "'";
+        }
+      }
+    });
+    if (info.messaged) {
+      return info.match;
+    }
+    if (info.count == 0) {
+      *listener << "which has no payload";
+    } else if (info.count == 1) {
+      *listener << "which has " << info.count << " payload";
+    } else {
+      *listener << "which has " << info.count << " payloads";
+    }
+    return info.match;
+  }
+
+ private:
+  struct PayloadInfo {
+    uint64_t count = 0;
+    bool match = false;
+    bool messaged = false;
+  };
+
+  const std::optional<std::string> type_url_;
+  const std::optional<::testing::Matcher<const std::string&>> payload_matcher_;
+};
+
+// Implementation of `StatusPayloads` matcher.
+class StatusPayloads {
+ public:
+  explicit StatusPayloads(const ::testing::Matcher<const std::map<std::string, std::string>&>& payload_matcher)
+      : payload_matcher_(payload_matcher) {}
+
+  void DescribeTo(std::ostream* os) const {
+    *os << "has a payloads map that ";
+    payload_matcher_.DescribeTo(os);
+  }
+
+  void DescribeNegationTo(std::ostream* os) const {
+    *os << "has a payloads map that ";
+    payload_matcher_.DescribeNegationTo(os);
+  }
+
+  template<typename StatusType>
+  bool MatchAndExplain(const StatusType& actual, ::testing::MatchResultListener* listener) const {
+    const absl::Status& actual_status = ::mbo::status::GetStatus(actual);
+    std::map<std::string, std::string> payload_map;
+    actual_status.ForEachPayload([&payload_map](absl::string_view type_url, const absl::Cord& payload) {
+      payload_map.emplace(type_url, payload);
+    });
+    ::testing::StringMatchResultListener inner;
+    bool match = payload_matcher_.MatchAndExplain(payload_map, &inner);
+    if (inner.str().empty()) {
+      if (actual_status.ok()) {
+        *listener << "which has OK status (and no payload)";
+      } else {
+        if (payload_map.empty()) {
+          *listener << "which has no payload";
+        } else if (payload_map.size() == 1) {
+          *listener << "which has 1 payload";
+        } else {
+          *listener << "which has " << payload_map.size() << " payloads";
+        }
+      }
+    } else {
+      if (match) {
+        *listener << "which has a matching payload map " << inner.str();
+      } else {
+        *listener << "which has a non-matching payload map " << inner.str();
+      }
+    }
+    return match;
+  }
+
+ private:
+  const ::testing::Matcher<const std::map<std::string, std::string>&> payload_matcher_;
+};
+
 }  // namespace testing_internal
 
 // Returns a gMock matcher that matches a Status or StatusOr<> which is OK.
@@ -237,24 +374,55 @@ inline ::testing::PolymorphicMatcher<testing_internal::StatusIsMatcher> StatusIs
 template<typename MessageMatcher>
 ::testing::PolymorphicMatcher<testing_internal::StatusIsMatcher> StatusIs(
     const absl::StatusCode& code,
-    const MessageMatcher& message) {
+    const MessageMatcher& message_matcher) {
   return ::testing::MakePolymorphicMatcher(
-      testing_internal::StatusIsMatcher(code, ::testing::MatcherCast<const std::string&>(message)));
+      testing_internal::StatusIsMatcher(code, ::testing::MatcherCast<const std::string&>(message_matcher)));
+}
+
+// Returns a gMock matcher that matches a Status/StatusOr<> whose status is NOT
+// OK and that has at least one payload.
+inline ::testing::PolymorphicMatcher<testing_internal::StatusHasPayload> StatusHasPayload() {
+  return ::testing::MakePolymorphicMatcher(testing_internal::StatusHasPayload());
+}
+
+// Returns a gMock matcher that matches a Status/StatusOr<> whose status is NOT
+// OK and that has a payload at `type_url`.
+inline ::testing::PolymorphicMatcher<testing_internal::StatusHasPayload> StatusHasPayload(std::string_view type_url) {
+  return ::testing::MakePolymorphicMatcher(testing_internal::StatusHasPayload(type_url));
+}
+
+// Returns a gMock matcher that matches a Status/StatusOr<> whose status is NOT
+// OK and that has a payload at `type_url` that matches `payload_matcher`.
+template<typename PayloadMatcher>
+inline ::testing::PolymorphicMatcher<testing_internal::StatusHasPayload> StatusHasPayload(
+    std::string_view type_url,
+    const PayloadMatcher& payload_matcher) {
+  return ::testing::MakePolymorphicMatcher(
+      testing_internal::StatusHasPayload(type_url, ::testing::MatcherCast<const std::string&>(payload_matcher)));
+}
+
+// Returns gMock matcher that matches against Status/StatusOr<> payload maps.
+// Unlike `StatusHasPayload` here we compare the whole mapping of urls to content.
+template<typename PayloadMatcher>
+inline ::testing::PolymorphicMatcher<testing_internal::StatusPayloads> StatusPayloads(
+    const PayloadMatcher& payload_matcher) {
+  return ::testing::MakePolymorphicMatcher(testing_internal::StatusPayloads(
+      ::testing::MatcherCast<const std::map<std::string, std::string>&>(payload_matcher)));
 }
 
 // NOLINTBEGIN(cppcoreguidelines-macro-usage)
 // NOLINTBEGIN(bugprone-macro-parentheses)
 
 // Helper macros
-#undef MBO_STATUS_MACROS_IMPL_CONCAT_INNER_
-#undef MBO_STATUS_MACROS_IMPL_CONCAT_
-#define MBO_STATUS_MACROS_IMPL_CONCAT_INNER_(x, y) x##y
-#define MBO_STATUS_MACROS_IMPL_CONCAT_(x, y) MBO_STATUS_MACROS_IMPL_CONCAT_INNER_(x, y)
+#undef MBO_PRIVATE_TESTING_STATUS_CONCAT_INNER_
+#undef MBO_PRIVATE_TESTING_STATUS_CONCAT_
+#define MBO_PRIVATE_TESTING_STATUS_CONCAT_INNER_(x, y) x##y
+#define MBO_PRIVATE_TESTING_STATUS_CONCAT_(x, y) MBO_PRIVATE_TESTING_STATUS_CONCAT_INNER_(x, y)
 
 // Macros for testing the results of functions that return absl::Status or
 // absl::StatusOr<T> (for any type T).
 #undef MBO_EXPECT_OK
-#define MBO_EXPECT_OK(expression) EXPECT_THAT(expression, mbo::testing::IsOk())
+#define MBO_EXPECT_OK(expression) EXPECT_THAT(expression, ::mbo::testing::IsOk())
 
 #ifndef EXPECT_OK
 # define EXPECT_OK(expr) MBO_EXPECT_OK(expr)
@@ -263,7 +431,7 @@ template<typename MessageMatcher>
 #endif
 
 #undef MBO_ASSERT_OK
-#define MBO_ASSERT_OK(expression) ASSERT_THAT(expression, mbo::testing::IsOk())
+#define MBO_ASSERT_OK(expression) ASSERT_THAT(expression, ::mbo::testing::IsOk())
 
 #ifndef ASSERT_OK
 # define ASSERT_OK(expr) MBO_ASSERT_OK(expr)
@@ -271,19 +439,36 @@ template<typename MessageMatcher>
 # warning "ASSERT_OK already defined"
 #endif
 
-#undef MBO_ASSERT_OK_AND_ASSIGN_IMPL_
+#undef MBO_PRIVATE_TESTING_STATUS_ASSERT_OK_AND_ASSIGN_
 #undef MBO_ASSERT_OK_AND_ASSIGN
+#undef MBO_ASSERT_OK_AND_ASSIGN_TO
 
-#define MBO_ASSERT_OK_AND_ASSIGN_IMPL_(statusor, lhs, rexpr) \
-  auto statusor = (rexpr);                                   \
-  ASSERT_TRUE(statusor.ok());                                \
-  lhs = std::move(statusor.value())
+// PRIVATE macro, do not use.
+#define MBO_PRIVATE_TESTING_STATUS_ASSERT_OK_AND_ASSIGN_(statusor, expression, ...) \
+  auto statusor = (expression);                                                     \
+  ASSERT_TRUE(statusor.ok());                                                       \
+  __VA_ARGS__ = std::move(statusor).value()
 
-#define MBO_ASSERT_OK_AND_ASSIGN(lhs, rexpr) \
-  MBO_ASSERT_OK_AND_ASSIGN_IMPL_(MBO_STATUS_MACROS_IMPL_CONCAT_(_status_or_value, __LINE__), lhs, rexpr)
+// Macro that verifies `expression` is OK and assigns its `value` by move to `targets`, where target
+// can be a declaration. Example:
+// ```
+// ASSERT_OK_OR_ASSIGN(const std::string result, StringOrStatus());
+// ```
+#define MBO_ASSERT_OK_AND_ASSIGN(target, expression) \
+  MBO_PRIVATE_TESTING_STATUS_ASSERT_OK_AND_ASSIGN_(  \
+      MBO_PRIVATE_TESTING_STATUS_CONCAT_(_status_or_value, __LINE__), expression, target)
+
+// Variant of `ASSERT_OK_OR_ASSIGN` that allows to assign to complex types, in particular to
+// structured bindings. Example:
+// ```
+// ASSERT_OK_AND_ASSIGN_TO(PairOrStatus(), const auto [first, second]);
+// ```
+#define MBO_ASSERT_OK_AND_ASSIGN_TO(expression, ...) \
+  MBO_PRIVATE_TESTING_STATUS_ASSERT_OK_AND_ASSIGN_(  \
+      MBO_PRIVATE_TESTING_STATUS_CONCAT_(_status_or_value, __LINE__), expression, __VA_ARGS__)
 
 #ifndef ASSERT_OK_AND_ASSIGN
-# define ASSERT_OK_AND_ASSIGN(lhs, rexpr) MBO_ASSERT_OK_AND_ASSIGN(lhs, rexpr)
+# define ASSERT_OK_AND_ASSIGN(target, expression) MBO_ASSERT_OK_AND_ASSIGN(target, expression)
 #elif __cplusplus >= 202'302L
 # warning "ASSERT_OK_AND_ASSIGN already defined"
 #endif

--- a/mbo/testing/status_test.cc
+++ b/mbo/testing/status_test.cc
@@ -35,11 +35,14 @@ using ::mbo::testing::testing_internal::IsOkAndHoldsMatcher;
 using ::mbo::testing::testing_internal::IsOkMatcher;
 using ::mbo::testing::testing_internal::StatusIsMatcher;
 using ::testing::_;
+using ::testing::ElementsAre;
 using ::testing::Ge;
 using ::testing::HasSubstr;
 using ::testing::IsEmpty;
+using ::testing::Key;
 using ::testing::Not;
 using ::testing::Pair;
+using ::testing::SizeIs;
 
 class StatusMatcherTest : public ::testing::Test {
  public:
@@ -191,6 +194,206 @@ TEST_F(StatusMatcherTest, IsOkAndHolds) {
     EXPECT_THAT(
         MatchAndExplain(matcher, absl::StatusOr<std::string>{"25"}),
         Pair(false, "which contains value \"25\", whose size is 2"));
+  }
+}
+
+TEST_F(StatusMatcherTest, AssertOkAndAssign) {
+  absl::StatusOr<std::pair<int, int>> status_or(std::make_pair(25, 17));
+  MBO_ASSERT_OK_AND_ASSIGN(auto res, status_or);
+  EXPECT_THAT(res, Pair(25, 17));
+}
+
+TEST_F(StatusMatcherTest, AssertOkAndAssignTo) {
+  absl::StatusOr<std::pair<int, int>> status_or(std::make_pair(25, 17));
+  MBO_ASSERT_OK_AND_ASSIGN_TO(status_or, auto [first, second]);
+  EXPECT_THAT(std::make_pair(first, second), Pair(25, 17));
+}
+
+TEST_F(StatusMatcherTest, StatusHasPayload) {
+  {
+    EXPECT_THAT(absl::OkStatus(), Not(StatusHasPayload()));
+    absl::Status status = absl::CancelledError();
+    EXPECT_THAT(status, Not(StatusHasPayload()));
+    status.SetPayload("url", absl::Cord("content"));
+    EXPECT_THAT(status, StatusHasPayload());
+    EXPECT_THAT(status, StatusHasPayload("url"));
+    EXPECT_THAT(status, Not(StatusHasPayload("other")));
+    EXPECT_THAT(status, StatusHasPayload("url", "content"));
+    EXPECT_THAT(status, Not(StatusHasPayload("other", "")));
+    EXPECT_THAT(status, StatusHasPayload("url", Not("other")));
+    EXPECT_THAT(status, StatusHasPayload("url", HasSubstr("tent")));
+    EXPECT_THAT(status, Not(StatusHasPayload("url", "other")));
+  }
+  {
+    EXPECT_THAT(absl::StatusOr<int>(1), Not(StatusHasPayload()));
+    EXPECT_THAT(absl::StatusOr<int>(absl::CancelledError()), Not(StatusHasPayload()));
+    const absl::StatusOr<int> status_or = [] {
+      absl::Status status = absl::CancelledError();
+      status.SetPayload("url", absl::Cord("content"));
+      return status;
+    }();
+    EXPECT_THAT(status_or, StatusHasPayload());
+    EXPECT_THAT(status_or, StatusHasPayload("url"));
+  }
+}
+
+TEST_F(StatusMatcherTest, MessagesOfStatusHasPayload) {
+  const absl::Status status_url_content = [] {
+    absl::Status status = absl::CancelledError();
+    status.SetPayload("url", absl::Cord("content"));
+    return status;
+  }();
+  const absl::Status status_url_other = [] {
+    absl::Status status = absl::CancelledError();
+    status.SetPayload("url", absl::Cord("other"));
+    return status;
+  }();
+  const absl::Status status_abc_content = [] {
+    absl::Status status = absl::CancelledError();
+    status.SetPayload("abc", absl::Cord("content"));
+    status.SetPayload("def", absl::Cord("content"));
+    return status;
+  }();
+  {
+    const ::testing::Matcher<absl::Status> matcher = StatusHasPayload();
+    EXPECT_THAT(Describe(matcher), "has any payload");
+    EXPECT_THAT(DescribeNegation(matcher), "has no payload");
+    EXPECT_THAT(MatchAndExplain(matcher, absl::OkStatus()), Pair(false, "which has OK status (and no payload)"));
+    EXPECT_THAT(MatchAndExplain(matcher, absl::CancelledError()), Pair(false, "which has no payload"));
+    EXPECT_THAT(MatchAndExplain(matcher, status_url_content), Pair(true, "which has 1 payload"));
+    EXPECT_THAT(MatchAndExplain(matcher, status_abc_content), Pair(true, "which has 2 payloads"));
+  }
+  {
+    const ::testing::Matcher<absl::StatusOr<int>> matcher = StatusHasPayload();
+    EXPECT_THAT(Describe(matcher), "has any payload");
+    EXPECT_THAT(DescribeNegation(matcher), "has no payload");
+  }
+  {
+    const ::testing::Matcher<absl::Status> matcher = StatusHasPayload("url");
+    EXPECT_THAT(Describe(matcher), "has a payload at url 'url'");
+    EXPECT_THAT(DescribeNegation(matcher), "has no payload at url 'url'");
+    EXPECT_THAT(MatchAndExplain(matcher, absl::OkStatus()), Pair(false, "which has OK status (and no payload)"));
+    EXPECT_THAT(MatchAndExplain(matcher, absl::CancelledError()), Pair(false, "which has no payload"));
+    EXPECT_THAT(MatchAndExplain(matcher, status_url_content), Pair(true, "which has a payload at url 'url'"));
+    EXPECT_THAT(MatchAndExplain(matcher, status_url_other), Pair(true, "which has a payload at url 'url'"));
+    EXPECT_THAT(MatchAndExplain(matcher, status_abc_content), Pair(false, "which has 2 payloads"));
+  }
+  {
+    const ::testing::Matcher<absl::Status> matcher = StatusHasPayload("url", "content");
+    EXPECT_THAT(Describe(matcher), "has a payload at url 'url' that is equal to \"content\"");
+    EXPECT_THAT(DescribeNegation(matcher), "has no payload at url 'url' or one that isn't equal to \"content\"");
+    EXPECT_THAT(MatchAndExplain(matcher, absl::OkStatus()), Pair(false, "which has OK status (and no payload)"));
+    EXPECT_THAT(MatchAndExplain(matcher, absl::CancelledError()), Pair(false, "which has no payload"));
+    EXPECT_THAT(MatchAndExplain(matcher, status_url_content), Pair(true, "which has a matching payload at url 'url'"));
+    EXPECT_THAT(
+        MatchAndExplain(matcher, status_url_other), Pair(false, "which has a non-matching payload at url 'url'"));
+    EXPECT_THAT(MatchAndExplain(matcher, status_abc_content), Pair(false, "which has 2 payloads"));
+  }
+  {
+    const ::testing::Matcher<absl::Status> matcher = StatusHasPayload("url", HasSubstr("tent"));
+    EXPECT_THAT(Describe(matcher), "has a payload at url 'url' that has substring \"tent\"");
+    EXPECT_THAT(DescribeNegation(matcher), "has no payload at url 'url' or one that has no substring \"tent\"");
+    EXPECT_THAT(MatchAndExplain(matcher, absl::OkStatus()), Pair(false, "which has OK status (and no payload)"));
+    EXPECT_THAT(MatchAndExplain(matcher, absl::CancelledError()), Pair(false, "which has no payload"));
+    EXPECT_THAT(MatchAndExplain(matcher, status_url_content), Pair(true, "which has a matching payload at url 'url'"));
+    EXPECT_THAT(
+        MatchAndExplain(matcher, status_url_other), Pair(false, "which has a non-matching payload at url 'url'"));
+    EXPECT_THAT(MatchAndExplain(matcher, status_abc_content), Pair(false, "which has 2 payloads"));
+  }
+}
+
+TEST_F(StatusMatcherTest, StatusPayloads) {
+  {
+    EXPECT_THAT(absl::OkStatus(), StatusPayloads(IsEmpty()));
+    absl::Status status = absl::CancelledError();
+    EXPECT_THAT(absl::OkStatus(), StatusPayloads(IsEmpty()));
+    EXPECT_THAT(absl::OkStatus(), StatusPayloads(SizeIs(0)));
+    status.SetPayload("url", absl::Cord("1"));
+    EXPECT_THAT(status, StatusPayloads(SizeIs(1)));
+    EXPECT_THAT(status, StatusPayloads(ElementsAre(Pair("url", "1"))));
+    EXPECT_THAT(status, StatusPayloads(ElementsAre(Not(Pair("bad", "bad")))));
+    EXPECT_THAT(status, StatusPayloads(Not(ElementsAre(Pair("bad", "bad")))));
+    EXPECT_THAT(status, Not(StatusPayloads(ElementsAre(Pair("bad", "bad")))));
+    status.SetPayload("abc", absl::Cord("2"));
+    EXPECT_THAT(status, StatusPayloads(SizeIs(2)));
+    EXPECT_THAT(status, StatusPayloads(ElementsAre(Key("abc"), Key("url"))));
+    EXPECT_THAT(status, StatusPayloads(ElementsAre(Pair("abc", "2"), Pair("url", "1"))));
+    EXPECT_THAT(status, Not(StatusPayloads(ElementsAre(Pair("abc", "2"), Pair("url", "0")))));
+  }
+  {
+    EXPECT_THAT(absl::StatusOr<int>(1), StatusPayloads(IsEmpty()));
+    EXPECT_THAT(absl::StatusOr<int>(absl::CancelledError()), StatusPayloads(IsEmpty()));
+    const absl::StatusOr<int> status_or = [] {
+      absl::Status status = absl::CancelledError();
+      status.SetPayload("url", absl::Cord("content"));
+      return status;
+    }();
+    EXPECT_THAT(status_or, StatusPayloads(ElementsAre(Pair("url", "content"))));
+  }
+}
+
+TEST_F(StatusMatcherTest, MessagesOfStatusPayloads) {
+  const absl::Status status_url_content = [] {
+    absl::Status status = absl::CancelledError();
+    status.SetPayload("url", absl::Cord("content"));
+    return status;
+  }();
+  const absl::Status status_abc_another = [] {
+    absl::Status status = absl::CancelledError();
+    status.SetPayload("abc", absl::Cord("another"));
+    status.SetPayload("url", absl::Cord("content"));
+    return status;
+  }();
+  const absl::Status status_abc_content = [] {
+    absl::Status status = absl::CancelledError();
+    status.SetPayload("abc", absl::Cord("another"));
+    status.SetPayload("def", absl::Cord("texting"));
+    return status;
+  }();
+  {
+    const ::testing::Matcher<absl::Status> matcher = StatusPayloads(IsEmpty());
+    EXPECT_THAT(Describe(matcher), "has a payloads map that is empty");
+    EXPECT_THAT(DescribeNegation(matcher), "has a payloads map that isn't empty");
+    EXPECT_THAT(MatchAndExplain(matcher, absl::OkStatus()), Pair(true, "which has OK status (and no payload)"));
+    EXPECT_THAT(MatchAndExplain(matcher, absl::CancelledError()), Pair(true, "which has no payload"));
+    EXPECT_THAT(
+        MatchAndExplain(matcher, status_url_content),
+        Pair(false, "which has a non-matching payload map whose size is 1"));
+    EXPECT_THAT(
+        MatchAndExplain(matcher, status_abc_content),
+        Pair(false, "which has a non-matching payload map whose size is 2"));
+  }
+  {
+    const ::testing::Matcher<absl::Status> matcher =
+        StatusPayloads(ElementsAre(Pair("abc", "another"), Pair("url", "content")));
+    EXPECT_THAT(
+        Describe(matcher),
+        "has a payloads map that has 2 elements where\n"
+        "element #0 has a first field that is equal to \"abc\", and has a second field that is equal to \"another\",\n"
+        "element #1 has a first field that is equal to \"url\", and has a second field that is equal to \"content\"");
+    EXPECT_THAT(
+        DescribeNegation(matcher),
+        "has a payloads map that doesn't have 2 elements, or\n"
+        "element #0 has a first field that isn't equal to \"abc\", or has a second field that isn't equal to "
+        "\"another\", or\n"
+        "element #1 has a first field that isn't equal to \"url\", or has a second field that isn't equal to "
+        "\"content\"");
+    EXPECT_THAT(MatchAndExplain(matcher, absl::OkStatus()), Pair(false, "which has OK status (and no payload)"));
+    EXPECT_THAT(MatchAndExplain(matcher, absl::CancelledError()), Pair(false, "which has no payload"));
+    EXPECT_THAT(
+        MatchAndExplain(matcher, status_url_content),
+        Pair(false, "which has a non-matching payload map which has 1 element"));
+    EXPECT_THAT(
+        MatchAndExplain(matcher, status_abc_content),
+        Pair(
+            false,
+            "which has a non-matching payload map whose element #1 doesn't match, whose first field does not match"));
+    EXPECT_THAT(
+        MatchAndExplain(matcher, status_abc_another),
+        Pair(
+            true,
+            "which has a matching payload map whose element #0 matches, whose both fields match,\n"
+            "and whose element #1 matches, whose both fields match"));
   }
 }
 

--- a/mbo/testing/status_test.cc
+++ b/mbo/testing/status_test.cc
@@ -305,9 +305,10 @@ TEST_F(StatusMatcherTest, MessagesOfStatusHasPayload) {
 TEST_F(StatusMatcherTest, StatusPayloads) {
   {
     EXPECT_THAT(absl::OkStatus(), StatusPayloads(IsEmpty()));
-    absl::Status status = absl::CancelledError();
-    EXPECT_THAT(absl::OkStatus(), StatusPayloads(IsEmpty()));
     EXPECT_THAT(absl::OkStatus(), StatusPayloads(SizeIs(0)));
+    absl::Status status = absl::CancelledError();
+    EXPECT_THAT(status, StatusPayloads(IsEmpty()));
+    EXPECT_THAT(status, StatusPayloads(SizeIs(0)));
     status.SetPayload("url", absl::Cord("1"));
     EXPECT_THAT(status, StatusPayloads(SizeIs(1)));
     EXPECT_THAT(status, StatusPayloads(ElementsAre(Pair("url", "1"))));


### PR DESCRIPTION
Improved absl::Status related functionality:
* Improved `MBO_RETURN_IF_ERROR` to correctly accept `absl::StatusOr` expressions independently of their implementation.
* Added `mbo::status::StatusBuilder` which allows to modify the message of an `absl::Status`.
* Added `mbo::status::GetStatus` which allows to convert its argument to an `absl::Status` if supported.
* Added macro `MBO_MOVE_TO_OR_RETURN` which can assign to structured binadings and other complex types.
* Added macro `MBO_ASSERT_OK_AND_ASSIGN_TO` which can assign to structured binadings and other complex types.
* Added matcher `mbo::testing::StatusHasPayload` that matches presence of any, a specific payload url, or a payload url with specific content.
* Added matcher `mbo::testing::StatusPayloads` that matches against `Status`/`StatusOr<>` payload maps.