### PR TITLE
Improve runfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 * Fixed issue in with struct names generation when compiling with Clang in mode ASAN.
 * Added ability for unified_diff tool flag `--strip_file_header_prefix` to accept re2 expressions.
 * Fixed various issues for bazelmod based builds.
+* Improved `mbo::testing::RunfilesDir/OrDie` to support a single param variant that understands bazel labels. Further add support for other repos than the current one by reading the repo mapping.
+* Fixed `//mbo/file/ini:ini_file_test` to be able to pass when run as remote repository.
 
 # 0.3.0
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,7 +17,7 @@
 module(name = "helly25_mbo", version = "0.3.0", repo_name = "com_helly25_mbo")
 
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
-bazel_dep(name = "rules_cc", version = "0.0.17")
+bazel_dep(name = "rules_cc", version = "0.1.1")
 bazel_dep(name = "platforms", version = "0.0.11")
 
 bazel_dep(name = "abseil-cpp", version = "20250127.0", repo_name = "com_google_absl")

--- a/mbo/file/ini/BUILD.bazel
+++ b/mbo/file/ini/BUILD.bazel
@@ -41,6 +41,7 @@ cc_test(
     "//mbo/file:file_cc",
     "//mbo/testing:runfiles_dir_cc",
     "//mbo/testing:status_cc",
+    "@com_google_absl//absl/log:initialize",
     "@com_google_googletest//:gtest_main",
   ],
 )

--- a/mbo/file/ini/ini_file_test.cc
+++ b/mbo/file/ini/ini_file_test.cc
@@ -19,6 +19,7 @@
 #include <string>
 #include <string_view>
 
+#include "absl/log/initialize.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "mbo/diff/unified_diff.h"
@@ -38,15 +39,17 @@ using ::testing::SizeIs;
 namespace fs = std::filesystem;
 
 struct IniFileTest : ::testing::Test {
-  static std::string SrcDir(std::string_view src_rel) { return mbo::testing::RunfilesDirOrDie("helly25_mbo", src_rel); }
+  static void SetUpTestSuite() { absl::InitializeLog(); }
+
+  static std::string SrcDir(std::string_view src_rel) { return mbo::testing::RunfilesDirOrDie(src_rel); }
 
   static std::string TmpDir() { return ::testing::TempDir(); }
 };
 
 TEST_F(IniFileTest, TestGolden) {
-  const std::string dir = SrcDir("mbo/file/ini/tests");
+  const fs::path test_ini = SrcDir("@com_helly25_mbo//mbo/file/ini:tests/test.ini");
   std::map<std::string, std::pair<std::string, std::string>> tests;
-  for (const auto& entry : fs::directory_iterator{dir}) {
+  for (const auto& entry : fs::directory_iterator{test_ini.parent_path()}) {
     std::string_view filename = entry.path().native();
     if (entry.path().extension() == ".ini") {
       tests[entry.path().stem().native()].first = filename;

--- a/mbo/testing/BUILD.bazel
+++ b/mbo/testing/BUILD.bazel
@@ -42,9 +42,11 @@ cc_library(
     hdrs = ["runfiles_dir.h"],
     deps = [
         "//mbo/file:file_cc",
+        "//mbo/status:status_macros_cc",
         "@com_google_absl//absl/log:absl_check",
         "@com_google_absl//absl/status:status",
         "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
         "@bazel_tools//tools/cpp/runfiles",
     ],
     testonly = True,

--- a/mbo/testing/runfiles_dir.cc
+++ b/mbo/testing/runfiles_dir.cc
@@ -18,11 +18,15 @@
 #include <cstdlib>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "absl/log/absl_check.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_split.h"
 #include "mbo/file/file.h"
+#include "mbo/status/status_macros.h"
 #include "tools/cpp/runfiles/runfiles.h"
 
 namespace mbo::testing {
@@ -35,16 +39,70 @@ std::string SafeStr(const char* str, std::string_view default_str) {
 }
 }  // namespace
 
+using bazel::tools::cpp::runfiles::Runfiles;
+
+absl::StatusOr<std::string> RunfilesDir(std::string_view source) {
+  if (source.starts_with("@")) {
+    std::pair<std::string_view, std::string> parts = absl::StrSplit(source, absl::MaxSplits("//", 1));
+    parts.first.remove_prefix(1);
+    if (auto pos = parts.second.find(':'); pos != std::string::npos) {
+      parts.second[pos] = '/';
+    }
+    return RunfilesDir(parts.first, parts.second);
+  }
+  if (source.starts_with("//")) {
+    source.remove_prefix(2);
+    std::string source_rel(source);
+    if (auto pos = source_rel.find(':'); pos != std::string::npos) {
+      source_rel[pos] = '/';
+    }
+    return RunfilesDir("", source_rel);
+  }
+  return RunfilesDir("", source);
+}
+
 absl::StatusOr<std::string> RunfilesDir(std::string_view workspace, std::string_view source_rel) {
   const std::string workspace_env = SafeStr(getenv("TEST_WORKSPACE"), workspace);
 
   std::string error;
-  std::unique_ptr<bazel::tools::cpp::runfiles::Runfiles> runfiles(
-      bazel::tools::cpp::runfiles::Runfiles::CreateForTest(&error));
+  std::unique_ptr<Runfiles> runfiles(Runfiles::CreateForTest(std::string(workspace_env), &error));
   if (runfiles == nullptr) {
-    return absl::NotFoundError("Could not determine runfiles directory.");
+    return absl::NotFoundError(absl::StrCat("Could not determine runfiles directory: ", error));
+  }
+  if (!workspace.empty() && workspace != workspace_env) {
+    // Must lookup the workspace and translate it.
+    const std::string test_bin = SafeStr(getenv("TEST_SRCDIR"), workspace);
+    if (test_bin.empty()) {
+      return absl::NotFoundError("Environment variable `TEST_SRCDIR` not present.");
+    }
+    static constexpr std::string_view kRunfiles = ".runfiles";
+    if (!test_bin.ends_with(kRunfiles)) {
+      return absl::NotFoundError("Environment variable `TEST_SRCDIR` does not end in '.runfiles'.");
+    }
+    const std::string mapping_file = absl::StrCat(test_bin, "/_repo_mapping");
+    MBO_ASSIGN_OR_RETURN(const std::string mapping, mbo::file::GetContents(mapping_file));
+    for (std::string_view line : absl::StrSplit(mapping, '\n')) {
+      const std::vector<std::string_view> parts = absl::StrSplit(line, ',', absl::AllowEmpty());
+      if (parts.size() == 3 && parts[1] == workspace) {
+        return runfiles->Rlocation(mbo::file::JoinPaths(parts[2], source_rel));
+      }
+    }
+    auto result = runfiles->Rlocation(mbo::file::JoinPaths(workspace, source_rel));
+    if (result.empty()) {
+      result = runfiles->Rlocation(mbo::file::JoinPaths(workspace_env, source_rel));
+    }
+    if (!result.empty()) {
+      return result;
+    }
+    return absl::NotFoundError(absl::StrFormat("Repo '%s' not found in mapping.", workspace));
   }
   return runfiles->Rlocation(mbo::file::JoinPaths(workspace_env, source_rel));
+}
+
+std::string RunfilesDirOrDie(std::string_view source) {
+  const auto runfiles_dir = RunfilesDir(source);
+  ABSL_QCHECK_OK(runfiles_dir);
+  return *runfiles_dir;
 }
 
 std::string RunfilesDirOrDie(std::string_view workspace, std::string_view source_rel) {

--- a/mbo/testing/runfiles_dir.h
+++ b/mbo/testing/runfiles_dir.h
@@ -24,9 +24,18 @@
 namespace mbo::testing {
 
 // Returns bazel_tools's `RLocation`.
-// If environment variable `WORKSPACE` is present then `workspace` will be ignored.
+// If environment variable `TEST_WORKSPACE` is present then `workspace` will be ignored.
 absl::StatusOr<std::string> RunfilesDir(std::string_view workspace, std::string_view source_rel);
 std::string RunfilesDirOrDie(std::string_view workspace, std::string_view source_rel);
+
+// The single parameter variants understand relative path, but also bazel labels.
+// If a source starts with '@' then it is assumed to be an absolute label. The function will split
+// the source at the first '//' to separate workspace and relative source.
+// If a source starts with '//', then it is assumed to be curren workspace rooted source.
+// In either case above the first ':' in the resulting source will be replaced with '/'.
+// Otherwise the source is assumed to be a plain file path.
+absl::StatusOr<std::string> RunfilesDir(std::string_view source);
+std::string RunfilesDirOrDie(std::string_view source);
 
 }  // namespace mbo::testing
 


### PR DESCRIPTION
* Improved `mbo::testing::RunfilesDir/OrDie` to support a single param variant that understands bazel labels. Further add support for other repos than the current one by reading the repo mapping.
* Fixed `//mbo/file/ini:ini_file_test` to be able to pass when run as remote repository.
