### PR TITLE
Added Glob and BigNumber

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Test Clang/ASAN
         run: |
-          bazel test --config=clang --config=asan -c dbg //...
+          bazel test --enable_bzlmod --noenable_workspace --config=clang --config=asan -c dbg //...
 
   test-clang-17:
     runs-on: ubuntu-latest
@@ -50,7 +50,7 @@ jobs:
         run: |
           sed -e 's,llvm_version = ".*",llvm_version = "17.0.4",g' MODULE.bazel > MODULE.bazel.bak
           mv MODULE.bazel.bak MODULE.bazel
-          bazel test --config=clang -c fastbuild //...
+          bazel test --enable_bzlmod --noenable_workspace --config=clang -c fastbuild //...
 
   test-clang-opt:
     runs-on: ubuntu-latest
@@ -69,7 +69,7 @@ jobs:
 
       - name: Test Clang/OPT
         run: |
-          bazel test --config=clang -c opt //...
+          bazel test --enable_bzlmod --noenable_workspace --config=clang -c opt //...
 
   test-gcc-fastbuild:
     runs-on: ubuntu-latest
@@ -88,4 +88,5 @@ jobs:
 
       - name: Test GCC/Fastbuild
         run: |
-          CC=gcc bazel test -c fastbuild //...
+          # Use WORKSPACE
+          CC=gcc bazel test --noenable_bzlmod --enable_workspace -c fastbuild //...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+# 0.3.1
+
+* Added function `mbo::strings::BigNumber`: Convert integral number to string with thousands separator.
+* Added function `mbo::strings::BigNumberLen`: Calculate required string length for `BigNumer`.
+* Added glob functionality:
+  * Added struct `mbo::file::Glob2Re2Options`: Control conversion of a [glob pattern](https://man7.org/linux/man-pages/man7/glob.7.html) into a [RE2 pattern](https://github.com/google/re2/wiki/Syntax).
+  * Added struct `mbo::file::GlobEntry`: Stores data for a single globbed entry (file, dir, etc.).
+  * Added struct `mbo::file::GlobOptions`: Options for functions `Glob2Re2` and `Glob2Re2Expression`.
+  * Added enum `mbo::file::GlobEntryAction`: Allows GlobEntryFunc to control further glob progression.
+  * Added type `mbo::file::GlobEntryFunc`: Callback for acceptable glob entries.
+  * Added function `mbo::file::GlobRe2`: Performs recursive glob functionality using a RE2 pattern.
+  * Added function `mbo::file::Glob`: Performs recursive glob functionality using a `fnmatch` style pattern.
+  * Added program `glob`: A recursive glob, see `glob --help`.
+* WORKSPACE support:
+  * Added rules_python and brought back com_google_protobuf support.
+* Fixed `RunfilesDir/OrDie` to use environment variable `TEST_WORKSPACE` if present.
+* Fixed formatting issue with `mbo/types/internal/decompose_count.h`.
+* Downgraded Clang from 19.1.7 to 19.1.6.
+* Updated GitHub workflow to test both Bazel flavors.
+
 # 0.3.0
 
 * Added struct `mbo::strings::AtLast` which allows `absl::StrSplit' to split on the last occurrence of a separator.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -23,7 +23,7 @@ bazel_dep(name = "abseil-cpp", version = "20250127.0", repo_name = "com_google_a
 bazel_dep(name = "re2", version = "2024-07-02.bcr.1", repo_name = "com_googlesource_code_re2")
 bazel_dep(name = "googletest", version = "1.16.0", repo_name = "com_google_googletest")
 bazel_dep(name = "google_benchmark", version = "1.9.1", repo_name = "com_github_google_benchmark")
-bazel_dep(name = "protobuf", version = "30.0-rc1", repo_name = "com_google_protobuf")
+# bazel_dep(name = "protobuf", version = "29.3", repo_name = "com_google_protobuf")
 bazel_dep(name = "toolchains_llvm", version = "1.3.0")
 
 git_override(
@@ -36,7 +36,7 @@ llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
 
 llvm.toolchain(
     name = "llvm_toolchain_llvm",
-    llvm_version = "19.1.7",
+    llvm_version = "19.1.6",
 )
 use_repo(llvm, "llvm_toolchain_llvm")
 register_toolchains("@llvm_toolchain_llvm//:all")

--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ The C++ library is organized in functional groups each residing in their own dir
         * function `NormalizePath`: Normalizes a path.
         * function `Readable`: Returns whether a file is readable or an absl::Status error.
         * function `SetContents`: Writes contents to a file.
+    * mbo/file:glob_cc, mbo/file/glob.h
+        * struct `mbo::file::Glob2Re2Options`: Control conversion of a [glob pattern](https://man7.org/linux/man-pages/man7/glob.7.html) into a [RE2 pattern](https://github.com/google/re2/wiki/Syntax).
+        * struct `mbo::file::GlobEntry`: Stores data for a single globbed entry (file, dir, etc.).
+        * struct `mbo::file::GlobOptions`: Options for functions `Glob2Re2` and `Glob2Re2Expression`.
+        * enum `mbo::file::GlobEntryAction`: Allows GlobEntryFunc to control further glob progression.
+        * type `mbo::file::GlobEntryFunc`: Callback for acceptable glob entries.
+        * function `mbo::file::GlobRe2`: Performs recursive glob functionality using a RE2 pattern.
+        * function `mbo::file::Glob`: Performs recursive glob functionality using a `fnmatch` style pattern.
+        * program `glob`: A recursive glob, see `glob --help`.
     * mbo/file/ini:ini_file_cc, mbo/file/ini/ini_file.h
         * class `IniFile`: A simple INI file reader.
 * Hash
@@ -93,6 +102,9 @@ The C++ library is organized in functional groups each residing in their own dir
     * mbo/strings:indent_cc, mbo/strings/indent.h
         * function `DropIndent`: Converts a raw-string text block as if it had no indent.
         * function `DropIndentAndSplit`: Variant of `DropIndent` that returns the result as lines.
+    * mbo/strings:numbers_cc, mbo/strings/numbers.h
+        * Added function `mbo::strings::BigNumber`: Convert integral number to string with thousands separator.
+        * Added function `mbo::strings::BigNumberLen`: Calculate required string length for `BigNumer`.
     * mbo/strings:parse_cc, mbo/strings/parse.h
         * function `ParseString`: Parses strings respecting C++ and custom escapes as well as quotes (all configurable).
         * function `ParseStringList`: Parses and splits strings respecting C++ and custom escapes as well as quotes (all configurable).
@@ -215,7 +227,7 @@ The project only comes with a Bazel BUILD.bazel file and can be added to other B
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-  name = "com_helly25_proto",
+  name = "com_helly25_mbo",
   url = "https://github.com/helly25/mbo/archive/refs/heads/main.tar.gz",
   # See https://github.com/helly25/mbo/releases for releases.
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -36,7 +36,15 @@ rules_foreign_cc_dependencies()
 
 ###########################################################################
 
+load("@rules_python//python:repositories.bzl", "py_repositories")
+
+py_repositories()
+
+###########################################################################
+
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
 
 ###########################################################################
 
@@ -48,7 +56,7 @@ load("@toolchains_llvm//toolchain:rules.bzl", "llvm_toolchain")
 
 llvm_toolchain(
     name = "llvm_toolchain",
-    llvm_version = "19.1.7",
+    llvm_version = "19.1.6",
 )
 
 load("@llvm_toolchain//:toolchains.bzl", "llvm_register_toolchains")

--- a/mbo/file/BUILD.bazel
+++ b/mbo/file/BUILD.bazel
@@ -50,3 +50,48 @@ cc_test(
     ],
     size = "small",
 )
+
+cc_library(
+    name = "glob_cc",
+    srcs = ["glob.cc"],
+    hdrs = ["glob.h"],
+    deps = [
+        "//mbo/status:status_macros_cc",
+        "//mbo/strings:split_cc",
+        "//mbo/types:extend_cc",
+        "@com_google_absl//absl/algorithm",
+        "@com_google_absl//absl/container:btree",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/flags:parse",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_googlesource_code_re2//:re2",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_test(
+    name = "glob_test",
+    srcs = ["glob_test.cc"],
+    deps = [
+        ":glob_cc",
+        "//mbo/testing:status_cc",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest_main",
+        "@com_googlesource_code_re2//:re2",
+    ],
+    size = "small",
+)
+
+cc_binary(
+    name = "glob",
+    srcs = ["glob_main.cc"],
+    deps = [
+        ":glob_cc",
+        "//mbo/strings:numbers_cc",
+        "@com_google_absl//absl/status",
+    ]
+)

--- a/mbo/file/file.cc
+++ b/mbo/file/file.cc
@@ -13,9 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This implementation avoids C++ STL to due to exceptions and instead
-// uses POSIX APIs.
-
 #include "mbo/file/file.h"
 
 #include <chrono>

--- a/mbo/file/file.h
+++ b/mbo/file/file.h
@@ -13,9 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This implementation avoids C++ STL to due to exceptions and instead
-// uses POSIX APIs.
-
 #ifndef MBO_FILE_FILE_H_
 #define MBO_FILE_FILE_H_
 

--- a/mbo/file/glob.cc
+++ b/mbo/file/glob.cc
@@ -1,0 +1,440 @@
+// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mbo/file/glob.h"
+
+#include <cstddef>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "absl/algorithm/container.h"
+#include "absl/strings/ascii.h"
+#include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+#include "mbo/status/status_macros.h"
+#include "mbo/types/extend.h"
+
+#ifdef MBO_ALWAYS_INLINE
+# undef MBO_ALWAYS_INLINE
+#endif
+#ifdef NDEBUG
+# define MBO_ALWAYS_INLINE __attribute__((always_inline)) inline
+#else
+# define MBO_ALWAYS_INLINE
+#endif
+
+namespace fs = std::filesystem;
+
+namespace mbo::file {
+namespace {
+
+MBO_ALWAYS_INLINE absl::Status ValidateCharacterClass(std::string_view text) {
+  if (text.empty()) {
+    return absl::InvalidArgumentError("Invalid empty character-class name.");
+  }
+  if (!absl::c_all_of(text, [](char chr) { return absl::ascii_isalpha(chr); })) {
+    return absl::InvalidArgumentError(absl::StrFormat("Invalid character-class name '%s'.", text));
+  }
+  return absl::OkStatus();
+}
+
+MBO_ALWAYS_INLINE absl::Status MaybeCharacterClass(std::string_view& glob_pattern, std::string& re2_pattern) {
+  if (!glob_pattern.starts_with("[:")) {
+    re2_pattern += glob_pattern.front();
+    glob_pattern.remove_prefix(1);
+    return absl::OkStatus();
+  }
+  std::size_t end = glob_pattern.find(":]", 2);
+  if (end == std::string_view::npos) {
+    return absl::InvalidArgumentError("Unterminated character-class.");
+  }
+  MBO_RETURN_IF_ERROR(ValidateCharacterClass(glob_pattern.substr(2, end - 2)));
+  ++end;
+  absl::StrAppend(&re2_pattern, glob_pattern.substr(0, end));
+  glob_pattern.remove_prefix(end);
+  return absl::OkStatus();
+}
+
+MBO_ALWAYS_INLINE void GlobFindRangePrefix(std::string_view& pattern, std::string& re2_pattern) {
+  if (pattern.starts_with("[!]")) {
+    absl::StrAppend(&re2_pattern, "[^\\]");
+    pattern.remove_prefix(3);
+  } else if (pattern.starts_with("[!")) {
+    absl::StrAppend(&re2_pattern, "[^");
+    pattern.remove_prefix(2);
+  } else if (pattern.starts_with("[]")) {
+    absl::StrAppend(&re2_pattern, "[\\]");
+    pattern.remove_prefix(2);
+  } else if (pattern.starts_with("[^")) {
+    absl::StrAppend(&re2_pattern, "[\\^");
+    pattern.remove_prefix(2);
+  } else {
+    absl::StrAppend(&re2_pattern, "[");
+    pattern.remove_prefix(1);
+  }
+}
+
+MBO_ALWAYS_INLINE absl::Status GlobFindRange(std::string_view& pattern, std::string& re2_pattern) {
+  GlobFindRangePrefix(pattern, re2_pattern);
+  while (true) {
+    if (pattern.empty()) {
+      return absl::InvalidArgumentError("Unterminated range expression.");
+    }
+    char chr = pattern.front();
+    switch (chr) {
+      default:
+        re2_pattern += chr;
+        pattern.remove_prefix(1);
+        continue;
+      case '[': {
+        MBO_RETURN_IF_ERROR(MaybeCharacterClass(pattern, re2_pattern));
+        continue;
+      }
+      case ']':
+        re2_pattern += chr;
+        pattern.remove_prefix(1);
+        break;
+      case '\\':
+        if (pattern.size() < 2) {
+          return absl::InvalidArgumentError("Unterminated range expression ending in back-slash.");
+        }
+        absl::StrAppend(&re2_pattern, pattern.substr(0, 2));
+        continue;
+    }
+    break;
+  }
+  if (!re2_pattern.ends_with(']')) {
+    return absl::InvalidArgumentError("Unterminated range expression.");
+  }
+  return absl::OkStatus();
+}
+
+struct GlobData : mbo::types::Extend<GlobData> {
+  std::string pattern;
+  std::optional<std::size_t> path_len;
+  bool mixed = false;
+};
+
+bool AllowApendStar(std::string_view pattern, std::size_t past_last_escape, const Glob2Re2Options& options) {
+  // We consider whether the previous chars were stars, but they could have been escaped.
+  // The escape char itself could be escaped, so we forward search for escape chars and drop those
+  // nad the next charater. What remains is an unescaped sequence.
+  pattern.remove_prefix(past_last_escape);
+  if (options.allow_star_star) {
+    return !pattern.ends_with("**");
+  } else {
+    return !pattern.ends_with("*");
+  }
+}
+
+bool AllowAppendSlash(std::string_view pattern, std::size_t past_last_escape) {
+  pattern.remove_prefix(past_last_escape);
+  return !pattern.ends_with("/") || pattern.ends_with(":/");
+}
+
+// Deduplicate '/'s, remove trailing '/' and reduce '*' sequences to at most `options.allow_star_star ? 2 : 1`.
+MBO_ALWAYS_INLINE absl::StatusOr<std::string> GlobNormalizeStr(
+    std::string_view glob_pattern,
+    const Glob2Re2Options& options) {
+  std::string result;
+  result.reserve(glob_pattern.size());
+  std::size_t past_last_escape = 0;
+  while (!glob_pattern.empty()) {
+    char chr = glob_pattern.front();
+    glob_pattern.remove_prefix(1);
+    if (chr == '\\') {
+      if (glob_pattern.empty()) {
+        return absl::InvalidArgumentError("No character left to escape at end of pattern.");
+      }
+      chr = glob_pattern.front();
+      glob_pattern.remove_prefix(1);
+      if (chr != '/') {
+        result += '\\';
+        result += chr;
+        past_last_escape = result.size();
+        continue;
+      }
+      // No need to escape the forward slash, but rather prevent duplicates even if escaped.
+    }
+    switch (chr) {
+      case '*':
+        if (AllowApendStar(result, past_last_escape, options)) {
+          result += chr;
+        }
+        continue;
+      case '[':
+        if (!options.allow_ranges || !glob_pattern.starts_with("/]")) {
+          result += chr;  // replace '[/]' with '/'.
+          continue;
+        }
+        glob_pattern.remove_prefix(2);
+        chr = '/';
+        [[fallthrough]];
+      case '/':
+        if (AllowAppendSlash(result, past_last_escape)) {
+          result += chr;
+        }
+        continue;
+      default: {
+        result += chr;
+        continue;
+      }
+    }
+  }
+  if (result.size() > 1 && result.ends_with('/')) {
+    result.pop_back();
+  }
+  return result;
+}
+
+MBO_ALWAYS_INLINE absl::StatusOr<GlobData> GlobNormalizeData(
+    std::string_view glob_pattern,
+    const Glob2Re2Options& options) {
+  MBO_MOVE_TO_OR_RETURN(GlobNormalizeStr(glob_pattern, options), std::string pattern);
+  char chr = '\0';
+  std::size_t slash_0 = std::string_view::npos;
+  std::size_t slash_1 = std::string_view::npos;
+  bool range_with_slash = false;
+  glob_pattern = pattern;  // Operate on the normalized pattern
+  GlobData result;
+  result.pattern = pattern;
+  while (!glob_pattern.empty()) {
+    chr = glob_pattern.front();
+    switch (chr) {
+      case '\\': {
+        glob_pattern.remove_prefix(2);
+        continue;
+      }
+      case '[': {
+        if (!options.allow_ranges) {
+          glob_pattern.remove_prefix(1);
+          continue;
+        }
+        std::string tmp_re2;  //  We do not care about the translated pattern here.
+        const bool negative = glob_pattern.size() > 1 && glob_pattern[1] == '!';
+        MBO_RETURN_IF_ERROR(GlobFindRange(glob_pattern, tmp_re2));
+        range_with_slash |= !negative && absl::StrContains(tmp_re2, '/');
+        continue;
+      }
+      case '/':
+        range_with_slash = false;
+        slash_0 = slash_1;
+        slash_1 = result.pattern.size() - glob_pattern.size();
+        glob_pattern.remove_prefix(1);
+        continue;
+      default: glob_pattern.remove_prefix(1); continue;
+    }
+  }
+  if (range_with_slash) {
+    result.path_len = result.pattern.size();
+    result.mixed = true;
+    return result;
+  }
+  if (result.pattern.size() > 1 && result.pattern.ends_with('/')) {
+    result.pattern.pop_back();
+    slash_1 = slash_0;
+  }
+  if (slash_1 == std::string_view::npos) {
+    return result;
+  }
+  bool star_star = result.pattern.find("**", slash_1) != std::string::npos;
+  if (star_star) {
+    result.path_len = result.pattern.size();
+  } else {
+    result.path_len = slash_1;
+  }
+  return result;
+}
+
+MBO_ALWAYS_INLINE void Glob2Re2ExpressionImplStar(std::string& re2_pattern, std::string_view& pattern) {
+  // Check for '**' if allowed, remove '**' or '*' otherwise and drop all following '*'.
+  // Normalize also changed '**' to '*' if `!options.allow_star_star`.
+  if (!pattern.starts_with("**")) {
+    pattern.remove_prefix(1);
+    absl::StrAppend(&re2_pattern, "[^/]*");
+    return;
+  }
+  pattern.remove_prefix(2);
+  if (re2_pattern.ends_with('/') && (pattern.starts_with('/') || pattern.empty())) {
+    // We have '/\*\*(/|$)' so the preceeding '/'s are optional.
+    re2_pattern.pop_back();  // Drop the last '/'.
+    absl::StrAppend(&re2_pattern, "(/.+)?");
+    return;
+  }
+  if (re2_pattern.empty() && pattern.starts_with('/')) {
+    // We have '^\*\*(/|$)'
+    pattern.remove_prefix(1);  // The next '/'
+    if (pattern.starts_with("**/") || pattern == "**") {
+      absl::StrAppend(&re2_pattern, "(.+/)+");
+    } else {
+      absl::StrAppend(&re2_pattern, "(.+/)?");
+    }
+    return;
+  }
+  absl::StrAppend(&re2_pattern, ".*");
+}
+
+MBO_ALWAYS_INLINE absl::StatusOr<std::string> Glob2Re2ExpressionImpl(
+    std::string_view pattern,
+    const Glob2Re2Options& options) {
+  std::string re2_pattern;
+  re2_pattern.reserve(pattern.size() * 2);
+  while (!pattern.empty()) {
+    char chr = pattern.front();
+    switch (chr) {
+      default:
+        re2_pattern += chr;
+        pattern.remove_prefix(1);
+        continue;
+      case '\\':
+        // if (pattern.size() < 2) { already handled
+        absl::StrAppend(&re2_pattern, pattern.substr(0, 2));
+        pattern.remove_prefix(2);
+        continue;
+      case '*': {
+        Glob2Re2ExpressionImplStar(re2_pattern, pattern);
+        continue;
+      }
+      case '?':
+        absl::StrAppend(&re2_pattern, "[^/]");
+        pattern.remove_prefix(1);
+        continue;
+      case '{':
+      case '}':
+      case '(':
+      case ')':
+      case '|':
+      case '+':
+      case '.':
+        // Characters that need to be escaped since they are literal in rglob but special in re2.
+        re2_pattern += '\\';
+        re2_pattern += chr;
+        pattern.remove_prefix(1);
+        continue;
+      case '[':
+        if (!options.allow_ranges) {
+          re2_pattern += pattern.front();
+          pattern.remove_prefix(1);
+          continue;
+        }
+        MBO_RETURN_IF_ERROR(GlobFindRange(pattern, re2_pattern));
+        continue;
+    }
+  }
+  return re2_pattern;
+}
+
+}  // namespace
+
+namespace file_internal {
+
+absl::StatusOr<GlobParts> GlobSplit(std::string_view pattern, const Glob2Re2Options& options) {
+  MBO_MOVE_TO_OR_RETURN(GlobNormalizeData(pattern, options), GlobData data);
+  if (data.mixed) {
+    return GlobParts{
+        .path_pattern{data.pattern},
+        .file_pattern{},
+        .mixed = true,
+    };
+  }
+  if (data.path_len.has_value()) {
+    if (*data.path_len + 1 < data.pattern.size()) {
+      return GlobParts{
+          .path_pattern{data.pattern.substr(0, *data.path_len)},
+          .file_pattern{data.pattern.substr(*data.path_len + 1)},
+      };
+    }
+    return GlobParts{
+        .path_pattern{data.pattern},
+        .file_pattern{},
+    };
+  }
+  return GlobParts{
+      .path_pattern{},
+      .file_pattern{data.pattern},
+  };
+}
+
+absl::StatusOr<std::string> Glob2Re2Expression(std::string_view pattern, const Glob2Re2Options& re2_convert_options) {
+  MBO_MOVE_TO_OR_RETURN(GlobNormalizeStr(pattern, re2_convert_options), const std::string normalized_pattern);
+  return Glob2Re2ExpressionImpl(normalized_pattern, re2_convert_options);
+}
+
+absl::StatusOr<std::unique_ptr<const RE2>> Glob2Re2(
+    std::string_view pattern,
+    const Glob2Re2Options& re2_convert_options) {
+  MBO_MOVE_TO_OR_RETURN(Glob2Re2Expression(pattern, re2_convert_options), std::string re2_pattern);
+  return std::make_unique<RE2>(re2_pattern, re2_convert_options.re2_options);
+}
+
+absl::Status GlobLoop(const fs::path& root, const GlobOptions& options, const GlobEntryFunc& func) {
+  const fs::path normalized_root = (root.empty() || root == ".") ? fs::current_path() : root.lexically_normal();
+  std::error_code error_code;
+  if (!fs::exists(normalized_root, error_code)) {
+    return absl::NotFoundError(
+        error_code ? error_code.message() : absl::StrFormat("Path does not exist: '%s'.", normalized_root));
+  }
+  auto it = fs::recursive_directory_iterator(normalized_root, options.dir_options, error_code);
+  if (error_code) {
+    return absl::CancelledError(error_code.message());
+  }
+  for (const fs::directory_entry& entry : it) {
+    const GlobEntry glob_entry{
+        .rel_path =
+            options.use_rel_path ? std::optional<fs::path>{entry.path().lexically_relative(root)} : std::nullopt,
+        .entry = entry,
+        .depth = it.depth(),
+    };
+    MBO_ASSIGN_OR_RETURN(const GlobEntryAction action, func(glob_entry));
+    switch (action) {
+      case GlobEntryAction::kContinue: continue;
+      case GlobEntryAction::kStop: break;
+      case GlobEntryAction::kDoNotRecurse: {
+        it.disable_recursion_pending();
+        continue;
+      }
+    }
+  }
+  return absl::OkStatus();
+}
+
+}  // namespace file_internal
+
+using namespace mbo::file::file_internal;
+
+absl::Status GlobRe2(const fs::path& root, const RE2& regex, const GlobOptions& options, const GlobEntryFunc& func) {
+  const auto wrap_func = [&](const GlobEntry& entry) -> absl::StatusOr<GlobEntryAction> {
+    if (!RE2::FullMatch(entry.MaybeRelativePath().native(), regex)) {
+      return GlobEntryAction::kContinue;  // Path/Filename rejected.
+    }
+    return func(entry);
+  };
+  return GlobLoop(root, options, wrap_func);
+}
+
+absl::Status Glob(
+    const fs::path& root,
+    std::string_view pattern,
+    const Glob2Re2Options& re2_convert_options,
+    const GlobOptions& options,
+    const GlobEntryFunc& func) {
+  MBO_MOVE_TO_OR_RETURN(Glob2Re2(pattern, re2_convert_options), const std::unique_ptr<const RE2> regex);
+  return GlobRe2(root, *regex, options, func);
+}
+
+}  // namespace mbo::file

--- a/mbo/file/glob.h
+++ b/mbo/file/glob.h
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MBO_FILE_GLOB_H_
+#define MBO_FILE_GLOB_H_
+
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "absl/status/statusor.h"
+#include "mbo/types/extend.h"
+#include "re2/re2.h"
+
+namespace mbo::file {
+
+struct GlobOptions {
+  // Whether to apply pattern matching to the path part relative to the given root or to just the
+  // full entry path. In other words, if true, then the entries will generally be prefixed with the
+  // requested root. If that root is itself relative, then it will be relative to the current path.
+  // Note that computing the relative path is not free.
+  // If true, then `GlobEntry.rel_path` will be set and `GlobEntry.MaybeRelativePath` will return
+  // the relative path as opposed to `entry.path`.
+  bool use_rel_path : 1 = false;
+
+  // Options passed to the creation of the `std::filesystem::recursive_directory_iterator`.
+  std::filesystem::directory_options dir_options = std::filesystem::directory_options::skip_permission_denied;
+};
+
+struct Glob2Re2Options {
+  bool allow_star_star : 1 = true;
+  bool allow_ranges : 1 = true;
+
+  RE2::Options re2_options = {};
+};
+
+namespace file_internal {
+
+struct GlobParts : mbo::types::Extend<GlobParts> {
+  std::string path_pattern;
+  std::string file_pattern;
+  bool mixed = false;  // Parts or all of the path can be a file component.
+};
+
+// Split a glob expression into its path and filename components.
+//
+// The function is "incomplete" in its ability to identify ranges that can accept slashes.
+// - while a range `[/]` is normalized to a single `/` and handled as such,
+// - any other range that can accept a slash can either be a path or file name component. Those cases will
+//   be reported as just a path component with the `mixed = true`.
+absl::StatusOr<GlobParts> GlobSplit(std::string_view pattern, const Glob2Re2Options& options = {});
+
+// Convert `pattern` into a RE2 expression.
+// Supported syntax:
+// - '*' -> '[^/]*'
+// - '?' -> '[^/]'
+// - '**' -> '.*' which requires `options.allow_star_star` and allows '/'.
+//   The generated pattern changes if enclosed in '/' or by pattern start/end to either
+//   '(/.+)?' or '(.+/)?'
+//   That is, the sequence '**/**' will not enforce a directory level. If that is required, then '*/**' or similar has
+//   to be used where the single '*' cannot match a '/' but the presence of a '/' requires a directory level.
+// - Ranges (requires `options.allow_ranges`):
+//   - '[...]': '...' may not be empty. The result is a matching positive range.
+//   - '[!...]': '...' may not be empty. The result is a matching negative range.
+//   - '[]]' -> '[\\]]' which matches the ']'.
+//   - '[!]]' -> '[^\\]]' which matches everythign but ']'.
+//   - ranges may incorrectly match against '/' as that is not handled.
+// Character classes (Posix extension):
+//   Character classes are translated directly. However, they require to be supported in RE2 as
+//   documneted in https://github.com/google/re2/wiki/Syntax.
+absl::StatusOr<std::string> Glob2Re2Expression(std::string_view pattern, const Glob2Re2Options& options = {});
+
+// Convert `pattern` into a RE2 instance.
+// See `Glob2Re2Expression` for supported syntax.
+absl::StatusOr<std::unique_ptr<const RE2>> Glob2Re2(std::string_view pattern, const Glob2Re2Options& options = {});
+
+}  // namespace file_internal
+
+struct GlobEntry : mbo::types::Extend<GlobEntry> {
+  const std::optional<const std::filesystem::path> rel_path;  // Must be first
+  const std::filesystem::directory_entry entry;
+  const int depth;
+
+  // Returns the path for the `entry` either as is or elative to `root` if that was requested using
+  // `GlobOptions.use_rel_path`.
+  const std::filesystem::path& MaybeRelativePath() const noexcept {
+    return rel_path.has_value() ? *rel_path : entry.path();
+  }
+
+  // Returns the file's size or 0 if the entry is not a regular file.
+  // If the file size cannot be retrieved, then the function also returns 0.
+  std::size_t FileSize() const noexcept {
+    if (!entry.is_regular_file()) {
+      return 0;
+    }
+    std::error_code error;
+    std::size_t result = entry.file_size(error);
+    return error ? 0 : result;
+  }
+};
+
+enum class GlobEntryAction {
+  // Normal continuation.
+  kContinue = 0,
+
+  // Prevents recursion into a directory by calling `disable_recursion_pending` on the dir iterator.
+  kDoNotRecurse = 1,
+
+  // Stops the iteration without generating an error. If an error is appropriate, then the callback
+  // should return with `absl::CancelledError(reason);
+  kStop = 2,
+};
+
+using GlobEntryFunc = std::function<absl::StatusOr<GlobEntryAction>(const GlobEntry&)>;
+
+// Recursive glob function that uses `RE2` regular expressions for path/filename matching.
+absl::Status GlobRe2(
+    const std::filesystem::path& root,
+    const RE2& regex,
+    const GlobOptions& options,
+    const GlobEntryFunc& func);
+
+// Recursive glob function that uses `glob` expressions for path/filename matching.
+absl::Status Glob(
+    const std::filesystem::path& root,
+    std::string_view pattern,
+    const Glob2Re2Options& re2_convert_options,
+    const GlobOptions& options,
+    const GlobEntryFunc& func);
+
+}  // namespace mbo::file
+
+#endif  // MBO_FILE_GLOB_H_

--- a/mbo/file/glob_main.cc
+++ b/mbo/file/glob_main.cc
@@ -1,0 +1,260 @@
+// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cmath>
+#include <filesystem>
+#include <functional>
+#include <iostream>
+#include <string>
+#include <string_view>
+
+#include "absl//container/btree_map.h"
+#include "absl//container/btree_set.h"
+#include "absl/flags/flag.h"
+#include "absl/flags/parse.h"
+#include "absl/flags/usage.h"
+#include "absl/status/status.h"
+#include "absl/strings/str_format.h"
+#include "mbo/file/glob.h"
+#include "mbo/strings/numbers.h"
+
+// NOLINTBEGIN: Bad flags macros
+
+ABSL_FLAG(bool, dotdir, true, "Whether to allow or skip directories starting with a '.'.");
+ABSL_FLAG(bool, dotfile, true, "Whether to allow or skip files starting with a '.'.");
+ABSL_FLAG(bool, entries, true, "Whether to show entries.");
+ABSL_FLAG(bool, fast, false, "Whether to show entries fast (no buffering and no field alignment).");
+ABSL_FLAG(
+    bool,
+    re2,
+    false,
+    "Whether to use re2 regular exressions. This program uses Google's Re2: "
+    "https://github.com/google/re2/wiki/Syntax.");
+ABSL_FLAG(bool, size, false, "Whether to show file sizes.");
+ABSL_FLAG(bool, sum, false, "Whether to show summary. This is automatically enabled if --sum_every > 0.");
+ABSL_FLAG(std::size_t, sum_every, 0, "If greater zero, then show a summary after every X entry.");
+ABSL_FLAG(bool, sum_extensions, false, "Whether to show an extension summary.");
+
+// NOLINTEND
+
+namespace fs = std::filesystem;
+
+using mbo::strings::BigNumber;
+using mbo::strings::BigNumberLen;
+
+class Entries {
+ public:
+  Entries()
+      : dotdir_(absl::GetFlag(FLAGS_dotdir)),
+        dotfile_(absl::GetFlag(FLAGS_dotfile)),
+        show_fast_(absl::GetFlag(FLAGS_fast)),
+        show_size_(absl::GetFlag(FLAGS_size)),
+        sum_extensions_(absl::GetFlag(FLAGS_sum_extensions)),
+        sum_every_(absl::GetFlag(FLAGS_sum_every)),
+        stats_{
+            {"Dirs", dirs_},          {"FileSize", bytes_}, {"Files", files_}, {"Links", links_},
+            {"MaxDepth", max_depth_}, {"Other", other_},    {"Total", seen_},
+        } {}
+
+  Entries(const Entries&) = delete;
+  Entries& operator=(const Entries&) = delete;
+  Entries(Entries&&) noexcept = default;
+  Entries& operator=(Entries&&) = delete;
+
+  mbo::file::GlobEntryAction Add(const mbo::file::GlobEntry& entry) {
+    // Filter
+    if (entry.entry.is_directory()) {
+      if (!dotdir_ && entry.entry.path().filename().string().starts_with('.')) {
+        return mbo::file::GlobEntryAction::kDoNotRecurse;
+      }
+    } else if (entry.entry.is_regular_file()) {
+      if (!dotfile_ && entry.entry.path().filename().string().starts_with('.')) {
+        return mbo::file::GlobEntryAction::kContinue;
+      }
+    }
+    // Actual Add
+    if (entry.entry.is_directory()) {
+      ++dirs_;
+    } else if (entry.entry.is_symlink()) {
+      ++links_;
+    } else if (entry.entry.is_regular_file()) {
+      ++files_;
+      const std::size_t size = entry.FileSize();
+      bytes_ += size;
+      bytes_len_ = std::max(bytes_len_, BigNumberLen(size));
+      if (sum_extensions_) {
+        if (entry.entry.path().has_extension()) {
+          const auto ext = entry.entry.path().extension().string();
+          ++extensions_[absl::StrCat("FileExt(", ext, ")")];
+          extensions_[absl::StrCat("FileSize(", ext, ")")] += size;
+        } else if (entry.entry.path().filename().string().starts_with(".")) {
+          // Dot files (/.conf) are shown as the full file name.
+          const auto ext = entry.entry.path().filename().string();
+          ++extensions_[absl::StrCat("FileExt(", ext, ")")];
+          extensions_[absl::StrCat("FileSize(", ext, ")")] += size;
+        } else {
+          ++extensions_["FileExt()"];
+          extensions_["FileSize()"] += size;
+        }
+      }
+    } else {
+      ++other_;
+    }
+    max_depth_ = std::max(max_depth_, static_cast<std::size_t>(entry.depth));
+    ++seen_;
+    // Maybe Print
+    if (show_fast_) {
+      PrintFastEntry(entry);
+    } else {
+      entries_.emplace(entry);
+    }
+    if (sum_every_ > 0 && seen_ % sum_every_ == 0) {
+      std::cout << "\n";
+      PrintSummary();
+    }
+    return mbo::file::GlobEntryAction::kContinue;
+  }
+
+  void PrintEntry(const mbo::file::GlobEntry& entry) const {
+    if (show_size_) {
+      std::cout << absl::StreamFormat("%*s ", bytes_len_, BigNumber(entry.FileSize()));
+    }
+    std::cout << entry.MaybeRelativePath().string() << "\n";
+  }
+
+  void PrintFastEntry(const mbo::file::GlobEntry& entry) const {
+    if (show_size_) {
+      std::cout << absl::StreamFormat("%*s ", bytes_len_, BigNumber(entry.FileSize()));
+    }
+    std::cout << entry.MaybeRelativePath().string() << "\n";
+  }
+
+  void PrintAllEntries() const {
+    for (const auto& entry : entries_) {
+      PrintEntry(entry);
+    }
+  }
+
+  void PrintSummary(bool show_extensions = false) const {
+    std::size_t name_len{1};
+    unsigned val_len{1};
+    absl::btree_map<std::string, std::size_t> data;
+    if (show_extensions) {
+      for (const auto& [name, count] : extensions_) {
+        const auto len = data.emplace(absl::StrCat(name, ":"), count).first->first.size();
+        name_len = std::max(name_len, len);
+        val_len = std::max(val_len, BigNumberLen(count));
+      }
+    }
+    for (const auto& [name, value] : stats_) {
+      const auto len = data.emplace(absl::StrCat(name, ":"), value).first->first.size();
+      name_len = std::max(name_len, len);
+      val_len = std::max(val_len, BigNumberLen(value));
+    }
+    for (const auto& [name, value] : data) {
+      std::cout << absl::StrFormat("%-*s %*s\n", name_len, name, val_len, BigNumber(value));
+    }
+  }
+
+ private:
+  const bool dotdir_{true};
+  const bool dotfile_{true};
+  const bool show_fast_{false};
+  const bool show_size_{false};
+  const bool sum_extensions_{false};
+  const std::size_t sum_every_{0};
+  absl::btree_set<mbo::file::GlobEntry> entries_;
+  absl::btree_map<std::string, std::size_t> extensions_;
+  std::size_t dirs_{0};
+  std::size_t links_{0};
+  std::size_t files_{0};
+  std::size_t other_{0};
+  std::size_t bytes_{0};
+  std::size_t max_depth_{0};
+  std::size_t seen_{0};
+  const absl::btree_map<std::string, std::size_t&> stats_;
+  unsigned bytes_len_{1};
+};
+
+constexpr std::string_view kUsage = R"usage(glob [<flags>*] <path> [<pattern>]
+
+Glog is a simple recursive file finder that can produce a summary. If a pattern
+is given then it follows `fnmame` convention or Google's RE2 is --re2 is set.
+
+The default glob expressions support:
+- '*':          Any number of characters not including '/'.
+- '**':         Any number of characters including '/'.
+- '?':          A single character (not '/').
+- '\?':         the character '?'. Note that all characters can be escaped.
+- '[<range>]':  Requiring the given <range> or ranges.
+- '[!<range>]': Excluding the given <range> or ranges.
+- '[]':         An empty range is not allowed.
+                This means that ']' can be allowed as the first character of a
+                range, e.g. '[!]]' allows all but ']'.
+
+A range is interpreted as follows:
+- 'x':          The single character x.
+- 'x-z':        Any character from 'x' to 'z' inclusive.
+- 'x-' or '-x': The characters 'x' and '-'.
+
+Examples:
+
+- Show all files under the current directory with their sizes but un-aligned:
+    glob . --fast --size
+
+- Show only a summary of all files:
+    glob . --noentries --sum
+
+- Show only a summary for all files excluding all directories and files starting
+  with a '.' while showing stats per file extension:
+    glob . --nodotdir --nodotfile --noentries --sum_extensions
+
+- Show only a summary of files under the current directory whose extension is
+  one of [.cc, .cpp, .h] and which are not under any directory that starts with
+  a dot (.):
+    glob . '.*[.](cc|cpp|h)' --nodotdir --noentries --re2 --sum
+    glob . '([^/]|/[^.])*[.](cc|cpp|h)' --noentries --re2 --sum
+
+Flags:)usage";
+
+int main(int argc, char** argv) {
+  absl::SetProgramUsageMessage(kUsage);
+  const std::vector<char*> args = absl::ParseCommandLine(argc, argv);
+  if (args.empty() || args.size() > 3) {
+    std::cerr << "Requires at most 2 arguments: glob [<path>] [<pattern>]\n";
+    return 1;
+  }
+  if (absl::GetFlag(FLAGS_sum_every) > 0 || absl::GetFlag(FLAGS_sum_extensions)) {
+    absl::SetFlag(&FLAGS_sum, true);
+  }
+  const fs::path root = fs::path(args.size() >= 2 ? args[1] : ".").lexically_normal();
+  const std::string pattern{args.size() == 3 ? args[2] : (absl::GetFlag(FLAGS_re2) ? ".*" : "**")};
+  Entries entries;
+  const auto collect = std::bind_front(&Entries::Add, &entries);
+  const auto result = absl::GetFlag(FLAGS_re2) ? mbo::file::GlobRe2(root, pattern, {}, collect)
+                                               : mbo::file::Glob(root, pattern, {}, {}, collect);
+  if (!result.ok()) {
+    std::cerr << "ERROR: " << result.message() << "\n";
+    return 1;
+  }
+  if (absl::GetFlag(FLAGS_entries) && !absl::GetFlag(FLAGS_fast)) {
+    entries.PrintAllEntries();
+  }
+  if (absl::GetFlag(FLAGS_sum)) {
+    std::cout << "\n";
+    entries.PrintSummary(absl::GetFlag(FLAGS_sum_extensions));
+  }
+  return 0;
+}

--- a/mbo/file/glob_test.cc
+++ b/mbo/file/glob_test.cc
@@ -1,0 +1,219 @@
+// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// If the macro `TEST_FNMATCH` is defined, and the <fnmatch.h> include is available, then the test
+// for `Glob2Re2` verifies that its result matches that of `fnmatch`.
+#define TEST_FNMATCH
+
+#if !__has_include(<fnmatch.h>)
+# undef TEST_FNMATCH
+#endif
+
+#include "mbo/file/glob.h"
+
+#ifdef TEST_FNMATCH
+# include <fnmatch.h>
+#endif  // TEST_FNMATCH
+#include <array>
+#include <source_location>
+
+#include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "mbo/testing/status.h"
+#include "re2/re2.h"
+
+namespace mbo::file {
+namespace {
+
+using namespace mbo::file::file_internal;
+
+using ::mbo::testing::IsOk;
+using ::mbo::testing::IsOkAndHolds;
+using ::mbo::testing::StatusIs;
+using ::testing::NotNull;
+
+struct GlobTest : ::testing::Test {
+  static void Glob2Re2Match(
+      std::string_view glob_pattern,
+      std::string_view text,
+      bool expected = true,
+      const std::source_location sloc = std::source_location::current()) {
+    SCOPED_TRACE(absl::StrCat(
+        "\n", sloc.file_name(), ":", sloc.line(), "\n  Pattern: '", glob_pattern, "'\n  Text: '", text, "'"));
+    MBO_ASSERT_OK_AND_MOVE_TO(Glob2Re2(glob_pattern), std::unique_ptr<const RE2> re2_pattern);
+    ASSERT_THAT(re2_pattern, NotNull());
+    EXPECT_THAT(re2::RE2::FullMatch(text, *re2_pattern), expected);
+#ifdef TEST_FNMATCH
+    EXPECT_THAT(fnmatch(glob_pattern.data(), text.data(), 0) == 0, expected);
+#endif  // TEST_FNMATCH
+  }
+};
+
+TEST_F(GlobTest, Glob2Re2Pattern) {
+  EXPECT_THAT(Glob2Re2Expression(""), IsOkAndHolds(""));
+  EXPECT_THAT(Glob2Re2Expression("/"), IsOkAndHolds("/"));
+  EXPECT_THAT(Glob2Re2Expression("//"), IsOkAndHolds("/"));
+  EXPECT_THAT(Glob2Re2Expression("/\\//\\/\\/"), IsOkAndHolds("/"));
+  EXPECT_THAT(Glob2Re2Expression("*"), IsOkAndHolds("[^/]*"));
+  EXPECT_THAT(Glob2Re2Expression("**"), IsOkAndHolds(".*"));
+  EXPECT_THAT(Glob2Re2Expression("***"), IsOkAndHolds(".*"));
+  EXPECT_THAT(Glob2Re2Expression("****"), IsOkAndHolds(".*"));
+  EXPECT_THAT(Glob2Re2Expression("*****"), IsOkAndHolds(".*"));
+  EXPECT_THAT(Glob2Re2Expression("**/**"), IsOkAndHolds("(.+/)+.*"));
+  EXPECT_THAT(Glob2Re2Expression("**/**/"), IsOkAndHolds("(.+/)+.*"));
+  EXPECT_THAT(Glob2Re2Expression("/**/**"), IsOkAndHolds("(/.+)?(/.+)?"));
+  EXPECT_THAT(Glob2Re2Expression("/**/**/"), IsOkAndHolds("(/.+)?(/.+)?"));
+  EXPECT_THAT(Glob2Re2Expression("*/*"), IsOkAndHolds("[^/]*/[^/]*"));
+  EXPECT_THAT(Glob2Re2Expression("**", {.allow_star_star = false}), IsOkAndHolds("[^/]*"));
+  EXPECT_THAT(Glob2Re2Expression("***", {.allow_star_star = false}), IsOkAndHolds("[^/]*"));
+  EXPECT_THAT(Glob2Re2Expression("?"), IsOkAndHolds("[^/]"));
+  EXPECT_THAT(Glob2Re2Expression("??"), IsOkAndHolds("[^/][^/]"));
+  EXPECT_THAT(Glob2Re2Expression("."), IsOkAndHolds("\\."));
+  EXPECT_THAT(Glob2Re2Expression(".."), IsOkAndHolds("\\.\\."));
+  EXPECT_THAT(Glob2Re2Expression("+"), IsOkAndHolds("\\+"));
+  EXPECT_THAT(Glob2Re2Expression("/"), IsOkAndHolds("/"));
+  EXPECT_THAT(Glob2Re2Expression("\\\\"), IsOkAndHolds("\\\\"));
+  EXPECT_THAT(Glob2Re2Expression("a\\\\b"), IsOkAndHolds("a\\\\b"));
+  EXPECT_THAT(Glob2Re2Expression("*/*****?/"), IsOkAndHolds("[^/]*/.*[^/]"));
+  EXPECT_THAT(Glob2Re2Expression("/*/*****?/"), IsOkAndHolds("/[^/]*/.*[^/]"));
+  EXPECT_THAT(Glob2Re2Expression("**/abc/**"), IsOkAndHolds("(.+/)?abc(/.+)?"));
+  EXPECT_THAT(Glob2Re2Expression("abc/**"), IsOkAndHolds("abc(/.+)?"));
+  EXPECT_THAT(Glob2Re2Expression("**/abc"), IsOkAndHolds("(.+/)?abc"));
+  EXPECT_THAT(Glob2Re2Expression("[]]"), IsOkAndHolds("[\\]]"));
+  EXPECT_THAT(Glob2Re2Expression("[!]]"), IsOkAndHolds("[^\\]]"));
+  EXPECT_THAT(Glob2Re2Expression("[:]"), IsOkAndHolds("[:]"));
+  EXPECT_THAT(Glob2Re2Expression("[:]"), IsOkAndHolds("[:]"));
+  EXPECT_THAT(Glob2Re2Expression("[[:alnum:]]"), IsOkAndHolds("[[:alnum:]]"));
+  EXPECT_THAT(Glob2Re2Expression("[[:alpha:][:digit:]]"), IsOkAndHolds("[[:alpha:][:digit:]]"));
+  EXPECT_THAT(Glob2Re2Expression("/**file/**/.*[.](cc|h)"), IsOkAndHolds("/.*file(/.+)?/\\.[^/]*[.]\\(cc\\|h\\)"));
+  EXPECT_THAT(Glob2Re2Expression("ftp://foo"), IsOkAndHolds("ftp://foo"));
+  EXPECT_THAT(Glob2Re2Expression("ftp\\://foo"), IsOkAndHolds("ftp\\:/foo"));
+  EXPECT_THAT(Glob2Re2Expression("foo/bar"), IsOkAndHolds("foo/bar"));
+  EXPECT_THAT(Glob2Re2Expression("foo//bar"), IsOkAndHolds("foo/bar"));
+  EXPECT_THAT(Glob2Re2Expression("foo\\/bar"), IsOkAndHolds("foo/bar"));
+  EXPECT_THAT(Glob2Re2Expression("foo\\//bar"), IsOkAndHolds("foo/bar"));
+  EXPECT_THAT(Glob2Re2Expression("foo/\\//bar"), IsOkAndHolds("foo/bar"));
+  EXPECT_THAT(Glob2Re2Expression("foo\\*bar"), IsOkAndHolds("foo\\*bar"));
+  EXPECT_THAT(Glob2Re2Expression("foo\\**bar"), IsOkAndHolds("foo\\*[^/]*bar"));
+  EXPECT_THAT(Glob2Re2Expression("foo\\***bar"), IsOkAndHolds("foo\\*.*bar"));
+  EXPECT_THAT(Glob2Re2Expression("foo\\****bar"), IsOkAndHolds("foo\\*.*bar"));
+  EXPECT_THAT(Glob2Re2Expression("foo\\*bar", {.allow_star_star = false}), IsOkAndHolds("foo\\*bar"));
+  EXPECT_THAT(Glob2Re2Expression("foo\\**bar", {.allow_star_star = false}), IsOkAndHolds("foo\\*[^/]*bar"));
+  EXPECT_THAT(Glob2Re2Expression("foo\\***bar", {.allow_star_star = false}), IsOkAndHolds("foo\\*[^/]*bar"));
+  EXPECT_THAT(Glob2Re2Expression("foo\\****bar", {.allow_star_star = false}), IsOkAndHolds("foo\\*[^/]*bar"));
+  EXPECT_THAT(Glob2Re2Expression("foo\\\\*bar"), IsOkAndHolds("foo\\\\[^/]*bar"));
+  EXPECT_THAT(Glob2Re2Expression("foo\\\\**bar"), IsOkAndHolds("foo\\\\.*bar"));
+  EXPECT_THAT(Glob2Re2Expression("foo\\\\***bar"), IsOkAndHolds("foo\\\\.*bar"));
+  EXPECT_THAT(Glob2Re2Expression("foo\\\\****bar"), IsOkAndHolds("foo\\\\.*bar"));
+}
+
+TEST_F(GlobTest, Glob2Re2PatternErrors) {
+  const auto no_char_to_escape =
+      StatusIs(absl::StatusCode::kInvalidArgument, "No character left to escape at end of pattern.");
+  EXPECT_THAT(Glob2Re2Expression("\\"), no_char_to_escape);
+  const auto unterminated_range = StatusIs(absl::StatusCode::kInvalidArgument, "Unterminated range expression.");
+  EXPECT_THAT(Glob2Re2Expression("[]"), unterminated_range);
+  EXPECT_THAT(Glob2Re2Expression("[!]"), unterminated_range);
+  const auto unterminated_char_class = StatusIs(absl::StatusCode::kInvalidArgument, "Unterminated character-class.");
+  EXPECT_THAT(Glob2Re2Expression("[[:]"), unterminated_char_class);
+  EXPECT_THAT(Glob2Re2Expression("[[:]]"), unterminated_char_class);
+  const auto empty_character_class =
+      StatusIs(absl::StatusCode::kInvalidArgument, "Invalid empty character-class name.");
+  EXPECT_THAT(Glob2Re2Expression("[[::]]"), empty_character_class);
+  EXPECT_THAT(Glob2Re2Expression("[[::]][[:alpha:]]"), empty_character_class);
+  EXPECT_THAT(
+      Glob2Re2Expression("[[:::]]"), StatusIs(absl::StatusCode::kInvalidArgument, "Invalid character-class name ':'."));
+  Glob2Re2Options disable_ranges{.allow_ranges = false};
+  constexpr std::array<std::string_view, 6> kRangeIssues{
+      "[]", "[!]", "[[:]", "[[:]]", "[[::]]", "[[::]][[:alpha:]]",
+  };
+  for (std::string_view issue : kRangeIssues) {
+    EXPECT_THAT(Glob2Re2Expression(issue, disable_ranges), IsOk());
+  }
+}
+
+TEST_F(GlobTest, Glob2Re2) {
+  Glob2Re2Match("[]]", "]");
+  Glob2Re2Match("[]]", "x", false);
+  Glob2Re2Match("[]]", "", false);
+  Glob2Re2Match("[!]]", "]", false);
+  Glob2Re2Match("[!]]", "", false);
+  Glob2Re2Match("[!]]", "x");
+  Glob2Re2Match("[!]]", "]", false);
+  Glob2Re2Match("[!]]", "x]", false);
+  Glob2Re2Match("[!]]", "!]", false);
+  Glob2Re2Match("[!]]]", "x]");
+  Glob2Re2Match("[[:alpha:][:digit:]]", "", false);
+  Glob2Re2Match("[[:alpha:][:digit:]]", "a");
+  Glob2Re2Match("[[:alpha:][:digit:]]", "0");
+  Glob2Re2Match("[[:alpha:][:digit:]]", "!", false);
+  Glob2Re2Match("[[:alpha:]![:digit:]]", "!");
+}
+
+MATCHER_P3(HasParts, path_matcher, file_matcher, is_mixed, "") {
+  using ::testing::AllOf;
+  using ::testing::Field;
+  return ::testing::ExplainMatchResult(
+      AllOf(
+          Field("path_pattern", &GlobParts::path_pattern, path_matcher),
+          Field("file_pattern", &GlobParts::file_pattern, file_matcher), Field("mixed", &GlobParts::mixed, is_mixed)),
+      arg, result_listener);
+}
+
+TEST_F(GlobTest, GlobSplit) {
+  EXPECT_THAT(
+      GlobSplit("\\"), StatusIs(absl::StatusCode::kInvalidArgument, "No character left to escape at end of pattern."));
+  EXPECT_THAT(GlobSplit(""), IsOkAndHolds(HasParts("", "", false)));
+  EXPECT_THAT(GlobSplit("/"), IsOkAndHolds(HasParts("/", "", false)));
+  EXPECT_THAT(GlobSplit("//"), IsOkAndHolds(HasParts("/", "", false)));
+  EXPECT_THAT(GlobSplit("a/b"), IsOkAndHolds(HasParts("a", "b", false)));
+  EXPECT_THAT(GlobSplit("a//b"), IsOkAndHolds(HasParts("a", "b", false)));
+  EXPECT_THAT(GlobSplit("a/b/c"), IsOkAndHolds(HasParts("a/b", "c", false)));
+  EXPECT_THAT(GlobSplit("a/**/c"), IsOkAndHolds(HasParts("a/**", "c", false)));
+  EXPECT_THAT(GlobSplit("a/b/**"), IsOkAndHolds(HasParts("a/b/**", "", false)));
+}
+
+TEST_F(GlobTest, GlobSplitWithRanges) {
+  EXPECT_THAT(GlobSplit("a[/]b/[/]c"), IsOkAndHolds(HasParts("a/b", "c", false)));
+  EXPECT_THAT(GlobSplit("a[/]b/[-/]c"), IsOkAndHolds(HasParts("a/b/[-/]c", "", true)));
+  EXPECT_THAT(GlobSplit("a[/]b/[!/]c"), IsOkAndHolds(HasParts("a/b", "[!/]c", false)));
+  EXPECT_THAT(GlobSplit("a[/]b/[/]/c"), IsOkAndHolds(HasParts("a/b", "c", false)));
+  EXPECT_THAT(GlobSplit("a[/]b/[-/]/c"), IsOkAndHolds(HasParts("a/b/[-/]", "c", false)));
+  EXPECT_THAT(GlobSplit("a[/]b/[!/]/c"), IsOkAndHolds(HasParts("a/b/[!/]", "c", false)));
+  EXPECT_THAT(GlobSplit("a[/]/b/[/]c"), IsOkAndHolds(HasParts("a/b", "c", false)));
+  EXPECT_THAT(GlobSplit("a[/]/b/[-/]c"), IsOkAndHolds(HasParts("a/b/[-/]c", "", true)));
+  EXPECT_THAT(GlobSplit("a[/]/b/[!/]c"), IsOkAndHolds(HasParts("a/b", "[!/]c", false)));
+  EXPECT_THAT(GlobSplit("a[/]/b/[/]/c"), IsOkAndHolds(HasParts("a/b", "c", false)));
+  EXPECT_THAT(GlobSplit("a[/]/b/[-/]/c"), IsOkAndHolds(HasParts("a/b/[-/]", "c", false)));
+  EXPECT_THAT(GlobSplit("a[/]/b/[!/]/c"), IsOkAndHolds(HasParts("a/b/[!/]", "c", false)));
+
+  EXPECT_THAT(GlobSplit("a[/]b[/]c"), IsOkAndHolds(HasParts("a/b", "c", false)));
+  EXPECT_THAT(GlobSplit("a[/]b[-/]c"), IsOkAndHolds(HasParts("a/b[-/]c", "", true)));
+  EXPECT_THAT(GlobSplit("a[/]b[!/]c"), IsOkAndHolds(HasParts("a", "b[!/]c", false)));
+  EXPECT_THAT(GlobSplit("a[/]b[/]/c"), IsOkAndHolds(HasParts("a/b", "c", false)));
+  EXPECT_THAT(GlobSplit("a[/]b[-/]/c"), IsOkAndHolds(HasParts("a/b[-/]", "c", false)));
+  EXPECT_THAT(GlobSplit("a[/]b[!/]/c"), IsOkAndHolds(HasParts("a/b[!/]", "c", false)));
+  EXPECT_THAT(GlobSplit("a[/]/b[/]c"), IsOkAndHolds(HasParts("a/b", "c", false)));
+  EXPECT_THAT(GlobSplit("a[/]/b[-/]c"), IsOkAndHolds(HasParts("a/b[-/]c", "", true)));
+  EXPECT_THAT(GlobSplit("a[/]/b[!/]c"), IsOkAndHolds(HasParts("a", "b[!/]c", false)));
+  EXPECT_THAT(GlobSplit("a[/]/b[/]/c"), IsOkAndHolds(HasParts("a/b", "c", false)));
+  EXPECT_THAT(GlobSplit("a[/]/b[-/]/c"), IsOkAndHolds(HasParts("a/b[-/]", "c", false)));
+  EXPECT_THAT(GlobSplit("a[/]/b[!/]/c"), IsOkAndHolds(HasParts("a/b[!/]", "c", false)));
+}
+
+}  // namespace
+}  // namespace mbo::file

--- a/mbo/file/ini/ini_file_test.cc
+++ b/mbo/file/ini/ini_file_test.cc
@@ -38,9 +38,7 @@ using ::testing::SizeIs;
 namespace fs = std::filesystem;
 
 struct IniFileTest : ::testing::Test {
-  static std::string SrcDir(std::string_view src_rel) {
-    return mbo::testing::RunfilesDirOrDie("com_helly25_mbo", src_rel);
-  }
+  static std::string SrcDir(std::string_view src_rel) { return mbo::testing::RunfilesDirOrDie("helly25_mbo", src_rel); }
 
   static std::string TmpDir() { return ::testing::TempDir(); }
 };

--- a/mbo/strings/BUILD.bazel
+++ b/mbo/strings/BUILD.bazel
@@ -36,6 +36,25 @@ cc_test(
 )
 
 cc_library(
+    name = "numbers_cc",
+    hdrs = ["numbers.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//mbo/container:limited_map_cc",
+    ],
+)
+
+cc_test(
+    name = "numbers_test",
+    srcs = ["numbers_test.cc"],
+    deps = [
+        ":numbers_cc",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
     name = "parse_cc",
     srcs = ["parse.cc"],
     hdrs = ["parse.h"],
@@ -65,6 +84,7 @@ cc_test(
 cc_library(
     name = "split_cc",
     hdrs = ["split.h"],
+    visibility = ["//visibility:public"],
 )
 
 cc_test(

--- a/mbo/strings/numbers.h
+++ b/mbo/strings/numbers.h
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MBO_STRINGS_NUMBERS_H_
+#define MBO_STRINGS_NUMBERS_H_
+
+#include <cassert>
+#include <cmath>
+#include <concepts>
+#include <limits>
+#include <string>
+
+#include "mbo/container/limited_map.h"
+
+namespace mbo::strings {
+
+// Determine the string length needed to convert a number into a representation where thousands are
+// separated by `'`.
+template<std::integral T>
+requires(sizeof(T) <= 8)
+unsigned BigNumberLen(T v) {
+  // We could compute this for smller numbers as:
+  //   len = 1 + static_cast<unsigned>(std::log10(std::abs(v)));
+  //   return (v < 0 ? 1 : 0) + len + std::floor((len - 1) / 3);
+  // But:
+  //   a) The input would need to be converted to `long double` and evne then can only handle up to
+  //      17 digits, but int64_t needs 19.
+  //   b) That computation is slow.
+  //   c) Binary searching in a limit/length map is much faster.
+  if constexpr (std::signed_integral<T>) {
+    if (v < 0) {
+      if (v == std::numeric_limits<T>::min()) {
+        return 1 + BigNumberLen(-(v + 1));
+      }
+      return 1 + BigNumberLen(-v);
+    }
+  }
+  // Perform binary search for length to limit the number of tests.
+  // We first check whether we can do even better by limiting us to 4 byte types.
+  // We use a macro to let the compiler compute the actual length values.
+  if constexpr (sizeof(v) <= 4) {
+#define CHECK_CAP(cap) std::make_pair<uint32_t, unsigned>(cap, std::string_view(#cap).size() - 3)
+    constexpr auto kData = mbo::container::ToLimitedMap<std::pair<uint32_t, unsigned>>({
+        CHECK_CAP(4'294'967'295ULL),
+        CHECK_CAP(999'999'999ULL),
+        CHECK_CAP(99'999'999ULL),
+        CHECK_CAP(9'999'999ULL),
+        CHECK_CAP(999'999ULL),
+        CHECK_CAP(99'999ULL),
+        CHECK_CAP(9'999ULL),
+        CHECK_CAP(999ULL),
+        CHECK_CAP(99ULL),
+        CHECK_CAP(9ULL),
+        CHECK_CAP(0ULL),
+    });
+#undef CHECK_CAP
+    return kData.lower_bound(v)->second;
+  } else {
+#define CHECK_CAP(cap) std::make_pair<uint64_t, unsigned>(cap, std::string_view(#cap).size() - 3)
+    constexpr auto kData = mbo::container::ToLimitedMap<std::pair<uint64_t, unsigned>>({
+        CHECK_CAP(18'446'744'073'709'551'615ULL),
+        CHECK_CAP(9'999'999'999'999'999'999ULL),
+        CHECK_CAP(999'999'999'999'999'999ULL),
+        CHECK_CAP(99'999'999'999'999'999ULL),
+        CHECK_CAP(9'999'999'999'999'999ULL),
+        CHECK_CAP(999'999'999'999'999ULL),
+        CHECK_CAP(99'999'999'999'999ULL),
+        CHECK_CAP(9'999'999'999'999ULL),
+        CHECK_CAP(999'999'999'999ULL),
+        CHECK_CAP(99'999'999'999ULL),
+        CHECK_CAP(9'999'999'999ULL),
+        CHECK_CAP(999'999'999ULL),
+        CHECK_CAP(99'999'999ULL),
+        CHECK_CAP(9'999'999ULL),
+        CHECK_CAP(999'999ULL),
+        CHECK_CAP(99'999ULL),
+        CHECK_CAP(9'999ULL),
+        CHECK_CAP(999ULL),
+        CHECK_CAP(99ULL),
+        CHECK_CAP(9ULL),
+        CHECK_CAP(0ULL),
+    });
+#undef CHECK_CAP
+    return kData.lower_bound(v)->second;
+  }
+}
+
+// Convert the number to a string representation with thousands separators.
+template<std::integral T>
+std::string BigNumber(T v) {
+  const std::string tmp = std::to_string(v);
+  const std::size_t neg = tmp.starts_with('-') ? 1 : 0;
+  const std::size_t ofs = tmp.size() % 3;
+  std::string res;
+  {
+    const std::size_t cap = tmp.size() + std::floor((tmp.size() - neg - 1) / 3);
+    if (cap > res.capacity()) {
+      res.reserve(cap);
+    }
+  }
+  std::size_t pos{0};
+  for (; pos < tmp.size(); ++pos) {
+    if (pos > neg && pos % 3 == ofs) {
+      break;
+    }
+    res.push_back(tmp[pos]);
+  }
+  while (pos < tmp.size()) {
+    res.push_back('\'');
+    res.push_back(tmp[pos]);
+    res.push_back(tmp[++pos]);
+    res.push_back(tmp[++pos]);
+    ++pos;
+  }
+  return res;
+}
+
+}  // namespace mbo::strings
+
+#endif  // MBO_STRINGS_NUMBERS_H_

--- a/mbo/strings/numbers_test.cc
+++ b/mbo/strings/numbers_test.cc
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mbo/strings/numbers.h"
+
+#include <limits>
+#include <string>
+#include <string_view>
+
+#include "absl/strings/str_format.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace mbo::strings {
+namespace {
+
+using ::testing::Gt;
+using ::testing::Pair;
+using ::testing::StartsWith;
+
+struct NumbersTest : ::testing::Test {
+  template<typename T>
+  static void BigNumberTest(T v, unsigned expected_len, std::string_view expected_str) {
+    SCOPED_TRACE(absl::StrFormat("Number: %d", v));
+    unsigned len = BigNumberLen(v);
+    std::string str = BigNumber(v);
+    EXPECT_THAT(str, expected_str);
+    EXPECT_THAT(str.size(), len) << "  Number: '" << str << "'";
+    EXPECT_THAT(len, expected_len) << "  Number: '" << str << "'";
+  }
+};
+
+template<typename T>
+struct TestData {
+  T value;
+  unsigned expected_len;
+  std::string_view expected_str;
+};
+
+TEST_F(NumbersTest, BigNumberMinMax) {
+  BigNumberTest<char>(-128, 4, "-128");
+  BigNumberTest<char>(127, 3, "127");
+  BigNumberTest<unsigned char>(255, 3, "255");
+  BigNumberTest<int16_t>(std::numeric_limits<int16_t>::min(), 7, "-32'768");
+  BigNumberTest<int16_t>(std::numeric_limits<int16_t>::max(), 6, "32'767");
+  BigNumberTest<uint16_t>(std::numeric_limits<uint16_t>::max(), 6, "65'535");
+  BigNumberTest<int32_t>(std::numeric_limits<int32_t>::min(), 14, "-2'147'483'648");
+  BigNumberTest<int32_t>(std::numeric_limits<int32_t>::max(), 13, "2'147'483'647");
+  BigNumberTest<uint32_t>(std::numeric_limits<uint32_t>::max(), 13, "4'294'967'295");
+  BigNumberTest<int64_t>(std::numeric_limits<int64_t>::min(), 26, "-9'223'372'036'854'775'808");
+  BigNumberTest<int64_t>(std::numeric_limits<int64_t>::max(), 25, "9'223'372'036'854'775'807");
+  BigNumberTest<uint64_t>(std::numeric_limits<uint64_t>::max(), 26, "18'446'744'073'709'551'615");
+}
+
+TEST_F(NumbersTest, BigNumberInt32) {
+  constexpr TestData<int32_t> kTests[] = {
+      {0, 1, "0"},
+      {1, 1, "1"},
+      {9, 1, "9"},
+      {10, 2, "10"},
+      {99, 2, "99"},
+      {100, 3, "100"},
+      {999, 3, "999"},
+      {1'000, 5, "1'000"},
+      {9'999, 5, "9'999"},
+      {10'000, 6, "10'000"},
+      {99'999, 6, "99'999"},
+      {100'000, 7, "100'000"},
+      {999'999, 7, "999'999"},
+      {1'000'000, 9, "1'000'000"},
+      {9'999'999, 9, "9'999'999"},
+      {10'000'000, 10, "10'000'000"},
+      {99'999'999, 10, "99'999'999"},
+      {100'000'000, 11, "100'000'000"},
+      {999'999'999, 11, "999'999'999"},
+      {1'000'000'000, 13, "1'000'000'000"},
+      {-1, 2, "-1"},
+      {-9, 2, "-9"},
+      {-10, 3, "-10"},
+      {-99, 3, "-99"},
+      {-100, 4, "-100"},
+      {-999, 4, "-999"},
+      {-1'000, 6, "-1'000"},
+      {-9'999, 6, "-9'999"},
+      {-10'000, 7, "-10'000"},
+      {-99'999, 7, "-99'999"},
+      {-100'000, 8, "-100'000"},
+      {-999'999, 8, "-999'999"},
+      {-1'000'000, 10, "-1'000'000"},
+      {-9'999'999, 10, "-9'999'999"},
+      {-10'000'000, 11, "-10'000'000"},
+      {-99'999'999, 11, "-99'999'999"},
+      {-100'000'000, 12, "-100'000'000"},
+      {-999'999'999, 12, "-999'999'999"},
+      {-1'000'000'000, 14, "-1'000'000'000"},
+  };
+  for (const auto& [value, expected_len, expected_str] : kTests) {
+    BigNumberTest(value, expected_len, expected_str);
+  }
+}
+
+TEST_F(NumbersTest, BigNumberInt64) {
+  constexpr TestData<int64_t> kTests[] = {
+      {0, 1, "0"},
+      {1, 1, "1"},
+      {9, 1, "9"},
+      {10, 2, "10"},
+      {99, 2, "99"},
+      {100, 3, "100"},
+      {999, 3, "999"},
+      {1'000, 5, "1'000"},
+      {9'999, 5, "9'999"},
+      {10'000, 6, "10'000"},
+      {99'999, 6, "99'999"},
+      {100'000, 7, "100'000"},
+      {999'999, 7, "999'999"},
+      {1'000'000, 9, "1'000'000"},
+      {9'999'999, 9, "9'999'999"},
+      {10'000'000, 10, "10'000'000"},
+      {99'999'999, 10, "99'999'999"},
+      {100'000'000, 11, "100'000'000"},
+      {999'999'999, 11, "999'999'999"},
+      {1'000'000'000, 13, "1'000'000'000"},
+      {9'999'999'999ull, 13, "9'999'999'999"},
+      {10'000'000'000ull, 14, "10'000'000'000"},
+      {99'999'999'999ull, 14, "99'999'999'999"},
+      {100'000'000'000ull, 15, "100'000'000'000"},
+      {999'999'999'999ull, 15, "999'999'999'999"},
+      {1'000'000'000'000ull, 17, "1'000'000'000'000"},
+      {9'999'999'999'999ull, 17, "9'999'999'999'999"},
+      {10'000'000'000'000ull, 18, "10'000'000'000'000"},
+      {99'999'999'999'999ull, 18, "99'999'999'999'999"},
+      {100'000'000'000'000ull, 19, "100'000'000'000'000"},
+      {999'999'999'999'999ull, 19, "999'999'999'999'999"},
+      {1'000'000'000'000'000ull, 21, "1'000'000'000'000'000"},
+      {9'999'999'999'999'999ull, 21, "9'999'999'999'999'999"},
+      {10'000'000'000'000'000ull, 22, "10'000'000'000'000'000"},
+      {99'999'999'999'999'999ull, 22, "99'999'999'999'999'999"},
+      {100'000'000'000'000'000ull, 23, "100'000'000'000'000'000"},
+      {999'999'999'999'999'999ull, 23, "999'999'999'999'999'999"},
+      {1'000'000'000'000'000'000ull, 25, "1'000'000'000'000'000'000"},
+  };
+  for (const auto& [value, expected_len, expected_str] : kTests) {
+    BigNumberTest(value, expected_len, expected_str);
+  }
+}
+
+}  // namespace
+}  // namespace mbo::strings

--- a/mbo/testing/runfiles_dir.cc
+++ b/mbo/testing/runfiles_dir.cc
@@ -15,6 +15,7 @@
 
 #include "mbo/testing/runfiles_dir.h"
 
+#include <cstdlib>
 #include <string>
 #include <string_view>
 
@@ -25,15 +26,25 @@
 #include "tools/cpp/runfiles/runfiles.h"
 
 namespace mbo::testing {
+namespace {
+std::string SafeStr(const char* str, std::string_view default_str) {
+  if (str) {
+    return std::string(str);
+  }
+  return std::string(default_str);
+}
+}  // namespace
 
 absl::StatusOr<std::string> RunfilesDir(std::string_view workspace, std::string_view source_rel) {
+  const std::string workspace_env = SafeStr(getenv("TEST_WORKSPACE"), workspace);
+
   std::string error;
   std::unique_ptr<bazel::tools::cpp::runfiles::Runfiles> runfiles(
       bazel::tools::cpp::runfiles::Runfiles::CreateForTest(&error));
   if (runfiles == nullptr) {
     return absl::NotFoundError("Could not determine runfiles directory.");
   }
-  return runfiles->Rlocation(mbo::file::JoinPaths(workspace, source_rel));
+  return runfiles->Rlocation(mbo::file::JoinPaths(workspace_env, source_rel));
 }
 
 std::string RunfilesDirOrDie(std::string_view workspace, std::string_view source_rel) {

--- a/mbo/testing/runfiles_dir.h
+++ b/mbo/testing/runfiles_dir.h
@@ -24,8 +24,7 @@
 namespace mbo::testing {
 
 // Returns bazel_tools's `RLocation`.
-// Set `workspace` to the Workspace name (as stated in file `WORKSPACE`).
-// Set `source_rel` to a file or directory relative to the workspace root.
+// If environment variable `WORKSPACE` is present then `workspace` will be ignored.
 absl::StatusOr<std::string> RunfilesDir(std::string_view workspace, std::string_view source_rel);
 std::string RunfilesDirOrDie(std::string_view workspace, std::string_view source_rel);
 

--- a/mbo/types/internal/decompose_count.h
+++ b/mbo/types/internal/decompose_count.h
@@ -448,11 +448,14 @@ struct AggregateInitializerCount
 template<IsAggregate T, typename Indices, typename FieldIndices>
 struct AggregateInitializeableWith;
 
+// clang-format off
 template<IsAggregate T, std::size_t... kIndices, std::size_t... kFieldIndices>
     struct AggregateInitializeableWith<T, std::index_sequence<kIndices...>, std::index_sequence<kFieldIndices...>>
     : std::bool_constant < requires {
   T{std::declval<AnyTypeN<kIndices>>()..., {std::declval<AnyNonBaseTypeN<kFieldIndices, T>>()...}};
 } > {};
+
+// clang-format on
 
 template<typename T, std::size_t N, std::size_t M>
 concept AggregateFieldAtInitializeableWithImpl =

--- a/mbo/types/internal/decompose_count.h.mope
+++ b/mbo/types/internal/decompose_count.h.mope
@@ -260,11 +260,14 @@ struct AggregateInitializerCount
 template<IsAggregate T, typename Indices, typename FieldIndices>
 struct AggregateInitializeableWith;
 
+// clang-format off
 template<IsAggregate T, std::size_t... kIndices, std::size_t... kFieldIndices>
     struct AggregateInitializeableWith<T, std::index_sequence<kIndices...>, std::index_sequence<kFieldIndices...>>
     : std::bool_constant < requires {
   T{std::declval<AnyTypeN<kIndices>>()..., {std::declval<AnyNonBaseTypeN<kFieldIndices, T>>()...}};
 } > {};
+
+// clang-format on
 
 template<typename T, std::size_t N, std::size_t M>
 concept AggregateFieldAtInitializeableWithImpl =

--- a/workspace.bzl
+++ b/workspace.bzl
@@ -105,11 +105,18 @@ def mbo_workspace_load_modules():
         sha256 = "348a643defa9ab34ed9cb2ed1dc54b1c4ffef1282240aa24c457ebd8385ff2d5",
     )
 
-    github_archive(
+    http_archive(
+        name = "rules_python",
+        sha256 = "9c6e26911a79fbf510a8f06d8eedb40f412023cf7fa6d1461def27116bff022c",
+        strip_prefix = "rules_python-1.1.0",
+        url = "https://github.com/bazelbuild/rules_python/releases/download/1.1.0/rules_python-1.1.0.tar.gz",
+    )
+
+    http_archive(
         name = "com_google_protobuf",
-        repo = "https://github.com/protocolbuffers/protobuf",
-        commit = "b407e8416e3893036aee5af9a12bd9b6a0e2b2e6", # v29.3
-        integrity = "sha256-VZElRjOEM/RlpVLp7wmTDGO562lwU5N0FokM/4OoYi0=",
+        sha256 = "008a11cc56f9b96679b4c285fd05f46d317d685be3ab524b2a310be0fbad987e",
+        strip_prefix = "protobuf-29.3",
+        url = "https://github.com/protocolbuffers/protobuf/releases/download/v29.3/protobuf-29.3.tar.gz",
     )
 
     # Cannot yet support toolchains_llvm 1.0.0. It enables C++20 modules in a broken way.
@@ -121,7 +128,7 @@ def mbo_workspace_load_modules():
     # * 2025.02.15: https://github.com/bazel-contrib/toolchains_llvm/pull/461: Add LLVM 19.1.4...19.1.7:
     #     0bd3bff40ab51a8e744ccddfd24f311a9df81c2d / sha256-YpBdoaSAXSatJwLcB2yzuZw5Ls/h5+dcWip+h+pVdUo=
     # In order to go past version 1.0.0 we also add the actual fix:
-    # * 2024.06.06: https://github.com/bazel-contrib/toolchains_llvm/pull/337: Force Clang modules with LLVM >= 14q
+    # * 2024.06.06: https://github.com/bazel-contrib/toolchains_llvm/pull/337: Force Clang modules with LLVM >= 14
     github_archive(
         name = "toolchains_llvm",
         commit = "0bd3bff40ab51a8e744ccddfd24f311a9df81c2d",


### PR DESCRIPTION
* Added function `mbo::strings::BigNumber`: Convert integral number to string with thousands separator.
* Added function `mbo::strings::BigNumberLen`: Calculate required string length for `BigNumer`.
* Added glob functionality:
  * Added struct `mbo::file::Glob2Re2Options`: Control conversion of a [glob pattern](https://man7.org/linux/man-pages/man7/glob.7.html) into a [RE2 pattern](https://github.com/google/re2/wiki/Syntax).
  * Added struct `mbo::file::GlobEntry`: Stores data for a single globbed entry (file, dir, etc.).
  * Added struct `mbo::file::GlobOptions`: Options for functions `Glob2Re2` and `Glob2Re2Expression`.
  * Added enum `mbo::file::GlobEntryAction`: Allows GlobEntryFunc to control further glob progression.
  * Added type `mbo::file::GlobEntryFunc`: Callback for acceptable glob entries.
  * Added function `mbo::file::GlobRe2`: Performs recursive glob functionality using a RE2 pattern.
  * Added function `mbo::file::Glob`: Performs recursive glob functionality using a `fnmatch` style pattern.
  * Added program `glob`: A recursive glob, see `glob --help`.
* WORKSPACE support:
  * Added rules_python and brought back com_google_protobuf support.
* Fixed `RunfilesDir/OrDie` to use environment variable `TEST_WORKSPACE` if present.
* Fixed formatting issue with `mbo/types/internal/decompose_count.h`.
* Downgraded Clang from 19.1.7 to 19.1.6.
* Updated GitHub workflow to test both Bazel flavors.