### PR TITLE
More bazelmod preparations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,9 +5,17 @@ repos:
   - id: check-merge-conflict
   - id: check-yaml
   - id: end-of-file-fixer
-    exclude: ^mbo/diff/tests/numbers_blanks.*$
+    exclude: |
+          (?x)(
+            ^mbo/diff/tests/abc_whitespace.*$|
+            .*[]].patch
+          )
   - id: trailing-whitespace
-    exclude: ^mbo/diff/tests/abc_whitespace.*$
+    exclude: |
+          (?x)(
+            ^mbo/diff/tests/abc_whitespace.*$|
+            .*[.]patch
+          )
 
 - repo: https://github.com/pre-commit/mirrors-clang-format
   rev: v19.1.6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,12 +8,14 @@ repos:
     exclude: |
           (?x)(
             ^mbo/diff/tests/abc_whitespace.*$|
+            ^mbo/diff/tests/numbers_blanks.*|
             .*[]].patch
           )
   - id: trailing-whitespace
     exclude: |
           (?x)(
             ^mbo/diff/tests/abc_whitespace.*$|
+            ^mbo/diff/tests/numbers_blanks.*|
             .*[.]patch
           )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,6 +16,11 @@
 # Due to flag and test references to the repo name we use the old name for now.
 module(name = "helly25_mbo", version = "0.3.0", repo_name = "com_helly25_mbo")
 
+# For local development we include LLVM and Hedron-Compile-Commands.
+# For bazelmod usage these have to be provided by the main module - if necessary.
+include("//bazelmod:hedron.MODULE.bazel")
+include("//bazelmod:llvm.MODULE.bazel")
+
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "rules_cc", version = "0.1.1")
 bazel_dep(name = "platforms", version = "0.0.11")
@@ -26,27 +31,3 @@ bazel_dep(name = "googletest", version = "1.16.0", repo_name = "com_google_googl
 bazel_dep(name = "google_benchmark", version = "1.9.1", repo_name = "com_github_google_benchmark")
 # In Bazelmod we do not need to specify the protobuf version yet.
 # bazel_dep(name = "protobuf", version = "29.3", repo_name = "com_google_protobuf")
-
-bazel_dep(name = "hedron_compile_commands", dev_dependency = True)
-git_override(
-    module_name = "hedron_compile_commands",
-    commit = "6dd21b47db481a70c61698742438230e2399b639",
-    remote = "https://github.com/hedronvision/bazel-compile-commands-extractor.git",
-)
-
-bazel_dep(name = "toolchains_llvm", version = "1.3.0")
-
-git_override(
-    module_name = "toolchains_llvm",
-    remote = "https://github.com/bazel-contrib/toolchains_llvm",
-    commit = "e831f94a8b7f3a39391f5822adcab8e4d443c03b", # Add more tools by default (#463)
-)
-
-llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm", dev_dependency = True)
-
-llvm.toolchain(
-    name = "llvm_toolchain_llvm",
-    llvm_version = "19.1.6",
-)
-use_repo(llvm, "llvm_toolchain_llvm")
-register_toolchains("@llvm_toolchain_llvm//:all", dev_dependency = True)

--- a/bazelmod/BUILD.bazel
+++ b/bazelmod/BUILD.bazel
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = [])
+
+exports_files([
+    "hedron.MODULE.bazel",
+    "llvm.MODULE.bazel",
+])

--- a/bazelmod/bazelmod.patch
+++ b/bazelmod/bazelmod.patch
@@ -1,0 +1,28 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index c298a32..658794e 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -18,8 +18,8 @@ module(name = "helly25_mbo", version = "0.3.0", repo_name = "com_helly25_mbo")
+ 
+ # For local development we include LLVM and Hedron-Compile-Commands.
+ # For bazelmod usage these have to be provided by the main module - if necessary.
+-include("//bazelmod:hedron.MODULE.bazel")
+-include("//bazelmod:llvm.MODULE.bazel")
++# include("//bazelmod:hedron.MODULE.bazel")
++# include("//bazelmod:llvm.MODULE.bazel")
+ 
+ bazel_dep(name = "bazel_skylib", version = "1.7.1")
+ bazel_dep(name = "rules_cc", version = "0.1.1")
+diff --git a/mbo/mope/mope.bzl b/mbo/mope/mope.bzl
+index d80d788..7aeac41 100644
+--- a/mbo/mope/mope.bzl
++++ b/mbo/mope/mope.bzl
+@@ -34,7 +34,7 @@ load("//mbo/diff:diff.bzl", "diff_test")
+ #    b) `$(which "clang_format")`
+ #    c) `clang-format-19` ... `clang-format-14`
+ #    d) If even (d) fails, then we will just copy the file.
+-_CLANG_FORMAT_BINARY = ""  # Ignore clang-format from repo with: "clang-format-auto"
++_CLANG_FORMAT_BINARY = "clang-format-auto"  # Ignore clang-format from repo with: "clang-format-auto"
+ 
+ def _get_clang_format(ctx):
+     """Get the selected clang-format from `--//mbo/mope:clang_format` bazel flag."""

--- a/bazelmod/hedron.MODULE.bazel
+++ b/bazelmod/hedron.MODULE.bazel
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+bazel_dep(name = "hedron_compile_commands", dev_dependency = True)
+git_override(
+    module_name = "hedron_compile_commands",
+    commit = "6dd21b47db481a70c61698742438230e2399b639",
+    remote = "https://github.com/hedronvision/bazel-compile-commands-extractor.git",
+)

--- a/bazelmod/llvm.MODULE.bazel
+++ b/bazelmod/llvm.MODULE.bazel
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+bazel_dep(name = "toolchains_llvm", version = "1.3.0")
+
+git_override(
+    module_name = "toolchains_llvm",
+    remote = "https://github.com/bazel-contrib/toolchains_llvm",
+    commit = "e831f94a8b7f3a39391f5822adcab8e4d443c03b", # Add more tools by default (#463)
+)
+
+llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm", dev_dependency = True)
+
+llvm.toolchain(
+    name = "llvm_toolchain_llvm",
+    llvm_version = "19.1.6",
+)
+use_repo(llvm, "llvm_toolchain_llvm")
+register_toolchains("@llvm_toolchain_llvm//:all", dev_dependency = True)

--- a/mbo/mope/BUILD.bazel
+++ b/mbo/mope/BUILD.bazel
@@ -25,7 +25,7 @@ package(default_visibility = ["//visibility:private"])
 # Otherwise the value should be the absolute file location of `clang-format`.
 string_flag(
     name = "clang_format",
-    build_setting_default = "clang-format-auto",
+    build_setting_default = "",
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
More bazelmod preparations
* In `b/.pre-commit-config.yaml`
  * Prevented reformatting of .patch files
* In `MODULE.bazel`
  * Changed to get hedron-compile-commands and llvm through includes so they can be patched out in modules.
* clang-format
  * Changed `//mbo//mope/clang_format/build_setting_default` to `""` so we automatically get to choose between repo provided and full automatic finding.
  * Changed `mbo/mope/mope.bzl` to:
    * If (newly) `_CLANG_FORMAT_BINARY` var is set, then disable sandboxing so all possible targets can actually be found.
    * Added additional location to find clang-format including both bazel 7.* and bazel 8.* locations.
    * Added ability to copy input to output file as a last fallback.
    * Added a log statement to denot the used clang-format binary and version in case an automatically found one was used.