### PR TITLE
* Added custom Bazel flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 0.2.34
 
 * Added `mbo::testing::WhenTransformedBy` which allows to compare containers after transforming them.
+* Added custom Bazel flag `--//mbo/config:require_throws` which controls whether `MBO_CONFIG_REQUIRE` throw exceptions or use crash logging (the default `False` or `0`). This mostly affects containers.
+* Added custom Bazel flag `--//mbo/config:limited_ordered_max_unroll_capacity`. This was undocumented as `--//mbo/container:limited_ordered_max_unroll_capacity` until now. It controls the maximum unroll size for LimitedOrdered/Map/Set.
 
 # 0.2.33
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ The library is tested with Clang and GCC using continuous integration: [![Test](
 
 The C++ library is organized in functional groups each residing in their own directory.
 
+* Config
+    * `namespace mbo::config`
+    * mbo/config:config_cc, mbo/config/config.h
+        * Custom Bazel flag `--//mbo/config:limited_ordered_max_unroll_capacity` which controls the maximum unroll size for `LimitedOrdered` and thus `LimitedMap` and `LimitedSet`.
+        * Custom Bazel flag `--//mbo/config:require_throws` which controls whether `MBO_CONFIG_REQUIRE` throw exceptions or use crash logging (the default `False` or `0`). This mostly affects containers.
+    * mbo/config:require_cc, mbo/config/require.h
+        * Marcos `MBO_CONFIG_REQUIRE(condition, message)` which allows to check a `condition` and either throw an exception or crash with Abseil FATAL logging. The behavior is controlled by `--//mbo/config:require_throws`.
 * Container
     * `namespace mbo::container`
     * mbo/container:any_scan_cc, mbo/container/any_scan.h

--- a/RULES.md
+++ b/RULES.md
@@ -54,3 +54,5 @@ Some rules for the code layout and its development.
 * Flags in libraries should be prefixed with their path/namespace. E.g. the flag
   `--mbo_log_timing_min_duration` has the prefix `mbo_log` as it is defined in
   `mbo/log/log_timing.cc` (path `mbo/log`) and uses namespace `mbo::log`.
+* API changes that are not backwards compatible should not occur in minor version changes.
+* Undocumented and private/internal APIs may be changed in any way at any time.

--- a/mbo/config/BUILD.bazel
+++ b/mbo/config/BUILD.bazel
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "int_flag")
+load(":internal/config.bzl", "config_gen")
+
+# Create custom bazel flag `--//mbo/container:limited_ordered_max_unroll_capacity`.
+int_flag(
+    name = "limited_ordered_max_unroll_capacity",
+    build_setting_default = 16,
+    visibility = ["//visibility:private"],
+)
+
+# Create custom bazel flag `--//mbo/config:require_throws`.
+bool_flag(
+    name = "require_throws",
+    build_setting_default = False,
+    visibility = ["//visibility:private"],
+)
+
+bzl_library(
+    name = "config_bzl",
+    srcs = [":internal/config.bzl"],
+    visibility = ["//visibility:private"],
+    deps = ["@bazel_skylib//rules:common_settings"],
+)
+
+config_gen(
+    name = "config_gen",
+    visibility = ["//visibility:private"],
+    output = "config.h",
+    template = "internal/config.h.in",
+)
+
+cc_library(
+    name = "config_cc",
+    hdrs = ["config.h"],
+    visibility = ["//mbo:__subpackages__"],
+)
+
+cc_library(
+    name = "require_cc",
+    hdrs = ["require.h"],
+    deps = [
+        ":config_cc",
+        "@com_google_absl//absl/log:absl_log",
+    ],
+    visibility = ["//mbo:__subpackages__"],
+)

--- a/mbo/config/internal/config.bzl
+++ b/mbo/config/internal/config.bzl
@@ -17,17 +17,19 @@
 
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 
-def _limited_ordered_config_gen_impl(ctx):
+def _config_gen_impl(ctx):
     limited_ordered_max_unroll_capacity = ctx.attr._limited_ordered_max_unroll_capacity[BuildSettingInfo].value
+    require_throws = ctx.attr._require_throws[BuildSettingInfo].value
     ctx.actions.expand_template(
         template = ctx.file.template,
         output = ctx.outputs.output,
         substitutions = {
             "kUnrollMaxCapacityDefault = 16;": "kUnrollMaxCapacityDefault = " + repr(limited_ordered_max_unroll_capacity) + ";",
+            "kRequireThrows = false;": "kRequireThrows = " + repr(require_throws).lower() + ";",
         },
     )
 
-limited_ordered_config_gen = rule(
+config_gen = rule(
     attrs = {
         "output": attr.output(
             mandatory = True,
@@ -36,7 +38,8 @@ limited_ordered_config_gen = rule(
             allow_single_file = True,
             mandatory = True,
         ),
-        "_limited_ordered_max_unroll_capacity": attr.label(default = Label("//mbo/container:limited_ordered_max_unroll_capacity")),
+        "_limited_ordered_max_unroll_capacity": attr.label(default = Label("//mbo/config:limited_ordered_max_unroll_capacity")),
+        "_require_throws": attr.label(default = Label("//mbo/config:require_throws")),
     },
-    implementation = _limited_ordered_config_gen_impl,
+    implementation = _config_gen_impl,
 )

--- a/mbo/config/internal/config.h.in
+++ b/mbo/config/internal/config.h.in
@@ -18,7 +18,7 @@
 
 #include <cstddef>
 
-namespace mbo::container::container_internal {
+namespace mbo::config {
 
 // The maximum unroll capacity for `LimitedOrdered` based containers: `LimitedSet` and `LimitedMap`.
 // Beyond unrolling 32 comparison steps, unrolling has deminishing returns for any architecture.
@@ -33,6 +33,12 @@ namespace mbo::container::container_internal {
 // `--@com_helly_25//mbo/container:limited_ordered_max_unroll_capacity`.
 static constexpr std::size_t kUnrollMaxCapacityDefault = 16;
 
-}  // namespace mbo::container::container_internal
+// Config macro `MBO_CONFIG_REQUIRE_THROWS` controls whether container requirement violations
+// result in throwing a `std::runtime_error` or a `ABSL_LOG_IF` (the latter (0) being the default).
+//
+// When exceptions are used then the affected functions cannot be declared `noexcept`.
+static constexpr bool kRequireThrows = false;
+
+}  // namespace mbo::config
 
 #endif  // MBO_CONTAINER_INTERNAL_LIMITED_ORDERED_CONFIG_H_

--- a/mbo/config/require.h
+++ b/mbo/config/require.h
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MBO_CONTAINER_INTERNAL_REQUIRE_H_
+#define MBO_CONTAINER_INTERNAL_REQUIRE_H_
+
+#include <stdexcept>  // IWYU pragma: keep
+
+#include "absl/log/absl_log.h"  // IWYU pragma: keep
+
+// If `mbo/config/config.h` is available, then include that. In order to
+// make indexers work, we also include the generator "...in" as a fallback.
+#if __has_include("mbo/config/config.h")
+# include "mbo/config/config.h"  // IWYU pragma: keep
+#else
+# include "mbo/config/internal/config.h.in"  // IWYU pragma: keep
+#endif
+
+// NOLINTBEGIN(cppcoreguidelines-macro-usage)
+
+#define MBO_PRIVATE_CONFIG_CAT_CAT_(line) #line
+#define MBO_PRIVATE_CONFIG_NUM2STR_(line) MBO_PRIVATE_CONFIG_CAT_CAT_(line)
+
+#ifdef MBO_CONFIG_REQUIRE
+# undef MBO_CONFIG_REQUIRE
+#endif
+
+#define MBO_CONFIG_REQUIRE(condition, message)                 \
+  if constexpr (!::mbo::config::kRequireThrows) {              \
+    /* NOLINTNEXTLINE(bugprone-switch-missing-default-case) */ \
+    ABSL_LOG_IF(FATAL, !(condition)) << message;               \
+  } else if ((condition)) { /* GOOD */                         \
+  } else                                                       \
+    throw std::runtime_error(__FILE__ ":" MBO_PRIVATE_CONFIG_NUM2STR_(__LINE__) " : " #condition " : " message)
+
+// NOLINTEND(cppcoreguidelines-macro-usage)
+
+#endif  // MBO_CONTAINER_INTERNAL_REQUIRE_H_

--- a/mbo/container/BUILD.bazel
+++ b/mbo/container/BUILD.bazel
@@ -111,6 +111,8 @@ cc_test(
     srcs = ["limited_ordered_test.cc"],
     deps = [
         ":limited_ordered_cc",
+        "//mbo/config:config_cc",
+        "//mbo/config:require_cc",
         "//mbo/testing:matchers_cc",
         "@com_google_absl//absl/log:initialize",
         "@com_google_googletest//:gtest_main",

--- a/mbo/container/BUILD.bazel
+++ b/mbo/container/BUILD.bazel
@@ -13,31 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@bazel_skylib//rules:common_settings.bzl", "int_flag")
-load(":internal/limited_ordered_config.bzl", "limited_ordered_config_gen")
-
-# Create custom bazel flag `--//mbo/container:limited_ordered_max_unroll_capacity`.
-int_flag(
-    name = "limited_ordered_max_unroll_capacity",
-    build_setting_default = 16,
-    visibility = ["//visibility:private"],
-)
-
-bzl_library(
-    name = "limited_ordered_config_bzl",
-    srcs = [":internal/limited_ordered_config.bzl"],
-    visibility = ["//visibility:private"],
-    deps = ["@bazel_skylib//rules:common_settings"],
-)
-
-limited_ordered_config_gen(
-    name = "limited_ordered_config_gen",
-    visibility = ["//visibility:private"],
-    output = "internal/limited_ordered_config.h",
-    template = "internal/limited_ordered_config.h.in"
-)
-
 cc_library(
     name = "any_scan_cc",
     hdrs = ["any_scan.h"],
@@ -118,13 +93,12 @@ cc_library(
 
 cc_library(
     name = "limited_ordered_cc",
-    hdrs = [
-      "internal/limited_ordered_config.h",
-      "internal/limited_ordered.h",
-    ],
+    hdrs = ["internal/limited_ordered.h"],
     visibility = ["//visibility:private"],
     deps = [
         ":limited_options_cc",
+        "//mbo/config:config_cc",
+        "//mbo/config:require_cc",
         "//mbo/types:compare_cc",
         "//mbo/types:traits_cc",
         "@com_google_absl//absl/log:absl_log",
@@ -189,6 +163,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":limited_options_cc",
+        "//mbo/config:require_cc",
         "//mbo/types:traits_cc",
         "@com_google_absl//absl/log:absl_log",
     ],

--- a/mbo/container/internal/limited_ordered.h
+++ b/mbo/container/internal/limited_ordered.h
@@ -25,18 +25,12 @@
 #include <type_traits>
 #include <utility>
 
-#include "absl/log/absl_log.h"
+#include "absl/log/absl_log.h"  // IWYU pragma: keep
+#include "mbo/config/config.h"
+#include "mbo/config/require.h"
 #include "mbo/container/limited_options.h"  // IWYU pragma: export
 #include "mbo/types/compare.h"              // IWYU pragma: export
 #include "mbo/types/traits.h"
-
-// If `mbo/container/internal/limited_ordered_config.h` is available, then include that. In order to
-// make indexers work, we also include the generator "...in" as a fallback.
-#if __has_include("mbo/container/internal/limited_ordered_config.h")
-# include "mbo/container/internal/limited_ordered_config.h"
-#else
-# include "mbo/container/internal/limited_ordered_config.h.in"
-#endif
 
 #ifdef MBO_FORCE_INLINE
 # undef MBO_FORCE_INLINE
@@ -51,15 +45,6 @@
 #define MBO_ALWAYS_INLINE __attribute__((always_inline))
 
 namespace mbo::container::container_internal {
-
-#ifdef LV_REQUIRE
-# undef LV_REQUIRE
-#endif
-
-// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define LV_REQUIRE(severity, condition)                      \
-  /* NOLINTNEXTLINE(bugprone-switch-missing-default-case) */ \
-  ABSL_LOG_IF(severity, !(condition))
 
 // NOLINTBEGIN(readability-identifier-naming)
 
@@ -89,11 +74,13 @@ class LimitedOrdered {
   static constexpr bool kOptimizeIndexOf = !Options::Has(LimitedOptionsFlag::kNoOptimizeIndexOf);
   static constexpr bool kCustomIndexOfBeyondUnroll = Options::Has(LimitedOptionsFlag::kCustomIndexOfBeyondUnroll);
 
-  static constexpr std::size_t kUnrollMaxCapacityLimit = 32;                    // The maximum supported in code.
-  static constexpr std::size_t kUnrollMaxCapacity = kUnrollMaxCapacityDefault;  // MUST MATCH `index_of`.
+  static constexpr std::size_t kUnrollMaxCapacityLimit = 32;  // The maximum supported in code.
+  static constexpr std::size_t kUnrollMaxCapacity = ::mbo::config::kUnrollMaxCapacityDefault;  // MUST MATCH `index_of`.
   static_assert(
       kUnrollMaxCapacity >= 4 && kUnrollMaxCapacity <= kUnrollMaxCapacityLimit,
-      "Check documentation for `mbo::container::container_internal::kUnrollMaxCapacityDefault`.");
+      "Check documentation for `::mbo::config::kUnrollMaxCapacityDefault`.");
+
+  static constexpr bool kRequireThrows = ::mbo::config::kRequireThrows;
 
   // Must declare each other as friends so that we can correctly move from other.
   template<typename OK, typename OM, typename OV, auto OtherN, typename Comp>
@@ -429,10 +416,11 @@ class LimitedOrdered {
 
   template<std::forward_iterator It>
   requires std::constructible_from<Value, mbo::types::ForwardIteratorValueType<It>>
-  constexpr LimitedOrdered(It first, It last, const Compare& key_comp = Compare()) noexcept : key_comp_(key_comp) {
+  constexpr LimitedOrdered(It first, It last, const Compare& key_comp = Compare()) noexcept(!kRequireThrows)
+      : key_comp_(key_comp) {
 #ifndef NDEBUG
     if constexpr (Options::Has(LimitedOptionsFlag::kRequireSortedInput)) {
-      LV_REQUIRE(FATAL, std::is_sorted(first, last, key_comp_));
+      MBO_CONFIG_REQUIRE(std::is_sorted(first, last, key_comp_), "Flag `kRequireSortedInput` violated.");
     }
 #endif  // NDEBUG
     while (first < last) {
@@ -782,13 +770,13 @@ class LimitedOrdered {
   }
 
   template<typename... Args>
-  constexpr std::pair<iterator, bool> emplace(Args&&... args) noexcept {
+  constexpr std::pair<iterator, bool> emplace(Args&&... args) noexcept(!kRequireThrows) {
     Value new_val(std::forward<Args>(args)...);
     const iterator dst = lower_bound(GetKey(new_val));
     if (dst != end() && !key_comp_(GetKey(*dst), GetKey(new_val)) && !key_comp_(GetKey(new_val), GetKey(*dst))) {
       return std::make_pair(dst, false);
     }
-    LV_REQUIRE(FATAL, size_ < Capacity) << "Called `emplace` at capacity.";
+    MBO_CONFIG_REQUIRE(size_ < Capacity, "Called `emplace` at capacity.");
     for (iterator next = end(); next > dst; --next) {
       std::construct_at(&*next, std::move(*std::prev(next)));
     }
@@ -799,8 +787,8 @@ class LimitedOrdered {
 
   template<typename It>
   requires IsIterator<It>::value
-  constexpr iterator erase(It pos) noexcept {
-    LV_REQUIRE(FATAL, begin() <= pos && pos < end()) << "Invalid `pos`";
+  constexpr iterator erase(It pos) noexcept(!kRequireThrows) {
+    MBO_CONFIG_REQUIRE(begin() <= pos && pos < end(), "Invalid `pos`.");
     auto dst = to_iterator(pos);
     --size_;
     std::destroy_at(&*dst);
@@ -810,8 +798,8 @@ class LimitedOrdered {
     return pos > end() ? end() : to_iterator(pos);
   }
 
-  constexpr iterator erase(const_iterator first, const_iterator last) noexcept {
-    LV_REQUIRE(FATAL, begin() <= first && first <= last && last <= end()) << "Invalid `first` or `last`";
+  constexpr iterator erase(const_iterator first, const_iterator last) noexcept(!kRequireThrows) {
+    MBO_CONFIG_REQUIRE(begin() <= first && first <= last && last <= end(), "Invalid `first` or `last`.");
     std::size_t deleted = 0;
     for (const_iterator it = first; it < last; ++it) {
       std::destroy_at(it);
@@ -876,7 +864,7 @@ class LimitedOrdered {
       dst->second = Mapped(args...);
       return std::make_pair(dst, false);
     }
-    LV_REQUIRE(FATAL, size_ < Capacity) << "Called `try_emplace` at capacity.";
+    MBO_CONFIG_REQUIRE(size_ < Capacity, "Called `try_emplace` at capacity.");
     for (iterator next = end(); next > dst; --next) {
       std::construct_at(&*next, std::move(*std::prev(next)));
     }
@@ -895,7 +883,7 @@ class LimitedOrdered {
       dst->second = Mapped(args...);
       return std::make_pair(dst, false);
     }
-    LV_REQUIRE(FATAL, size_ < Capacity) << "Called `try_emplace` at capacity.";
+    MBO_CONFIG_REQUIRE(size_ < Capacity, "Called `try_emplace` at capacity.");
     for (iterator next = end(); next > dst; --next) {
       std::construct_at(&*next, std::move(*std::prev(next)));
     }
@@ -914,7 +902,7 @@ class LimitedOrdered {
       dst->second = std::forward<V>(value);
       return std::make_pair(dst, false);
     }
-    LV_REQUIRE(FATAL, size_ < Capacity) << "Called `insert_or_assign` at capacity.";
+    MBO_CONFIG_REQUIRE(size_ < Capacity, "Called `insert_or_assign` at capacity.");
     for (iterator next = end(); next > dst; --next) {
       std::construct_at(&*next, std::move(*std::prev(next)));
     }
@@ -931,7 +919,7 @@ class LimitedOrdered {
       dst->second = std::forward<V>(value);
       return std::make_pair(dst, false);
     }
-    LV_REQUIRE(FATAL, size_ < Capacity) << "Called `emplace` at capacity.";
+    MBO_CONFIG_REQUIRE(size_ < Capacity, "Called `emplace` at capacity.");
     for (iterator next = end(); next > dst; --next) {
       std::construct_at(&*next, std::move(*std::prev(next)));
     }
@@ -1023,8 +1011,6 @@ class LimitedOrdered {
 };
 
 // NOLINTEND(readability-identifier-naming)
-
-#undef LV_REQUIRE
 
 }  // namespace mbo::container::container_internal
 

--- a/mbo/container/internal/limited_ordered.h
+++ b/mbo/container/internal/limited_ordered.h
@@ -26,7 +26,6 @@
 #include <utility>
 
 #include "absl/log/absl_log.h"  // IWYU pragma: keep
-#include "mbo/config/config.h"
 #include "mbo/config/require.h"
 #include "mbo/container/limited_options.h"  // IWYU pragma: export
 #include "mbo/types/compare.h"              // IWYU pragma: export
@@ -61,7 +60,7 @@ concept LimitedOrderedValid =  //
 
 template<typename Key, typename Mapped, typename Value, auto options, typename Compare = std::less<Key>>
 requires(LimitedOrderedValid<Key, Mapped, Value>)
-class LimitedOrdered {
+class [[nodiscard]] LimitedOrdered {
  protected:
   static constexpr bool kKeyOnly = std::same_as<Key, Value>;  // true = set, false = map (of pairs).
 
@@ -418,11 +417,9 @@ class LimitedOrdered {
   requires std::constructible_from<Value, mbo::types::ForwardIteratorValueType<It>>
   constexpr LimitedOrdered(It first, It last, const Compare& key_comp = Compare()) noexcept(!kRequireThrows)
       : key_comp_(key_comp) {
-#ifndef NDEBUG
     if constexpr (Options::Has(LimitedOptionsFlag::kRequireSortedInput)) {
       MBO_CONFIG_REQUIRE(std::is_sorted(first, last, key_comp_), "Flag `kRequireSortedInput` violated.");
     }
-#endif  // NDEBUG
     while (first < last) {
       if constexpr (Options::Has(LimitedOptionsFlag::kRequireSortedInput)) {
         std::construct_at(&values_[size_++].data, *first);

--- a/mbo/container/limited_map.h
+++ b/mbo/container/limited_map.h
@@ -25,15 +25,11 @@
 #include <type_traits>
 #include <utility>
 
-#include "absl/log/absl_log.h"
 #include "mbo/container/internal/limited_ordered.h"
 #include "mbo/types/compare.h"
 #include "mbo/types/traits.h"
 
 namespace mbo::container {
-
-// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define LV_REQUIRE(severity, condition) ABSL_LOG_IF(severity, !(condition))
 
 // NOLINTBEGIN(readability-identifier-naming)
 
@@ -385,8 +381,6 @@ constexpr auto ToLimitedMap(std::pair<K, V> (&&array)[N], const KComp& key_comp 
 // NOLINTEND(*-avoid-c-arrays)
 
 // NOLINTEND(readability-identifier-naming)
-
-#undef LV_REQUIRE
 
 }  // namespace mbo::container
 

--- a/mbo/container/limited_ordered_test.cc
+++ b/mbo/container/limited_ordered_test.cc
@@ -23,7 +23,7 @@
 #include "absl/log/initialize.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "mbo/config/config.h"
+#include "mbo/config/require.h"  // IWYU pragma: keep
 #include "mbo/testing/matchers.h"
 
 namespace mbo::container {
@@ -95,16 +95,21 @@ TEST_F(LimitedOrderedTest, ConstexprRequireSortedInput) {
   EXPECT_THAT(kTest, ElementsAre(1, 2, 3));
 }
 
-TEST_F(LimitedOrderedTest, ConstexprRequireSortedInputThrows) {
+void DoTestConstexprRequireSortedInputThrows() {
+  constexpr auto kOptions = LimitedOptions<3, LimitedOptionsFlag::kRequireSortedInput>{};
   const std::vector<int> v{1, 3, 2};
+  const auto container = LimitedOrdered<int, int, int, kOptions>{v.begin(), v.end()};
+  EXPECT_THAT(container, SizeIs(3));
+}
+
+TEST_F(LimitedOrderedTest, ConstexprRequireSortedInputThrows) {
   if constexpr (kRequireThrows) {
     bool caught = false;
     try {
       // Passing the value list direvtly into the constructor of `LimitedOrdered` results in a compile time exception.
       // That exception cannot be tested here, so the values are being passed at run-time using a vector. That allows
       // to catch and examine the excption.
-      (void)LimitedOrdered<int, int, int, LimitedOptions<3, LimitedOptionsFlag::kRequireSortedInput>{}>{
-          v.begin(), v.end()};
+      DoTestConstexprRequireSortedInputThrows();
     } catch (const std::runtime_error& error) {
       caught = true;
       EXPECT_THAT(error.what(), ::testing::HasSubstr("std::is_sorted(first, last, key_comp_)"));
@@ -113,10 +118,7 @@ TEST_F(LimitedOrderedTest, ConstexprRequireSortedInputThrows) {
     }
     ASSERT_TRUE(caught);
   } else {
-    ASSERT_DEATH(
-        ((void)LimitedOrdered<int, int, int, LimitedOptions<3, LimitedOptionsFlag::kRequireSortedInput>{}>{
-            v.begin(), v.end()}),
-        "Flag `kRequireSortedInput` violated.");
+    ASSERT_DEATH(DoTestConstexprRequireSortedInputThrows(), "Flag `kRequireSortedInput` violated.");
   }
 }
 

--- a/mbo/container/limited_ordered_test.cc
+++ b/mbo/container/limited_ordered_test.cc
@@ -23,6 +23,7 @@
 #include "absl/log/initialize.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "mbo/config/config.h"
 #include "mbo/testing/matchers.h"
 
 namespace mbo::container {
@@ -30,6 +31,7 @@ namespace {
 
 // NOLINTBEGIN(*-magic-numbers)
 
+using ::mbo::config::kRequireThrows;
 using ::mbo::container::container_internal::LimitedOrdered;
 using ::mbo::testing::CapacityIs;
 using ::testing::ElementsAre;
@@ -86,11 +88,36 @@ TEST_F(LimitedOrderedTest, ConstexprNoDtor) {
 
 TEST_F(LimitedOrderedTest, ConstexprRequireSortedInput) {
   static constexpr auto kTest =
-      LimitedOrdered<int, int, int, LimitedOptions<3, LimitedOptionsFlag::kRequireSortedInput>{}>{};
-  EXPECT_THAT(kTest, IsEmpty());
-  EXPECT_THAT(kTest, SizeIs(0));
+      LimitedOrdered<int, int, int, LimitedOptions<3, LimitedOptionsFlag::kRequireSortedInput>{}>{1, 2, 3};
+  EXPECT_THAT(kTest, Not(IsEmpty()));
+  EXPECT_THAT(kTest, SizeIs(3));
   EXPECT_THAT(kTest, CapacityIs(3));
-  EXPECT_THAT(kTest, ElementsAre());
+  EXPECT_THAT(kTest, ElementsAre(1, 2, 3));
+}
+
+TEST_F(LimitedOrderedTest, ConstexprRequireSortedInputThrows) {
+  const std::vector<int> v{1, 3, 2};
+  if constexpr (kRequireThrows) {
+    bool caught = false;
+    try {
+      // Passing the value list direvtly into the constructor of `LimitedOrdered` results in a compile time exception.
+      // That exception cannot be tested here, so the values are being passed at run-time using a vector. That allows
+      // to catch and examine the excption.
+      (void)LimitedOrdered<int, int, int, LimitedOptions<3, LimitedOptionsFlag::kRequireSortedInput>{}>{
+          v.begin(), v.end()};
+    } catch (const std::runtime_error& error) {
+      caught = true;
+      EXPECT_THAT(error.what(), ::testing::HasSubstr("std::is_sorted(first, last, key_comp_)"));
+    } catch (...) {
+      ADD_FAILURE() << "Wrong exception type.";
+    }
+    ASSERT_TRUE(caught);
+  } else {
+    ASSERT_DEATH(
+        ((void)LimitedOrdered<int, int, int, LimitedOptions<3, LimitedOptionsFlag::kRequireSortedInput>{}>{
+            v.begin(), v.end()}),
+        "Flag `kRequireSortedInput` violated.");
+  }
 }
 
 // NOLINTEND(*-magic-numbers)

--- a/mbo/container/limited_set.h
+++ b/mbo/container/limited_set.h
@@ -25,15 +25,11 @@
 #include <type_traits>
 #include <utility>
 
-#include "absl/log/absl_log.h"
 #include "mbo/container/internal/limited_ordered.h"  // IWYU pragma: export
 #include "mbo/types/compare.h"                       // IWYU pragma: keep
 #include "mbo/types/traits.h"
 
 namespace mbo::container {
-
-// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define LV_REQUIRE(severity, condition) ABSL_LOG_IF(severity, !(condition))
 
 // NOLINTBEGIN(readability-identifier-naming)
 
@@ -297,8 +293,6 @@ constexpr LimitedSet<std::remove_cvref_t<Key>, N, Compare> ToLimitedSet(
 // NOLINTEND(*-avoid-c-arrays)
 
 // NOLINTEND(readability-identifier-naming)
-
-#undef LV_REQUIRE
 
 }  // namespace mbo::container
 

--- a/mbo/log/log_timing_test.cc
+++ b/mbo/log/log_timing_test.cc
@@ -131,8 +131,8 @@ TEST_F(LogTimingTest, LogFormat) {
           {")", "\\)"},
       });
   Sequence sequence;
-  const std::string expected_log1 = absl::StrFormat(".*LogTiming\\([0-9:.]+[mnu]s @ (%s)*\\)$", function);
-  const std::string expected_log2 = absl::StrFormat(".*LogTiming\\([0-9:.]+[mnu]s @ (%s)*\\): Foo$", function);
+  const std::string expected_log1 = absl::StrFormat(".*LogTiming\\(([0-9:.]+[mnu]s|0) @ (%s)*\\)$", function);
+  const std::string expected_log2 = absl::StrFormat(".*LogTiming\\(([0-9:.]+[mnu]s|0) @ (%s)*\\): Foo$", function);
   ExpectLogConst(absl::LogSeverity::kInfo, ContainsRegex(expected_log1)).Times(1).InSequence(sequence);
   ExpectLogConst(absl::LogSeverity::kInfo, ContainsRegex(expected_log2)).Times(1).InSequence(sequence);
   (void)LogTiming();  // Manually discarding the result means, this one logs immediately.

--- a/mbo/testing/matchers_test.cc
+++ b/mbo/testing/matchers_test.cc
@@ -29,7 +29,6 @@ namespace {
 
 // NOLINTBEGIN(*-magic-numbers)
 
-using ::testing::_;
 using ::testing::ElementsAre;
 using ::testing::Ge;
 using ::testing::IsEmpty;


### PR DESCRIPTION
* Added custom Bazel flag `--//mbo/config:require_throws` which controls whether `MBO_CONFIG_REQUIRE` throw exceptions or use crash logging (the default `False` or `0`). This mostly affects containers.
* Added custom Bazel flag `--//mbo/config:limited_ordered_max_unroll_capacity`. This was undocumented as `--//mbo/container:limited_ordered_max_unroll_capacity` until now. It controls the maximum unroll size for LimitedOrdered/Map/Set.
