### PR TITLE
Naming consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Added `mbo::status::StatusBuilder` which allows to modify the message of an `absl::Status`.
 * Added `mbo::status::GetStatus` which allows to convert its argument to an `absl::Status` if supported.
 * Added macro `MBO_MOVE_TO_OR_RETURN` which can assign to structured binadings and other complex types.
-* Added macro `MBO_ASSERT_OK_AND_ASSIGN_TO` which can assign to structured binadings and other complex types.
+* Added macro `MBO_ASSERT_OK_AND_MOVE_TO` which can assign to structured binadings and other complex types.
 * Added matcher `mbo::testing::StatusHasPayload` that matches presence of any, a specific payload url, or a payload url with specific content.
 * Added matcher `mbo::testing::StatusPayloads` that matches against `Status`/`StatusOr<>` payload maps.
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The C++ library is organized in functional groups each residing in their own dir
         * gmock-matcher `StatusHasPayload`: Tests whether an `absl::Status` or `absl::StatusOr` payload map has any payload, a specific payload url, or a payload url with specific content.
         * gmock-matcher `StatusPayloads` Tests whether an `absl::Status` or `absl::StatusOr` payload map matches.
         * macro `MBO_ASSERT_OK_AND_ASSIGN`: Simplifies testing with functions that return `absl::StatusOr<T>`.
-        * macro `MBO_ASSERT_OK_AND_ASSIGN_TO`: Simplifies testing with functions that return `absl::StatusOr<T>` where the result requires commas, in particular structured bindings.
+        * macro `MBO_ASSERT_OK_AND_MOVE_TO`: Simplifies testing with functions that return `absl::StatusOr<T>` where the result requires commas, in particular structured bindings.
 * Types
     * `namespace mbo::types`
     * mbo/types:cases_cc, mbo/types/cases.h

--- a/mbo/testing/status.h
+++ b/mbo/testing/status.h
@@ -441,7 +441,7 @@ inline ::testing::PolymorphicMatcher<testing_internal::StatusPayloads> StatusPay
 
 #undef MBO_PRIVATE_TESTING_STATUS_ASSERT_OK_AND_ASSIGN_
 #undef MBO_ASSERT_OK_AND_ASSIGN
-#undef MBO_ASSERT_OK_AND_ASSIGN_TO
+#undef MBO_ASSERT_OK_AND_MOVE_TO
 
 // PRIVATE macro, do not use.
 #define MBO_PRIVATE_TESTING_STATUS_ASSERT_OK_AND_ASSIGN_(statusor, expression, ...) \
@@ -452,19 +452,19 @@ inline ::testing::PolymorphicMatcher<testing_internal::StatusPayloads> StatusPay
 // Macro that verifies `expression` is OK and assigns its `value` by move to `targets`, where target
 // can be a declaration. Example:
 // ```
-// ASSERT_OK_OR_ASSIGN(const std::string result, StringOrStatus());
+// MBO_ASSERT_OK_AND_ASSIGN(const std::string result, StringOrStatus());
 // ```
 #define MBO_ASSERT_OK_AND_ASSIGN(target, expression) \
   MBO_PRIVATE_TESTING_STATUS_ASSERT_OK_AND_ASSIGN_(  \
       MBO_PRIVATE_TESTING_STATUS_CONCAT_(_status_or_value, __LINE__), expression, target)
 
-// Variant of `ASSERT_OK_OR_ASSIGN` that allows to assign to complex types, in particular to
+// Variant of `MBO_ASSERT_OK_AND_ASSIGN` that allows to assign to complex types, in particular to
 // structured bindings. Example:
 // ```
-// ASSERT_OK_AND_ASSIGN_TO(PairOrStatus(), const auto [first, second]);
+// MBO_ASSERT_OK_AND_MOVE_TO(PairOrStatus(), const auto [first, second]);
 // ```
-#define MBO_ASSERT_OK_AND_ASSIGN_TO(expression, ...) \
-  MBO_PRIVATE_TESTING_STATUS_ASSERT_OK_AND_ASSIGN_(  \
+#define MBO_ASSERT_OK_AND_MOVE_TO(expression, ...)  \
+  MBO_PRIVATE_TESTING_STATUS_ASSERT_OK_AND_ASSIGN_( \
       MBO_PRIVATE_TESTING_STATUS_CONCAT_(_status_or_value, __LINE__), expression, __VA_ARGS__)
 
 #ifndef ASSERT_OK_AND_ASSIGN

--- a/mbo/testing/status_test.cc
+++ b/mbo/testing/status_test.cc
@@ -205,7 +205,7 @@ TEST_F(StatusMatcherTest, AssertOkAndAssign) {
 
 TEST_F(StatusMatcherTest, AssertOkAndAssignTo) {
   absl::StatusOr<std::pair<int, int>> status_or(std::make_pair(25, 17));
-  MBO_ASSERT_OK_AND_ASSIGN_TO(status_or, auto [first, second]);
+  MBO_ASSERT_OK_AND_MOVE_TO(status_or, auto [first, second]);
   EXPECT_THAT(std::make_pair(first, second), Pair(25, 17));
 }
 


### PR DESCRIPTION
Change `MBO_ASSERT_OK_AND_ASSIGN_TO` to `MBO_ASSERT_OK_AND_MOVE_TO` to match `MBO_MOVE_TO_OR_RETURN`.