### PR TITLE
If `MBO_CONFIG_REQUIRE` throws, then explicitly call out the condition as a requirement.

### DIFF
--- a/mbo/config/require.h
+++ b/mbo/config/require.h
@@ -37,13 +37,14 @@
 # undef MBO_CONFIG_REQUIRE
 #endif
 
-#define MBO_CONFIG_REQUIRE(condition, message)                 \
-  if constexpr (!::mbo::config::kRequireThrows) {              \
-    /* NOLINTNEXTLINE(bugprone-switch-missing-default-case) */ \
-    ABSL_LOG_IF(FATAL, !(condition)) << message;               \
-  } else if ((condition)) { /* GOOD */                         \
-  } else                                                       \
-    throw std::runtime_error(__FILE__ ":" MBO_PRIVATE_CONFIG_NUM2STR_(__LINE__) " : " #condition " : " message)
+#define MBO_CONFIG_REQUIRE(condition, message)                                                             \
+  if constexpr (!::mbo::config::kRequireThrows) {                                                          \
+    /* NOLINTNEXTLINE(bugprone-switch-missing-default-case) */                                             \
+    ABSL_LOG_IF(FATAL, !(condition)) << message;                                                           \
+  } else if ((condition)) { /* GOOD */                                                                     \
+  } else                                                                                                   \
+    throw std::runtime_error(__FILE__ ":" MBO_PRIVATE_CONFIG_NUM2STR_(__LINE__) " : Required (" #condition \
+                                                                                ") : " message)
 
 // NOLINTEND(cppcoreguidelines-macro-usage)
 

--- a/mbo/container/limited_ordered_test.cc
+++ b/mbo/container/limited_ordered_test.cc
@@ -112,7 +112,7 @@ TEST_F(LimitedOrderedTest, ConstexprRequireSortedInputThrows) {
       DoTestConstexprRequireSortedInputThrows();
     } catch (const std::runtime_error& error) {
       caught = true;
-      EXPECT_THAT(error.what(), ::testing::HasSubstr("std::is_sorted(first, last, key_comp_)"));
+      EXPECT_THAT(error.what(), ::testing::HasSubstr("Required (std::is_sorted(first, last, key_comp_))"));
     } catch (...) {
       ADD_FAILURE() << "Wrong exception type.";
     }


### PR DESCRIPTION
If `MBO_CONFIG_REQUIRE` throws, then explicitly call out the condition as a requirement.