### PR TITLE
Add ability to retrieve field names for structs without default constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.35
+
+* Added ability to retrieve field names for structs without default constructor (e.g. due to reference fields).
+
 # 0.2.34
 
 * Added `mbo::types::Required` which is similar to `RefWrap` but stores the actual type (and unlike `std::optional` cannot be reset).

--- a/mbo/types/internal/struct_names_test.cc
+++ b/mbo/types/internal/struct_names_test.cc
@@ -58,11 +58,21 @@ struct Two {
 static_assert(SupportsFieldNames<Two>);
 static_assert(TestGetFieldNames<Two, "first"_ts, "second"_ts>);
 
-struct NoDefaultConstructor {
-  NoDefaultConstructor() = delete;
+struct DefaultConstructorDeleted {
+  DefaultConstructorDeleted() = delete;
 };
 
-static_assert(!SupportsFieldNames<NoDefaultConstructor>);
+static_assert(!std::is_default_constructible_v<DefaultConstructorDeleted>);
+static_assert(SupportsFieldNames<DefaultConstructorDeleted>);
+
+struct NoDefaultConstructor {
+  int& ref;
+  int val;
+};
+
+static_assert(!std::is_default_constructible_v<NoDefaultConstructor>);
+static_assert(SupportsFieldNames<NoDefaultConstructor>);
+static_assert(TestGetFieldNames<NoDefaultConstructor, "ref"_ts, "val"_ts>);
 
 struct NoDestructor {  // NOLINT(*-special-member-functions)
   constexpr NoDestructor() = default;


### PR DESCRIPTION
Add ability to retrieve field names for structs without default constructor (e.g. due to reference fields).