### PR TITLE
Added `mbo::strings::AtLast`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -63,6 +63,8 @@ CheckOptions:
     value:           'NULL'
   - key:             performance-unnecessary-value-param.AllowedTypes
     value:           'absl::Status;absl::StatusOr;std::string_view'
+  - key:             readability-function-cognitive-complexity.Threshold
+    value:           '25'
   - key:             readability-braces-around-statements.ShortStatementLines
     value:           '1'
   - key:             readability-identifier-length.IgnoredLoopCounterNames

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.2.36
+
+* Added struct `mbo::strings::AtLast` which allows `absl::StrSplit' to split on the last occurrence of a separator.
+* Added concept `mbo::types::IsSet`.
+* Added concept `mbo::types::IsVector`.
+* Fixed concept `mbo::types::IsPair` and `mbo::types::IsPairFirstString` to not remove cvref.
+
 # 0.2.35
 
 * Added ability to retrieve field names for structs without default constructor (e.g. due to reference fields).

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ The C++ library is organized in functional groups each residing in their own dir
     * mbo/strings:parse_cc, mbo/strings/parse.h
         * function `ParseString`: Parses strings respecting C++ and custom escapes as well as quotes (all configurable).
         * function `ParseStringList`: Parses and splits strings respecting C++ and custom escapes as well as quotes (all configurable).
+    * mbo/strings:split_cc, mbo/strings/split.h
+        * struct `mbo::strings::AtLast`: Allows `absl::StrSplit' to split on the last occurrence of a separator.
     * mbo/strings:strip_cc, mbo/strings/strip.h
         * struct `StripCommentsArgs`: Arguments for `StripComments` and `StripLineComments`.
         * function `StripComments`: Strips comments from lines.
@@ -147,12 +149,6 @@ The C++ library is organized in functional groups each residing in their own dir
         * template-type `RefWrap<T>`: similar to `std::reference_wrapper` but supports operators `->` and `*`.
     * mbo/types:required_cc, mbo/types/required.h
         * template-type `Required<T>`: similar to `RefWrap` but stores the actual type (and unlike `std::optional` cannot be reset).
-
-    * mbo/types:template_search_cc, mbo/types/template_search.h:
-        * template struct `BinarySearch` implements templated binary search algorithm.
-        * template struct `LinearSearch` implements templated linear search algorithm.
-        * template struct `ReverseSearch` implements templated reverse linear search algorithm.
-        * template struct `MaxSearch` implements templated linear search for last match algorithm.
     * mbo/types:stringify_cc, mbo/types/stringify.h
         * class `Stringify` a utility to convert structs into strings.
         * function `StringifyWithFieldNames` a format control adapter for `Stringify`.
@@ -181,13 +177,20 @@ The C++ library is organized in functional groups each residing in their own dir
         * concept `IsDecomposable` determines whether a type can be used in static-bindings.
         * concept `IsInitializerList` determines whether a type is `std::initializer<T> type.
         * concept `IsBracesConstructibleV` determines whether a type can be constructe from given argument types.
-        * concept `IsOptional` determines whether a type is a `std::optional`.
-        * concept `IsPair` determines whether a type is a `std::pair`.
+        * concept `IsOptional` determines whether a type is a `std::optional` type.
+        * concept `IsPair` determines whether a type is a `std::pair` type.
+        * concept `IsSet` determines whether a type is a `std::set` type.
         * concept `IsSameAsAnyOfRaw` / `NotSameAsAnyOfRaw` which determine whether type is one of a list of types.
         * concept `IsSmartPtr` determines whether a type is a `std::shared_ptr`, `std::unique_ptr` or `std::weak_ptr`.
           * Can be extended with other smart pointers through `IsSmartPtrImpl`.
-        * concept `IsTuple` determines whether a type is a `std::tuple`.
+        * concept `IsTuple` determines whether a type is a `std::tuple` type.
         * concept `IsVariant` determines whether a type is a `std::variant` type.
+        * concept `IsVector` determines whether a type is a `std::vector` type.
+    * mbo/types:template_search_cc, mbo/types/template_search.h:
+        * template struct `BinarySearch` implements templated binary search algorithm.
+        * template struct `LinearSearch` implements templated linear search algorithm.
+        * template struct `ReverseSearch` implements templated reverse linear search algorithm.
+        * template struct `MaxSearch` implements templated linear search for last match algorithm.
     * mbo/types:tstring_cc, mbo/types/tstring.h
         * struct `tstring`: Implements type `tstring` a compile time string-literal type.
         * operator `operator"" _ts`: String literal support for Clang, GCC and derived compilers.

--- a/mbo/container/internal/limited_ordered.h
+++ b/mbo/container/internal/limited_ordered.h
@@ -50,7 +50,7 @@ namespace mbo::container::container_internal {
 template<typename Key, typename Mapped, typename Value>
 concept LimitedOrderedValidImpl =
     std::same_as<std::remove_const_t<Key>, std::remove_const_t<Value>>
-    || (mbo::types::IsPair<Value>
+    || (mbo::types::IsPair<std::remove_const_t<Value>>
         && std::same_as<std::remove_const_t<Key>, std::remove_const_t<typename Value::first_type>>);
 
 template<typename Key, typename Mapped, typename Value>

--- a/mbo/container/limited_map.h
+++ b/mbo/container/limited_map.h
@@ -305,7 +305,7 @@ template<
     auto N,
     std::forward_iterator It,
     typename KComp = types::CompareLess<typename mbo::types::ForwardIteratorValueType<It>::first_type>>
-requires(types::IsPair<typename mbo::types::ForwardIteratorValueType<It>>)
+requires(types::IsPair<std::remove_cvref_t<typename mbo::types::ForwardIteratorValueType<It>>>)
 inline constexpr auto MakeLimitedMap(It begin, It end, const KComp& key_comp = KComp()) noexcept {
   using KV = mbo::types::ForwardIteratorValueType<It>;
   return LimitedMap<typename KV::first_type, typename KV::second_type, N, KComp>(begin, end, key_comp);
@@ -332,10 +332,8 @@ inline constexpr auto MakeLimitedMap() noexcept {
 }
 
 // NOLINTBEGIN(*-avoid-c-arrays)
-template<
-    types::IsPair KV,
-    std::size_t N,
-    typename KComp = types::CompareLess<typename std::remove_cvref_t<KV>::first_type>>
+template<typename KV, std::size_t N, typename KComp = types::CompareLess<typename std::remove_cvref_t<KV>::first_type>>
+requires(types::IsPair<std::remove_cvref_t<KV>>)
 constexpr auto ToLimitedMap(KV (&array)[N], const KComp& key_comp = KComp()) {
   LimitedMap<typename std::remove_cvref_t<KV>::first_type, typename std::remove_cvref_t<KV>::second_type, N, KComp>
       result(key_comp);
@@ -345,10 +343,8 @@ constexpr auto ToLimitedMap(KV (&array)[N], const KComp& key_comp = KComp()) {
   return result;
 }
 
-template<
-    types::IsPair KV,
-    std::size_t N,
-    typename KComp = types::CompareLess<typename std::remove_cvref_t<KV>::first_type>>
+template<typename KV, std::size_t N, typename KComp = types::CompareLess<typename std::remove_cvref_t<KV>::first_type>>
+requires(types::IsPair<std::remove_cvref_t<KV>>)
 constexpr auto ToLimitedMap(KV (&&array)[N], const KComp& key_comp = KComp()) {
   LimitedMap<typename std::remove_cvref_t<KV>::first_type, typename std::remove_cvref_t<KV>::second_type, N, KComp>
       result(key_comp);
@@ -359,7 +355,7 @@ constexpr auto ToLimitedMap(KV (&&array)[N], const KComp& key_comp = KComp()) {
 }
 
 template<typename K, typename V, std::size_t N, typename KComp = types::CompareLess<K>>
-requires(!types::IsPair<K>)
+requires(!types::IsPair<std::remove_cvref_t<K>>)
 constexpr auto ToLimitedMap(std::pair<K, V> (&array)[N], const KComp& key_comp = KComp()) {
   LimitedMap<K, V, N, KComp> result(key_comp);
   for (std::size_t idx = 0; idx < N; ++idx) {
@@ -369,7 +365,7 @@ constexpr auto ToLimitedMap(std::pair<K, V> (&array)[N], const KComp& key_comp =
 }
 
 template<typename K, typename V, std::size_t N, typename KComp = types::CompareLess<K>>
-requires(!types::IsPair<K>)
+requires(!types::IsPair<std::remove_cvref_t<K>>)
 constexpr auto ToLimitedMap(std::pair<K, V> (&&array)[N], const KComp& key_comp = KComp()) {
   LimitedMap<K, V, N, KComp> result(key_comp);
   for (std::size_t idx = 0; idx < N; ++idx) {

--- a/mbo/strings/BUILD.bazel
+++ b/mbo/strings/BUILD.bazel
@@ -63,6 +63,22 @@ cc_test(
 )
 
 cc_library(
+    name = "split_cc",
+    hdrs = ["split.h"],
+)
+
+cc_test(
+    name = "split_test",
+    srcs = ["split_test.cc"],
+    deps = [
+        ":split_cc",
+        "//mbo/types:traits_cc",
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
     name = "strip_cc",
     srcs = ["strip.cc"],
     hdrs = ["strip.h"],

--- a/mbo/strings/split.h
+++ b/mbo/strings/split.h
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MBO_STRINGS_SPLIT_H_
+#define MBO_STRINGS_SPLIT_H_
+
+#include <cstddef>
+#include <string_view>
+
+namespace mbo::strings {
+
+// Modifier for `absl::StrSplit` that creates at most two parts separated by 'sep'.
+class AtLast {
+ public:
+  explicit AtLast(char sep) : sep_(sep){};
+
+  std::string_view Find(std::string_view text, std::size_t pos) const {
+    std::size_t next_pos = text.substr(pos).rfind(sep_);
+    if (next_pos == std::string_view::npos) {
+      return std::string_view{text.data() + text.size(), 0};
+    }
+    return text.substr(next_pos, 1);
+  }
+
+ private:
+  const char sep_;
+};
+
+}  // namespace mbo::strings
+
+#endif  // MBO_STRINGS_SPLIT_H_

--- a/mbo/strings/split_test.cc
+++ b/mbo/strings/split_test.cc
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mbo/strings/split.h"
+
+#include <list>
+#include <set>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+
+#include "absl/strings/str_split.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "mbo/types/traits.h"  // IWYU pragma: keep
+
+namespace mbo::strings {
+namespace {
+
+using ::absl::SkipEmpty;
+
+template<typename T>
+struct SplitTest : ::testing::Test {
+  template<typename Arg>
+  static T StrSplit(std::string_view text, AtLast sep, Arg&& arg) {
+    return T(absl::StrSplit(text, sep, std::forward<Arg>(arg)));
+  }
+
+  static T StrSplit(std::string_view text, AtLast sep) { return T(absl::StrSplit(text, sep)); }
+};
+
+template<typename T>
+concept IsSet = requires {
+  typename T::value_type;
+  typename T::key_compare;
+  typename T::allocator_type;
+  requires std::same_as<T, std::set<typename T::value_type, typename T::key_compare, typename T::allocator_type>>;
+};
+
+MATCHER(IsEmpty, "") {
+  if constexpr (mbo::types::IsPair<std::remove_cvref_t<arg_type>>) {
+    return arg.first.empty() && arg.second.empty();
+  } else {
+    return arg.empty();
+  }
+}
+
+MATCHER_P(Elements, elements, "") {
+  if constexpr (IsSet<std::remove_cvref_t<arg_type>>) {
+    std::set<std::string> expected_set{elements.begin(), elements.end()};
+    return ::testing::ExplainMatchResult(::testing::UnorderedElementsAreArray(expected_set), arg, result_listener);
+  } else if constexpr (mbo::types::IsPair<std::remove_cvref_t<arg_type>>) {
+    if (elements.size() == 2) {
+      return elements[0] == arg.first && elements[1] == arg.second;
+    } else if (elements.size() == 1) {
+      return elements[0] == arg.first && arg.second.empty();
+    } else if (elements.size() == 0) {
+      return arg.first.empty() && arg.second.empty();
+    } else {
+      return ::testing::ExplainMatchResult(::testing::Le(2), elements.size(), result_listener);
+    }
+  } else {
+    return ::testing::ExplainMatchResult(::testing::ElementsAreArray(elements), arg, result_listener);
+  }
+}
+
+using MyTypes = ::testing::Types<         //
+    std::list<std::string>,               //
+    std::vector<std::string_view>,        //
+    std::vector<std::string_view>,        //
+    std::pair<std::string, std::string>,  //
+    std::set<std::string>>;
+
+TYPED_TEST_SUITE(SplitTest, MyTypes);
+
+TYPED_TEST(SplitTest, SkipEmpty) {
+  using I = std::vector<std::string_view>;
+  using S = std::remove_cvref_t<decltype(*this)>;
+  EXPECT_THAT(S::StrSplit("", AtLast('/'), SkipEmpty()), IsEmpty());
+  EXPECT_THAT(S::StrSplit("/", AtLast('/'), SkipEmpty()), IsEmpty());
+  EXPECT_THAT(S::StrSplit("//", AtLast('/'), SkipEmpty()), Elements(I{"/"}));
+  EXPECT_THAT(S::StrSplit("a//", AtLast('/'), SkipEmpty()), Elements(I{"a/"}));
+  EXPECT_THAT(S::StrSplit("a/b/", AtLast('/'), SkipEmpty()), Elements(I{"a/b"}));
+  EXPECT_THAT(S::StrSplit("a/b/c", AtLast('/'), SkipEmpty()), Elements(I{"a/b", "c"}));
+  EXPECT_THAT(S::StrSplit("a//c", AtLast('/'), SkipEmpty()), Elements(I{"a/", "c"}));
+  EXPECT_THAT(S::StrSplit("/b/", AtLast('/'), SkipEmpty()), Elements(I{"/b"}));
+  EXPECT_THAT(S::StrSplit("/b/c", AtLast('/'), SkipEmpty()), Elements(I{"/b", "c"}));
+  EXPECT_THAT(S::StrSplit("//c", AtLast('/'), SkipEmpty()), Elements(I{"/", "c"}));
+}
+
+TYPED_TEST(SplitTest, NoSkipEmpty) {
+  using I = std::vector<std::string_view>;
+  using S = std::remove_cvref_t<decltype(*this)>;
+  EXPECT_THAT(S::StrSplit("", AtLast('/')), Elements(I{""}));
+  EXPECT_THAT(S::StrSplit("/", AtLast('/')), Elements(I{"", ""}));
+  EXPECT_THAT(S::StrSplit("//", AtLast('/')), Elements(I{"/", ""}));
+  EXPECT_THAT(S::StrSplit("a//", AtLast('/')), Elements(I{"a/", ""}));
+  EXPECT_THAT(S::StrSplit("a/b/", AtLast('/')), Elements(I{"a/b", ""}));
+  EXPECT_THAT(S::StrSplit("a/b/c", AtLast('/')), Elements(I{"a/b", "c"}));
+  EXPECT_THAT(S::StrSplit("a//c", AtLast('/')), Elements(I{"a/", "c"}));
+  EXPECT_THAT(S::StrSplit("/b/", AtLast('/')), Elements(I{"/b", ""}));
+  EXPECT_THAT(S::StrSplit("/b/c", AtLast('/')), Elements(I{"/b", "c"}));
+  EXPECT_THAT(S::StrSplit("//c", AtLast('/')), Elements(I{"/", "c"}));
+}
+
+}  // namespace
+}  // namespace mbo::strings

--- a/mbo/strings/strip.cc
+++ b/mbo/strings/strip.cc
@@ -20,7 +20,7 @@
 
 namespace mbo::strings {
 
-std::string_view StripLineComments(std::string_view line, StripCommentArgs args) {
+std::string_view StripLineComments(std::string_view line, const StripCommentArgs& args) {
   const auto pos = line.find(args.comment_start);
   if (pos != std::string_view::npos) {
     line = line.substr(0, pos);
@@ -31,13 +31,13 @@ std::string_view StripLineComments(std::string_view line, StripCommentArgs args)
   return line;
 }
 
-std::string StripComments(std::string_view input, StripCommentArgs args) {
+std::string StripComments(std::string_view input, const StripCommentArgs& args) {
   return absl::StrJoin(absl::StrSplit(input, '\n'), "\n", [&](std::string* out, std::string_view line) {
     absl::StrAppend(out, StripLineComments(line, args));
   });
 }
 
-absl::StatusOr<std::string> StripParsedLineComments(std::string_view line, StripParsedCommentArgs args) {
+absl::StatusOr<std::string> StripParsedLineComments(std::string_view line, const StripParsedCommentArgs& args) {
   auto line_or = ParseString(args.parse, line);
   if (!line_or.ok()) {
     return absl::InvalidArgumentError(absl::StrCat("Cannot parse input."));
@@ -49,7 +49,7 @@ absl::StatusOr<std::string> StripParsedLineComments(std::string_view line, Strip
   return std::string(line);
 }
 
-absl::StatusOr<std::string> StripParsedComments(std::string_view input, StripParsedCommentArgs args) {
+absl::StatusOr<std::string> StripParsedComments(std::string_view input, const StripParsedCommentArgs& args) {
   absl::Status error = absl::OkStatus();
   std::string result_str =
       absl::StrJoin(absl::StrSplit(input, '\n'), "\n", [&](std::string* out, std::string_view line) {

--- a/mbo/strings/strip.h
+++ b/mbo/strings/strip.h
@@ -51,10 +51,10 @@ struct StripCommentArgs {
   bool strip_trailing_whitespace = true;
 };
 
-std::string StripComments(std::string_view input, StripCommentArgs args);
+std::string StripComments(std::string_view input, const StripCommentArgs& args);
 
 // This is the single line version of `StripComments`.
-std::string_view StripLineComments(std::string_view line, StripCommentArgs args);
+std::string_view StripLineComments(std::string_view line, const StripCommentArgs& args);
 
 // Similar to `StripComment`, this function can strip out comments. However, this variant supports
 // per line parsing to in order to support single or double quotes. This can be enabled by providing
@@ -69,10 +69,10 @@ struct StripParsedCommentArgs {
   bool strip_trailing_whitespace = true;
 };
 
-absl::StatusOr<std::string> StripParsedComments(std::string_view input, StripParsedCommentArgs args);
+absl::StatusOr<std::string> StripParsedComments(std::string_view input, const StripParsedCommentArgs& args);
 
 // This is the single line version of `StripParsedComments`.
-absl::StatusOr<std::string> StripParsedLineComments(std::string_view line, StripParsedCommentArgs args);
+absl::StatusOr<std::string> StripParsedLineComments(std::string_view line, const StripParsedCommentArgs& args);
 
 }  // namespace mbo::strings
 

--- a/mbo/testing/status.h
+++ b/mbo/testing/status.h
@@ -446,7 +446,7 @@ inline ::testing::PolymorphicMatcher<testing_internal::StatusPayloads> StatusPay
 // PRIVATE macro, do not use.
 #define MBO_PRIVATE_TESTING_STATUS_ASSERT_OK_AND_ASSIGN_(statusor, expression, ...) \
   auto statusor = (expression);                                                     \
-  ASSERT_TRUE(statusor.ok());                                                       \
+  ASSERT_OK(statusor);                                                              \
   __VA_ARGS__ = std::move(statusor).value()
 
 // Macro that verifies `expression` is OK and assigns its `value` by move to `targets`, where target

--- a/mbo/types/stringify.h
+++ b/mbo/types/stringify.h
@@ -491,7 +491,7 @@ class Stringify {
   template<typename C>
   requires(::mbo::types::ContainerIsForwardIteratable<C> && !std::convertible_to<C, std::string_view>)
   void StreamValue(std::ostream& os, const C& vs, const StringifyOptions& field_options, bool allow_field_names) const {
-    if constexpr (mbo::types::IsPairFirstStr<typename C::value_type>) {
+    if constexpr (mbo::types::IsPairFirstStr<std::remove_cvref_t<typename C::value_type>>) {
       if (field_options.special_pair_first_is_name) {
         // Each pair element of the container `vs` is an element whose key is the `first` member and
         // whose value is the `second` member.


### PR DESCRIPTION
* Added struct `mbo::strings::AtLast` which allows `absl::StrSplit' to split on the last occurrence of a separator.

Additional cleanup and fixes:
* Added concept `mbo::types::IsSet`.
* Added concept `mbo::types::IsVector`.
* Fixed concept `mbo::types::IsPair` and `mbo::types::IsPairFirstString` to not remove cvref.