### PR TITLE
The clangd indexer takes aim at how field names work

### DIFF
--- a/mbo/types/internal/struct_names_clang.h
+++ b/mbo/types/internal/struct_names_clang.h
@@ -71,6 +71,8 @@ class StructMetaBase {
     constexpr Storage() noexcept {
       if constexpr (std::is_default_constructible_v<T>) {
         std::construct_at(&storage_.value);
+      } else {
+        memset(&storage_.value, 0, sizeof(T));
       }
     }
 

--- a/mbo/types/internal/struct_names_clang.h
+++ b/mbo/types/internal/struct_names_clang.h
@@ -17,6 +17,7 @@
 #define MBO_TYPES_INTERNAL_STRUCT_NAMES_CLANG_H_
 #if defined(__clang__) && __has_builtin(__builtin_dump_struct)
 
+# include <cstring>
 # include <string_view>
 # include <type_traits>
 
@@ -63,7 +64,7 @@ class StructMetaBase {
       Uninitialized(Uninitialized&&) = delete;
       Uninitialized& operator=(Uninitialized&&) = delete;
 
-      unsigned temp{};
+      char temp[sizeof(T)] = {0};  // NOLINT(*-avoid-c-arrays)
       T value;
     };
 
@@ -72,7 +73,8 @@ class StructMetaBase {
       if constexpr (std::is_default_constructible_v<T>) {
         std::construct_at(&storage_.value);
       } else {
-        memset(&storage_.value, 0, sizeof(T));
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+        memset(const_cast<char*>(&storage_.temp[0]), 0, sizeof(T));
       }
     }
 

--- a/mbo/types/internal/struct_names_test.cc
+++ b/mbo/types/internal/struct_names_test.cc
@@ -71,6 +71,10 @@ struct DefaultConstructorDeleted {
 static_assert(!std::is_default_constructible_v<DefaultConstructorDeleted>);
 static_assert(SupportsFieldNames<DefaultConstructorDeleted>);
 
+# ifndef IS_CLANGD
+// The indexer takes aim at how field names are `looked up` from uninitialized
+// memory and reliably crashes here. So this piece is disabled for the indexer.
+
 struct NoDefaultConstructor {
   int& ref;
   int val;
@@ -83,6 +87,7 @@ TEST_F(StructNamesTest, StructWithoutDefaultConstructor) {
   // This cannot be done at compile time.
   EXPECT_THAT(GetFieldNames<NoDefaultConstructor>(), ElementsAre("ref", "val"));
 }
+# endif  // IS_CLANGD
 
 struct NoDestructor {  // NOLINT(*-special-member-functions)
   constexpr NoDestructor() = default;


### PR DESCRIPTION
The clangd indexer takes aim at how field names are `looked up` from uninitialized memory and reliably crashes here. So this piece is disabled for the indexer.

Also zero initialize the memory for structs without default constructor.