### PR TITLE
Improve unified_diff tool

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,7 @@
 # To debug bazel options, uncomment next line.
 # common --announce_rc
 
+common --consistent_labels
 common --enable_bzlmod
 common --noincompatible_enable_cc_toolchain_resolution
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 * Downgraded Clang from 19.1.7 to 19.1.6.
 * Updated GitHub workflow to test both Bazel flavors.
 * Fixed issue in with struct names generation when compiling with Clang in mode ASAN.
+* Added ability for unified_diff tool flag `--strip_file_header_prefix` to accept re2 expressions.
+* Fixed various issues for bazelmod based builds.
 
 # 0.3.0
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -26,6 +26,14 @@ bazel_dep(name = "googletest", version = "1.16.0", repo_name = "com_google_googl
 bazel_dep(name = "google_benchmark", version = "1.9.1", repo_name = "com_github_google_benchmark")
 # In Bazelmod we do not need to specify the protobuf version yet.
 # bazel_dep(name = "protobuf", version = "29.3", repo_name = "com_google_protobuf")
+
+bazel_dep(name = "hedron_compile_commands", dev_dependency = True)
+git_override(
+    module_name = "hedron_compile_commands",
+    commit = "6dd21b47db481a70c61698742438230e2399b639",
+    remote = "https://github.com/hedronvision/bazel-compile-commands-extractor.git",
+)
+
 bazel_dep(name = "toolchains_llvm", version = "1.3.0")
 
 git_override(
@@ -34,11 +42,11 @@ git_override(
     commit = "e831f94a8b7f3a39391f5822adcab8e4d443c03b", # Add more tools by default (#463)
 )
 
-llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
+llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm", dev_dependency = True)
 
 llvm.toolchain(
     name = "llvm_toolchain_llvm",
     llvm_version = "19.1.6",
 )
 use_repo(llvm, "llvm_toolchain_llvm")
-register_toolchains("@llvm_toolchain_llvm//:all")
+register_toolchains("@llvm_toolchain_llvm//:all", dev_dependency = True)

--- a/REPO.bazel
+++ b/REPO.bazel
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/mbo/diff/tests/diff_test_test.bzl
+++ b/mbo/diff/tests/diff_test_test.bzl
@@ -75,7 +75,7 @@ def diff_test_test(
                 --ignore_matching_lines={ignore_matching_lines} \\
                 --ignore_space_change={ignore_space_change} \\
                 --strip_comments={strip_comments} \\
-                --strip_file_header_prefix="external/com_helly25_mbo/" \\
+                --strip_file_header_prefix="external/(com_)?helly25_mbo[^/]*/" \\
                 --strip_parsed_comments={strip_parsed_comments} \\
                 || true
         """.format(

--- a/mbo/diff/unified_diff.cc
+++ b/mbo/diff/unified_diff.cc
@@ -256,7 +256,13 @@ class Chunk {
 
  private:
   static std::string FileHeader(const file::Artefact& info, const UnifiedDiff::Options& options) {
-    std::string_view name = absl::StripPrefix(info.name, options.strip_file_header_prefix);
+    std::string_view name;
+    if (options.strip_file_header_prefix.find_first_of(".*?()[]|") == std::string::npos) {
+      name = absl::StripPrefix(info.name, options.strip_file_header_prefix);
+    } else {
+      name = info.name;
+      RE2::Consume(&name, options.strip_file_header_prefix);
+    }
     return absl::StrCat(info.name.empty() ? "-" : name, " ", absl::FormatTime(options.time_format, info.time, info.tz));
   }
 

--- a/mbo/diff/unified_diff_main.cc
+++ b/mbo/diff/unified_diff_main.cc
@@ -76,7 +76,9 @@ ABSL_FLAG(
     std::string,
     strip_file_header_prefix,
     "",
-    "If this is a prefix to a filename in the header, then remove from header.");
+    "\
+If this is a prefix to a filename in the header, then remove from filename in header. This can be \
+a regular expression (https://github.com/google/re2/wiki/Syntax).");
 ABSL_FLAG(
     bool,
     strip_parsed_comments,

--- a/mbo/mope/mope.bzl
+++ b/mbo/mope/mope.bzl
@@ -194,11 +194,12 @@ def _gen_name_base_no_ext(file):
 
 def _build_relative(ctx, file):
     path = "/".join(ctx.build_file_path.split("/")[:-1])
-    return file.short_path.removeprefix("../com_helly25_mbo/").removeprefix(path).removeprefix("/")
+    res = path + "/" + file.basename
+    return res
 
 def _mope_rule_impl(ctx):
     srcs = {_template_base_no_ext(src): src for src in ctx.files.srcs}
-    outs = {_gen_name_base_no_ext(out): ctx.actions.declare_file(_build_relative(ctx, out)) for out in ctx.outputs.outs}
+    outs = {_gen_name_base_no_ext(out): out for out in ctx.outputs.outs}
     inis = {_base_no_ext(ini): ini.path for ini in ctx.files.data if ini.extension == "ini"}
     if srcs.keys() != outs.keys():
         fail("Files in `srcs` and `outs` do not match on basenames without extensions.")


### PR DESCRIPTION
* Added ability for unified_diff tool flag `--strip_file_header_prefix` to accept re2 expressions.
* Fixed various issues for bazelmod based builds.