### PR TITLE
Added ContainerProxy and Opaque types.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.3.0
+  rev: v3.0.0
   hooks:
   - id: check-merge-conflict
   - id: check-yaml
@@ -10,6 +10,6 @@ repos:
     exclude: ^mbo/diff/tests/abc_whitespace.*$
 
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v16.0.4
+  rev: v19.1.6
   hooks:
   - id: clang-format

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@
 * Fixed various issues for bazelmod based builds.
 * Improved `mbo::testing::RunfilesDir/OrDie` to support a single param variant that understands bazel labels. Further add support for other repos than the current one by reading the repo mapping.
 * Fixed `//mbo/file/ini:ini_file_test` to be able to pass when run as remote repository.
+* Added struct `mbo::types::ContainerProxy` which allows to add container access to other types including smart pointers of containers.
+* Added struct `mbo::types::OpaquePtr` an opaque alternative to `std::unique_ptr` which works with forward declared types.
+* Added struct `mbo::types::OpaqueValue` an `OpaquePtr` with direct access, comparison and hashing which will not allow a nullptr.
+* Added struct `mbo::types::OpaqueContainer` an `OpaqueValue` with direct container access.
+* Changed pre-commit to use clang-format 19.1.6.
 
 # 0.3.0
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ The C++ library is organized in functional groups each residing in their own dir
         * meta-type `IfTrueThenVoid`: Helper type to inject default cases and to ensure the required type expansion is always possible.
     * mbo/types:compare_cc, mbo/types/compare.h
         * comparator `mbo::types::CompareLess` which is compatible to std::Less but allows container optimizations.
+    * mbo/types:container_proxy_cc, mbo/types/container_proxy.h
+        * struct `mbo::types::ContainerProxy` which allows to add container access to other types including smart pointers of containers.
     * mbo/types:extend_cc, mbo/types/extend.h
         * crtp-struct `Extend`: Enables extending of struct/class types with basic functionality.
         * crtp-struct `ExtendNoDefault` Like `Extend` but without default extender functionality.
@@ -157,6 +159,10 @@ The C++ library is organized in functional groups each residing in their own dir
     * mbo/types:no_destruct_cc, mbo/types/no_destruct.h
         * struct `NoDestruct<T>`: Implements a type that allows to use any type as a static constant.
         * Mainly, this prevents calling the destructor and thus prevents termination issues (initialization order fiasco).
+    * mbo/types:opaque_cc, mbo/types/opaque.h
+        * struct `mbo::types::OpaquePtr` an opaque alternative to `std::unique_ptr` which works with forward declared types.
+        * struct `mbo::types::OpaqueValue` an `OpaquePtr` with direct access, comparison and hashing which will not allow a nullptr.
+        * struct `mbo::types::OpaqueContainer` an `OpaqueValue` with direct container access.
     * mbo/types:ref_wrap_cc, mbo/types/ref_wrap.h
         * template-type `RefWrap<T>`: similar to `std::reference_wrapper` but supports operators `->` and `*`.
     * mbo/types:required_cc, mbo/types/required.h

--- a/mbo/container/any_scan.h
+++ b/mbo/container/any_scan.h
@@ -355,18 +355,18 @@ class AnyScanImpl {
   requires(kAccessByRef)
   explicit AnyScanImpl(MakeAnyScanData<Container, kScanMode> data)
       : funcs_{
-          .iter =
-              [data = data] {
-                auto pos = MakeSharedIterator(data.container());
-                return IterFuncs{
-                    .more = [data = data, pos = pos]() -> bool { return *pos != data.container().end(); },
-                    .curr = [&it = *pos]() -> AccessType { return *it; },
-                    .next = [&it = *pos] { ++it; },
-                };
-              },
-          .empty = [data = data] { return data.empty(); },
-          .size = [data = data] { return data.size(); },
-      } {}
+            .iter =
+                [data = data] {
+                  auto pos = MakeSharedIterator(data.container());
+                  return IterFuncs{
+                      .more = [data = data, pos = pos]() -> bool { return *pos != data.container().end(); },
+                      .curr = [&it = *pos]() -> AccessType { return *it; },
+                      .next = [&it = *pos] { ++it; },
+                  };
+                },
+            .empty = [data = data] { return data.empty(); },
+            .size = [data = data] { return data.size(); },
+        } {}
 
   // For MakConvertingScan
   template<AcceptableContainer Container>
@@ -376,19 +376,19 @@ class AnyScanImpl {
       && std::constructible_from<value_type, AccessType>)
   explicit AnyScanImpl(MakeAnyScanData<Container, kScanMode> data)
       : funcs_{
-          // NOTE: data must be copied here!
-          .iter =
-              [data = data] {
-                auto pos = MakeSharedIterator(data.container());
-                return IterFuncs{
-                    .more = [data = data, pos = pos]() -> bool { return *pos != data.container().end(); },
-                    .curr = [&it = *pos]() -> AccessType { return AccessType(*it); },
-                    .next = [&it = *pos] { ++it; },
-                };
-              },
-          .empty = [data = data] { return data.empty(); },
-          .size = [data = data] { return data.size(); },
-      } {}
+            // NOTE: data must be copied here!
+            .iter =
+                [data = data] {
+                  auto pos = MakeSharedIterator(data.container());
+                  return IterFuncs{
+                      .more = [data = data, pos = pos]() -> bool { return *pos != data.container().end(); },
+                      .curr = [&it = *pos]() -> AccessType { return AccessType(*it); },
+                      .next = [&it = *pos] { ++it; },
+                  };
+                },
+            .empty = [data = data] { return data.empty(); },
+            .size = [data = data] { return data.size(); },
+        } {}
 
   // NOLINTEND(bugprone-forwarding-reference-overload)
 
@@ -405,10 +405,10 @@ class AnyScanImpl {
 
     iterator_impl()
         : funcs_{
-            .more = [] { return false; },
-            .curr = nullptr,
-            .next = [] {},
-        } {}
+              .more = [] { return false; },
+              .curr = nullptr,
+              .next = [] {},
+          } {}
 
     explicit iterator_impl(const AccessFuncs& funcs) : funcs_(funcs.iter()) {}
 
@@ -510,8 +510,8 @@ class AnyScan : public container_internal::AnyScanImpl<ValueType, DifferenceType
  public:
   AnyScan(const std::initializer_list<ValueType>& data)
       : AnyScanImpl(
-          container_internal::MakeAnyScanData<std::initializer_list<ValueType>, container_internal::ScanMode::kAny>(
-              data)) {}
+            container_internal::MakeAnyScanData<std::initializer_list<ValueType>, container_internal::ScanMode::kAny>(
+                data)) {}
 
   template<::mbo::types::ContainerHasInputIterator Container>
   requires(std::constructible_from<ValueType, typename std::remove_cvref_t<Container>::value_type>)
@@ -533,8 +533,8 @@ class ConstScan
  public:
   ConstScan(const std::initializer_list<ValueType>& data)
       : AnyScanImpl(
-          container_internal::MakeAnyScanData<std::initializer_list<ValueType>, container_internal::ScanMode::kConst>(
-              data)) {}
+            container_internal::MakeAnyScanData<std::initializer_list<ValueType>, container_internal::ScanMode::kConst>(
+                data)) {}
 
   template<container_internal::AcceptableContainer Container>
   requires(std::constructible_from<const ValueType, typename std::remove_cvref_t<Container>::value_type>)
@@ -556,8 +556,8 @@ class ConvertingScan
  public:
   ConvertingScan(const std::initializer_list<ValueType>& data)
       : AnyScanImpl(
-          container_internal::
-              MakeAnyScanData<std::initializer_list<ValueType>, container_internal::ScanMode::kConverting>(data)) {}
+            container_internal::
+                MakeAnyScanData<std::initializer_list<ValueType>, container_internal::ScanMode::kConverting>(data)) {}
 
   template<container_internal::AcceptableContainer Container>
   requires(std::constructible_from<ValueType, typename std::remove_cvref_t<Container>::value_type>)

--- a/mbo/container/internal/limited_ordered.h
+++ b/mbo/container/internal/limited_ordered.h
@@ -99,9 +99,10 @@ class [[nodiscard]] LimitedOrdered {
     constexpr ~Data() noexcept
     requires(std::is_trivially_destructible_v<Value>)
     = default;
+
     ~Data() noexcept
     requires(!std::is_trivially_destructible_v<Value>)
-    {};
+    {}
 
     Value data;
     None none;
@@ -378,7 +379,8 @@ class [[nodiscard]] LimitedOrdered {
   }
 
   constexpr LimitedOrdered() noexcept = default;
-  constexpr explicit LimitedOrdered(const Compare& key_comp) noexcept : key_comp_(key_comp){};
+
+  constexpr explicit LimitedOrdered(const Compare& key_comp) noexcept : key_comp_(key_comp) {}
 
   constexpr LimitedOrdered(const LimitedOrdered& other) noexcept {
     for (; size_ < other.size_; ++size_) {

--- a/mbo/container/limited_map.h
+++ b/mbo/container/limited_map.h
@@ -79,7 +79,7 @@ class LimitedMap final
 
   constexpr LimitedMap() noexcept = default;
 
-  constexpr explicit LimitedMap(const KeyComp& key_comp) noexcept : LimitedBase(key_comp){};
+  constexpr explicit LimitedMap(const KeyComp& key_comp) noexcept : LimitedBase(key_comp) {}
 
   constexpr LimitedMap(const LimitedMap& other) noexcept : LimitedBase(other) {}
 

--- a/mbo/container/limited_set.h
+++ b/mbo/container/limited_set.h
@@ -69,7 +69,7 @@ class LimitedSet final : public container_internal::LimitedOrdered<Key, Key, Key
 
   constexpr ~LimitedSet() noexcept = default;
 
-  constexpr explicit LimitedSet(const Compare& key_comp) noexcept : LimitedBase(key_comp){};
+  constexpr explicit LimitedSet(const Compare& key_comp) noexcept : LimitedBase(key_comp) {}
 
   constexpr LimitedSet(const LimitedSet& other) noexcept : LimitedBase(other) {}
 

--- a/mbo/container/limited_vector.h
+++ b/mbo/container/limited_vector.h
@@ -85,7 +85,7 @@ class LimitedVector final {
 
     constexpr ~Data() noexcept
     requires(!std::is_trivially_destructible_v<T>)
-    {};
+    {}
 
     None none;
     T data;

--- a/mbo/mope/mope.bzl
+++ b/mbo/mope/mope.bzl
@@ -65,13 +65,21 @@ def _clang_format_impl(ctx, src, dst):
         tools = clang_format_tool,
         command = """
             CLANG_FORMAT="{clang_format}"
-            if [ "{clang_format}" == "clang-format-auto" ] || [ -x "${{CLANG_FORMAT}}" ]; then
+            if [ "{clang_format}" == "clang-format-auto" ] || [ ! -x "${{CLANG_FORMAT}}" ]; then
                 if [ -x "external/llvm_toolchain_llvm/bin/clang-format" ]; then
                     CLANG_FORMAT="external/llvm_toolchain_llvm/bin/clang-format"
                 elif [ -x "${{LLVM_PATH}}/bin/clang-format" ]; then
                     CLANG_FORMAT="${{LLVM_PATH}}/bin/clang-format"
                 elif [ $(which "clang_format") ]; then
                     CLANG_FORMAT="clang_format"
+                elif [ $(which "clang-format-23") ]; then
+                    CLANG_FORMAT="clang-format-23"
+                elif [ $(which "clang-format-22") ]; then
+                    CLANG_FORMAT="clang-format-22"
+                elif [ $(which "clang-format-21") ]; then
+                    CLANG_FORMAT="clang-format-21"
+                elif [ $(which "clang-format-20") ]; then
+                    CLANG_FORMAT="clang-format-20"
                 elif [ $(which "clang-format-19") ]; then
                     CLANG_FORMAT="clang-format-19"
                 elif [ $(which "clang-format-18") ]; then
@@ -121,7 +129,7 @@ _clang_format_common_attrs = {
     ),
     "_clang_format_tool": attr.string(
         doc = "The target of the clang-format executable.",
-        default = CLANG_FORMAT_BINARY if type(CLANG_FORMAT_BINARY) == "string" else "clang-format",
+        default = CLANG_FORMAT_BINARY if type(CLANG_FORMAT_BINARY) == "string" else "clang-format-auto",
     ) if CLANG_FORMAT_BINARY else attr.label(
         doc = "The target of the clang-format executable.",
         default = Label("@llvm_toolchain_llvm//:bin/clang-format"),

--- a/mbo/strings/split.h
+++ b/mbo/strings/split.h
@@ -24,7 +24,7 @@ namespace mbo::strings {
 // Modifier for `absl::StrSplit` that creates at most two parts separated by 'sep'.
 class AtLast {
  public:
-  explicit AtLast(char sep) : sep_(sep){};
+  explicit AtLast(char sep) : sep_(sep) {}
 
   std::string_view Find(std::string_view text, std::size_t pos) const {
     std::size_t next_pos = text.substr(pos).rfind(sep_);

--- a/mbo/types/BUILD.bazel
+++ b/mbo/types/BUILD.bazel
@@ -123,6 +123,30 @@ cc_test(
 )
 
 cc_library(
+    name = "container_proxy_cc",
+    hdrs = ["container_proxy.h"],
+)
+
+cc_library(
+    name = "opaque_cc",
+    hdrs = ["opaque.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":container_proxy_cc",
+        "@com_google_absl//absl/hash",
+    ],
+)
+
+cc_test(
+    name = "opaque_test",
+    srcs = ["opaque_test.cc"],
+    deps = [
+        ":opaque_cc",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
     name = "ref_wrap_cc",
     hdrs = ["ref_wrap.h"],
     visibility = ["//visibility:public"],

--- a/mbo/types/container_proxy.h
+++ b/mbo/types/container_proxy.h
@@ -1,0 +1,183 @@
+// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MBO_TYPES_CONTAINER_PROXY_H_
+#define MBO_TYPES_CONTAINER_PROXY_H_
+
+#include <compare>
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+#include "absl/hash/hash.h"
+
+namespace mbo::types {
+
+// ContainerProxy is a wrapper for a type `T` which provides mutable and const access to a container.
+//
+// Example:
+//
+// ```
+// // Data defines a struct with a field `data` that holds a container in a `std::unique_ptr`.
+// // The type provides the two access methods `GetData`.
+// template<typename Container = std::vector<std::string>>
+// struct Data {
+//  using ContainerType = Container;
+//
+//  Data() : data(std::make_unique<ContainerType>()) {}
+//
+//  std::unique_ptr<ContainerType> data;
+//
+//  ContainerType& GetData() { return *data; }
+//
+//  const ContainerType& GetData() const { return *data; }
+// };
+//
+// template<typename C = std::vector<std::string>>
+// using Proxy = ContainerProxy<Data<C>, C, &C::GetData, &C::GetData>;
+// ```
+//
+// In other words `ContainerProxy` allows to add container access to a field within a struct.
+// This includes smart pointers like `std::unique_ptr` and `std::shared_ptr` which work directly.
+// That means that the `ContainerProxy` can also be used to add container access to smart pointers.
+//
+// For further application check `mbo::types::OpaqueContainer` which allows direct member field
+// wrapping without the need to change any other code.
+// ```
+template<
+    typename T,
+    typename Container = typename T::element_type,
+    Container& (T::*GetMutable)() = &T::operator*,
+    const Container& (T::*GetConst)() const = &T::operator*>
+requires requires { typename std::remove_cvref_t<Container>::value_type; }
+struct ContainerProxy : T {
+ private:
+  using C = std::remove_cvref_t<Container>;
+  using CC = const C;
+
+  constexpr auto& Get() { return (this->*GetMutable)(); }
+
+  constexpr const auto& Get() const { return (this->*GetConst)(); }
+
+ public:
+  using size_type = typename C::size_type;
+  using value_type = typename C::value_type;
+
+  // NOLINTBEGIN(readability-identifier-naming)
+  // clang-format off
+  constexpr auto begin() const requires(requires(const C& v) { v.begin(); }) { return Get().begin(); }
+  constexpr auto end() const requires(requires(const C& v) { v.end(); }) { return Get().end(); }
+  constexpr auto begin() requires(requires(C& v) { v.begin(); }) { return Get().begin(); }
+  constexpr auto end() requires(requires(C& v) { v.end(); }) { return Get().end(); }
+
+  constexpr auto rbegin() const requires(requires(const C& v) { v.rbegin(); }) { return Get().rbegin(); }
+  constexpr auto rend() const requires(requires(const C& v) { v.rend(); }) { return Get().rend(); }
+  constexpr auto rbegin() requires(requires(C& v) { v.rbegin(); }) { return Get().rbegin(); }
+  constexpr auto rend() requires(requires(C& v) { v.rend(); }) { return Get().rend(); }
+
+  constexpr auto cbegin() const requires(requires(const C& v) { v.cbegin(); }) { return Get().cbegin(); }
+  constexpr auto cend() const requires(requires(const C& v) { v.cend(); }) { return Get().cend(); }
+  constexpr auto crbegin() const requires(requires(const C& v) { v.crbegin(); }) { return Get().crbegin(); }
+  constexpr auto crend() const requires(requires(const C& v) { v.crend(); }) { return Get().crend(); }
+
+  constexpr bool empty() const requires(requires(const C& v) { v.empty(); }) { return Get().empty(); }
+  constexpr auto size() const requires(requires(const C& v) { v.size(); }) { return Get().size(); }
+  constexpr auto max_size() const requires(requires(const C& v) { v.max_size(); }) { return Get().max_size(); }
+  constexpr auto capacity() const requires(requires(const C& v) { v.capacity(); }) { return Get().capacity(); }
+
+  constexpr void clear() requires(requires(const C& v) { v.clear(); }) { Get().clear(); }
+  constexpr void reserve(size_type capacity) requires(requires(C& v) { v.reserve(std::declval<size_type>()); }) { Get().reserve(capacity); }
+  constexpr void resize(size_type size) requires(requires(C& v) { v.resize(std::declval<size_type>()); }) { Get().resize(size); }
+
+  constexpr auto& at(std::size_t pos) const requires(requires(const C& v) { v.at(0); }) { return Get().at(pos); }
+  constexpr auto& at(std::size_t pos) requires(requires(C& v) { v.at(0); }) { return Get().at(pos); }
+  constexpr auto& operator[](std::size_t pos) const requires(requires(const C& v) { v[pos]; }) { return at(pos); }
+  constexpr auto& operator[](std::size_t pos) requires(requires(C& v) { v[pos]; }) { return at(pos); }
+
+  constexpr void push_back(const value_type& arg)
+  requires(requires(C& v) { v.push_back(std::declval<const value_type&>()); }) {
+    Get().push_back(arg);
+  }
+
+  constexpr void push_back(value_type&& arg)
+  requires(requires(C& v) { v.push_back(std::declval<value_type>()); }) {
+    Get().push_back(std::move(arg));
+  }
+
+  constexpr void push_front(const value_type& arg)
+  requires(requires(C& v) { v.push_front(std::declval<const value_type&>()); }) {
+    Get().push_front(arg);
+  }
+
+  constexpr void push_front(value_type&& arg)
+  requires(requires(C& v) { v.push_front(std::declval<value_type>()); }) {
+    Get().push_front(std::move(arg));
+  }
+
+  template<typename... Args>
+  constexpr auto& emplace_back(Args&&... args)
+  requires(requires(C& v) { v.emplace_back(std::declval<Args>()...); }) {
+    return Get().emplace_back(std::forward<Args>(args)...);
+  }
+
+  template<typename... Args>
+  constexpr auto& emplace_front(Args&&... args)
+  requires(requires(C& v) { v.emplace_front(std::declval<Args>()...); }) {
+    return Get().emplace_front(std::forward<Args>(args)...);
+  }
+
+  constexpr auto& back() const requires(requires(const C& v) { v.back(); }) { return Get().back(); }
+  constexpr auto& back() requires(requires(C& v) { v.back(); }) { return Get().back(); }
+  constexpr auto& front() const requires(requires(const T& v) { v.front(); }) { return Get().front(); }
+  constexpr auto& front() requires(requires(C& v) { v.front(); }) { return Get().front(); }
+
+  constexpr void pop_back() requires(requires(C& v) { v.pop_back(); }) { Get().pop_back(); }
+  constexpr void pop_front() requires(requires(C& v) { v.pop_frontk(); }) { Get().pop_front(); }
+
+  auto operator<=>(const ContainerProxy& other) const
+  requires std::three_way_comparable<T>
+  {
+    return Get() <=> other.Get();
+  }
+
+  auto operator<=>(const C& other) const
+  requires std::three_way_comparable<T>
+  {
+    return Get() <=> other;
+  }
+
+  template<typename H>
+  friend H AbslHashValue(H hash, const ContainerProxy& proxy) {
+    return H::combine(std::move(hash), absl::HashOf<>(proxy.Get()));
+  }
+
+  // clang-format on
+  // NOLINTEND(readability-identifier-naming)
+};
+
+}  // namespace mbo::types
+
+namespace std {
+
+template<typename T, typename R, std::remove_cvref_t<R>& (T::*F)(), const std::remove_cvref_t<R>& (T::*FC)() const>
+requires(requires(const T& val) { std::hash<T>{}; })
+struct hash<mbo::types::ContainerProxy<T, R, F, FC>> {
+  constexpr std::size_t operator()(const mbo::types::ContainerProxy<T, R, F, FC>& ptr) const noexcept {
+    return absl::HashOf<>(ptr);
+  }
+};
+}  // namespace std
+
+#endif  // MBO_TYPES_CONTAINER_PROXY_H_

--- a/mbo/types/opaque.h
+++ b/mbo/types/opaque.h
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MBO_TYPES_OPAQUE_H_
+#define MBO_TYPES_OPAQUE_H_
+
+#include <compare>
+#include <concepts>
+#include <cstddef>
+#include <memory>
+#include <type_traits>
+
+#include "absl/hash/hash.h"
+#include "mbo/types/container_proxy.h"  // IWYU pragma: export
+
+namespace mbo::types {
+namespace types_internal {
+
+template<typename T>
+struct OpaquePtrDeleter {
+  void operator()(T* ptr) { OpaquePtrDeleterHook(ptr); }
+};
+}  // namespace types_internal
+
+// A `unique_ptr` alternative that works with forward declared types.
+//
+// In order to make this work, the macro `MBO_TYPES_OPAQUE_HOOKS(T)` has to be used after
+// the definition of the type. Further, all users of the OpaquePtr type must have access to it.
+// NOTE: The macro defines the necessary ADL functions as inline functions.
+template<typename T>
+using OpaquePtr = std::unique_ptr<T, types_internal::OpaquePtrDeleter<T>>;
+
+// Determine whether a type `T` is an `OpaquePtr`.
+template<typename T>
+concept IsOpaquePtr = requires {
+  typename T::element_type;
+  requires std::same_as<T, OpaquePtr<typename T::element_type>>;
+};
+
+// Similar to `std::make_unique` but for `OpaquePtr`.
+//
+// In order to make this work, the macro `MBO_TYPES_OPAQUE_HOOKS(T)` has to be used after
+// the definition of the type. Further, all users of the OpaquePtr type must have access to it.
+// NOTE: The macro defines the necessary ADL functions as inline functions.
+template<typename T, typename... Args>
+OpaquePtr<T> MakeOpaquePtr(Args&&... args) {
+  ::mbo::types::OpaquePtr<T> ptr;
+  OpaquePtrMakerHook(ptr, std::forward<Args>(args)...);
+  return ptr;
+}
+
+// OpaqueValue defines a wrapper around a type `T` as an opaque std::unique_ptr that can be
+// accessed, compared and hashed (absl and std) but will never be a `nullptr`.
+//
+// In order to make this work, the macro `MBO_TYPES_OPAQUE_HOOKS(T)` has to be used after
+// the definition of the type. Further, all users of the OpaquePtr type must have access to it.
+// NOTE: The macro defines the necessary ADL functions as inline functions.
+template<typename T>
+struct OpaqueValue {
+  using element_type = T;
+
+  ~OpaqueValue() = default;
+
+  OpaqueValue()
+  requires(std::is_default_constructible_v<T>)
+      : ptr_(MakeOpaquePtr<T>()) {}
+
+  template<typename... Args>
+  explicit OpaqueValue(Args&&... args)
+  requires std::constructible_from<T, Args...>
+      : ptr_(MakeOpaquePtr<T>(std::forward<Args>(args)...)) {}
+
+  OpaqueValue(OpaqueValue&&) noexcept = default;
+  OpaqueValue& operator=(OpaqueValue&&) noexcept = default;
+
+  OpaqueValue(const OpaqueValue& other)
+  requires(std::is_copy_constructible_v<T>)
+      : ptr_(MakeOpaquePtr<T>(*other.ptr_)) {}
+
+  OpaqueValue& operator=(const OpaqueValue& other)
+  requires(std::is_copy_constructible_v<T>)
+  {
+    if (&other != this) {
+      ptr_ = MakeOpaquePtr<T>(*other.ptr_);
+    }
+    return *this;
+  }
+
+  template<typename... Args>
+  explicit OpaqueValue(Args&&... args) : ptr_(MakeOpaquePtr<T>(std::forward<Args>(args)...)) {}
+
+  T& operator*() { return *ptr_; }
+
+  T* operator->() { return &*ptr_; }
+
+  const T& operator*() const { return *ptr_; }
+
+  const T* operator->() const { return &*ptr_; }
+
+  auto operator<=>(const OpaqueValue& other) const
+  requires std::three_way_comparable<T>
+  {
+    return *ptr_ <=> *other.ptr_;
+  }
+
+  auto operator<=>(const T& other) const
+  requires std::three_way_comparable<T>
+  {
+    return *ptr_ <=> other;
+  }
+
+  template<typename H>
+  friend H AbslHashValue(H hash, const OpaqueValue<T>& ptr) {
+    return H::combine(std::move(hash), absl::HashOf<>(*ptr.ptr_));
+  }
+
+ private:
+  OpaquePtr<T> ptr_;  // Will never be nullptr
+};
+
+// Determine whether a type `T` is an `OpaqueValue`.
+template<typename T>
+concept IsOpaqueValue = requires {
+  typename T::element_type;
+  requires std::same_as<T, OpaqueValue<typename T::element_type>>;
+};
+
+// OpaqueContainer wraps a container into an opaque std::unique_ptr and allows direct access for
+// most of the STL container functions (in particular std::vector). That is, the majority of the
+// containers functions are directly available in the type.
+//
+// In order to make this work, the macro `MBO_TYPES_OPAQUE_HOOKS(T)` has to be used after
+// the definition of the type. Further, all users of the OpaquePtr type must have access to it.
+// NOTE: The macro defines the necessary ADL functions as inline functions.
+//
+// NOTE: If the container is a `std` type, then the `MBO_TYPES_OPAQUE_HOOKS` must be placed in the
+// namespace `std`.
+//
+// Example:
+//
+// ```
+// namespace mine {
+// using OpaqueStringVector = OpaqueContainer<std::vector<std::string>>;
+// } // namespace mine
+//
+// namespace std {
+// MBO_TYPES_OPAQUE_HOOKS(std::vector<std::string>);
+// }  // namespace std
+//
+// Practically this type allows to change container fields to smart pointer wrapped container fields
+// without the need to change any other code. Example:
+//
+// ```
+// struct Mine {
+//   std::vector<std::string> data;
+// };
+// ```
+//
+// Can be modified to:
+//
+// ```
+// struct Mine {
+//   mbo::types::OpaqueContainer<std::vector<std::string>> data;
+// };
+// ```
+//
+// In the above no other code needs to change (as long as the necessary function was already added).
+// The type guarantees, just like in the original form, that the field `data` is always usable, or
+// rather never has a `nullptr`. The advantage here is that now the container type or its value_type
+// can be forward declared.
+template<typename Container>
+struct OpaqueContainer : ContainerProxy<OpaqueValue<Container>, Container> {};
+
+}  // namespace mbo::types
+
+// Macro to define an ADL deletion hook for the specified type to be used with `OpaquePtr`.
+// NOLINTBEGIN(cppcoreguidelines-macro-usage,bugprone-macro-parentheses)
+#define MBO_TYPES_OPAQUE_HOOKS(T)                                                   \
+  inline void OpaquePtrDeleterHook(T* ptr) {                                        \
+    delete ptr;                                                                     \
+  }                                                                                 \
+  template<typename... Args>                                                        \
+  inline void OpaquePtrMakerHook(::mbo::types::OpaquePtr<T>& ptr, Args&&... args) { \
+    ptr.reset(new T(std::forward<Args>(args)...));                                  \
+  }
+
+// NOLINTEND(cppcoreguidelines-macro-usage,bugprone-macro-parentheses)
+
+namespace std {
+
+template<typename T>
+requires(requires(const T& val) { std::hash<T>{}; })
+struct hash<mbo::types::OpaqueValue<T>> {
+  constexpr std::size_t operator()(const mbo::types::OpaqueValue<T>& ptr) const noexcept { return hash<T>{}(*ptr); }
+};
+}  // namespace std
+
+#endif  // MBO_TYPES_OPAQUE_H_

--- a/mbo/types/opaque_test.cc
+++ b/mbo/types/opaque_test.cc
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mbo/types/opaque.h"
+
+#include <concepts>  // IWYU pragma: keep
+#include <list>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace mbo::types {
+
+struct StringWrap;  // Forward declared!
+
+namespace {
+
+using ::testing::ElementsAre;
+using ::testing::IsEmpty;
+using ::testing::Not;
+using ::testing::SizeIs;
+
+struct OpaqueTest : ::testing::Test {};
+
+template<typename T>
+struct OpaqueContainerTest : ::testing::Test {};
+
+template<typename Container = std::vector<std::string>>
+struct Data {
+  using ContainerType = Container;
+
+  Data() : data(std::make_unique<ContainerType>()) {}
+
+  std::unique_ptr<ContainerType> data;
+
+  ContainerType& GetData() { return *data; }
+
+  const ContainerType& GetData() const { return *data; }
+};
+
+template<typename Container>
+struct Proxy : ContainerProxy<Data<Container>, Container, &Data<Container>::GetData, &Data<Container>::GetData> {};
+
+// Access through the proxy means accessing the `std::vector` that is wrapped in a `std::unique_ptr`.
+using ProxyVectorString = Proxy<std::vector<std::string>>;
+
+// Access works the same way if the container is a `std::list` since vector and list both suppport the functions that
+// the test below needs.
+using ProxyListString = Proxy<std::list<std::string>>;
+
+// A vector of string can be used in a std::unique_ptr just fine. We provide this so we guarantee that the opaque types
+// behave identical.
+using OpaqueVectorString = OpaqueContainer<std::vector<std::string>>;
+
+// The use of the `StringWrap` as the `value_type` for the `std::vector` prevents the container from working as the
+// `element_type` in a `std::unique_ptr`. That is becasue the `StringWrap` type is forward declared and hence when the
+// `std::unique_ptr` gets declared, it fails to see the required destructor; or more precisely the delete operation
+// of the `std::unique_ptr` would trigger the deletion of the `std::vector` which in turn would trigger the deletion of
+// all elements. But those are not fully defined, and so their size is unknown and so they cannot be deleted. However,
+// the template `OpaqueContainer` works around this by forward declaring the deletor and then providing it through the
+// macro `MBO_TYPES_OPAQUE_HOOKS(std::vector<StringWrap>)`.
+using OpaqueVectorStringWrap = OpaqueContainer<std::vector<StringWrap>>;
+
+using OpaqueListStringWrap = OpaqueContainer<std::list<StringWrap>>;
+
+using MyTypes = ::testing::Types<
+    std::vector<std::string>,
+    ProxyVectorString,
+    ProxyListString,
+    OpaqueVectorString,
+    OpaqueVectorStringWrap,
+    OpaqueListStringWrap>;
+
+class MyTypeNames {
+ public:
+  template<typename T>
+  static std::string GetName(int) {
+    if constexpr (std::is_same<T, std::vector<std::string>>()) {
+      return "VectorOfString";
+    } else if constexpr (std::is_same<T, ProxyVectorString>()) {
+      return "ProxyVectorString";
+    } else if constexpr (std::is_same<T, ProxyListString>()) {
+      return "ProxyListString";
+    } else if constexpr (std::is_same<T, OpaqueVectorString>()) {
+      return "OpaqueVectorString";
+    } else if constexpr (std::is_same<T, OpaqueVectorStringWrap>()) {
+      return "OpaqueVectorStringWrap";
+    } else {
+      return "Unknown";
+    }
+  }
+};
+
+TYPED_TEST_SUITE(OpaqueContainerTest, MyTypes, MyTypeNames);
+
+TYPED_TEST(OpaqueContainerTest, Test) {
+  TypeParam data;
+  EXPECT_THAT(data, IsEmpty());
+  EXPECT_THAT(data, SizeIs(0));
+  data.push_back("1");
+  EXPECT_THAT(data.front(), "1");
+  EXPECT_THAT(data.back(), "1");
+  data.push_back("2");
+  EXPECT_THAT(data.front(), "1");
+  EXPECT_THAT(data.back(), "2");
+  EXPECT_THAT(data, Not(IsEmpty()));
+  EXPECT_THAT(data, SizeIs(2));
+  EXPECT_THAT(data, ElementsAre("1", "2"));
+  data.pop_back();
+  EXPECT_THAT(data, Not(IsEmpty()));
+  EXPECT_THAT(data, SizeIs(1));
+  EXPECT_THAT(data, ElementsAre("1"));
+}
+
+}  // namespace
+
+struct StringWrap : std::string {
+  using std::string::string;
+};
+
+}  // namespace mbo::types
+
+namespace std {
+
+MBO_TYPES_OPAQUE_HOOKS(std::vector<std::string>);
+MBO_TYPES_OPAQUE_HOOKS(std::vector<mbo::types::StringWrap>);
+MBO_TYPES_OPAQUE_HOOKS(std::list<mbo::types::StringWrap>);
+
+}  // namespace std

--- a/mbo/types/template_search_test.cc
+++ b/mbo/types/template_search_test.cc
@@ -42,10 +42,12 @@ struct IsNonZero {
 
 template<
     std::size_t Expected,
-    template<template<std::size_t> typename, std::size_t Start, std::size_t End, std::size_t NotFound>
-    typename Algorithm,
-    template<typename>
-    typename TestFunc,
+    template<
+        template<std::size_t> typename,
+        std::size_t Start,
+        std::size_t End,
+        std::size_t NotFound> typename Algorithm,
+    template<typename> typename TestFunc,
     typename TestType,
     std::size_t Start = 0,
     std::size_t End = TestType::size(),

--- a/mbo/types/traits_test.cc
+++ b/mbo/types/traits_test.cc
@@ -81,7 +81,7 @@ struct CtorDefault {
 };
 
 struct CtorUser {
-  CtorUser(){};  // NOLINT(*-use-equals-default)
+  CtorUser() {}  // NOLINT(*-use-equals-default)
 };
 
 struct CtorBase : CtorUser {};

--- a/mbo/types/tstring.h
+++ b/mbo/types/tstring.h
@@ -457,8 +457,8 @@ struct MakeTstringLiteralHelper {
   // NOLINTBEGIN(google-explicit-constructor)
   constexpr MakeTstringLiteralHelper(const char (&str)[N]) noexcept
       : MakeTstringLiteralHelper(
-          std::string_view{str, Length(N)},
-          std::make_integer_sequence<std::size_t, Length(N)>()) {}
+            std::string_view{str, Length(N)},
+            std::make_integer_sequence<std::size_t, Length(N)>()) {}
 
   // NOLINTEND(google-explicit-constructor)
   // NOLINTEND(*-avoid-c-arrays)


### PR DESCRIPTION
* Added struct `mbo::types::ContainerProxy` which allows to add container access to other types including smart pointers of containers.
* Added struct `mbo::types::OpaquePtr` an opaque alternative to `std::unique_ptr` which works with forward declared types.
* Added struct `mbo::types::OpaqueValue` an `OpaquePtr` with direct access, comparison and hashing which will not allow a nullptr.
* Added struct `mbo::types::OpaqueContainer` an `OpaqueValue` with direct container access.
* Changed pre-commit to use clang-format 19.1.6.