### PR TITLE
Improve Extended type handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,36 @@ repos:
             .*[.]patch
           )
 
+- repo: local
+  hooks:
+  - id: mope-uses-external-clang
+    name: mope-uses-external-clang
+    description: |
+      File //mbo/mope/mope.bzl can be configured to find clang-format automatically.
+      However, the repo version must set `_CLANG_FORMAT_BINARY = ""` so that it uses
+      the repo provided version which does not work for Bazel module use.
+    language: pygrep
+    entry: _CLANG_FORMAT_BINARY\s+=\s+"[^"]+"
+    files: mbo/mope/mope.bzl
+  - id: uncomment-bazelmod-includes
+    name: uncomment-bazelmod-includes
+    description: |
+      The repo version of MODULE.bazel may not have commented out includes.
+    language: pygrep
+    entry: \s*#\s*include
+    files: MODULE.bazel
+  - id: bazelmod-patch-applies
+    name: bazelmod-patch-applies
+    description: |
+      The patch in bazelmod/bazelmod.patch can be applied
+    language: system
+    entry: patch
+    args: ["-p1", "--dry-run", "-i", "bazelmod/bazelmod.patch"]
+    pass_filenames: False
+    types: [text]
+
+
+
 - repo: https://github.com/pre-commit/mirrors-clang-format
   rev: v19.1.6
   hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.3.1
+# 0.4.0
 
 * Added function `mbo::strings::BigNumber`: Convert integral number to string with thousands separator.
 * Added function `mbo::strings::BigNumberLen`: Calculate required string length for `BigNumer`.
@@ -27,6 +27,8 @@
 * Added struct `mbo::types::OpaqueValue` an `OpaquePtr` with direct access, comparison and hashing which will not allow a nullptr.
 * Added struct `mbo::types::OpaqueContainer` an `OpaqueValue` with direct container access.
 * Changed pre-commit to use clang-format 19.1.6.
+* Added ability to construct Extended types from conversions (`ConstructFromConversions`).
+* Removed support for type marker `MboTypesExtendDoNotPrintFieldNames`.
 
 # 0.3.0
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Due to flag and test references to the repo name we use the old name for now.
-module(name = "helly25_mbo", version = "0.3.0", repo_name = "com_helly25_mbo")
+module(name = "helly25_mbo", version = "0.4.0", repo_name = "com_helly25_mbo")
 
 # For local development we include LLVM and Hedron-Compile-Commands.
 # For bazelmod usage these have to be provided by the main module - if necessary.

--- a/bazelmod/bazelmod.patch
+++ b/bazelmod/bazelmod.patch
@@ -2,7 +2,7 @@ diff --git a/MODULE.bazel b/MODULE.bazel
 index c298a32..658794e 100644
 --- a/MODULE.bazel
 +++ b/MODULE.bazel
-@@ -18,8 +18,8 @@ module(name = "helly25_mbo", version = "0.3.0", repo_name = "com_helly25_mbo")
+@@ -18,8 +18,8 @@ module(name = "helly25_mbo", version = "0.4.0", repo_name = "com_helly25_mbo")
  
  # For local development we include LLVM and Hedron-Compile-Commands.
  # For bazelmod usage these have to be provided by the main module - if necessary.
@@ -17,10 +17,10 @@ diff --git a/mbo/mope/mope.bzl b/mbo/mope/mope.bzl
 index d80d788..7aeac41 100644
 --- a/mbo/mope/mope.bzl
 +++ b/mbo/mope/mope.bzl
-@@ -34,7 +34,7 @@ load("//mbo/diff:diff.bzl", "diff_test")
- #    b) `$(which "clang_format")`
- #    c) `clang-format-19` ... `clang-format-14`
- #    d) If even (d) fails, then we will just copy the file.
+@@ -35,7 +35,7 @@ load("//mbo/diff:diff.bzl", "diff_test")
+ #    c) `$(which "clang_format")`
+ #    d) `clang-format-23` ... `clang-format-15`, `clang-format`
+ #    e) If even (d) fails, then we will just copy the file.
 -_CLANG_FORMAT_BINARY = ""  # Ignore clang-format from repo with: "clang-format-auto"
 +_CLANG_FORMAT_BINARY = "clang-format-auto"  # Ignore clang-format from repo with: "clang-format-auto"
  

--- a/mbo/diff/unified_diff.h
+++ b/mbo/diff/unified_diff.h
@@ -29,8 +29,7 @@ namespace mbo::diff {
 
 // Creates the unified line-by-line diff between `lhs_text` and `rhs_text`.
 //
-// `lhs_name` and `rhs_name` are used as the file names in the diff headers,
-// `context_size` is ignored (TODO implement).
+// `lhs_name` and `rhs_name` are used as the file names in the diff headers.
 //
 // If left and right are identical, returns an empty string.
 //

--- a/mbo/types/extend_test.cc
+++ b/mbo/types/extend_test.cc
@@ -913,8 +913,6 @@ TEST_F(ExtendTest, FromTupleToStrings) {
     std::string two;
   };
 
-  // TODO(helly25): This should work as test `FromTupleToConversions` where `static constexpr std::string_view` converts
-  // to the string fields.
   const std::string str1{"a"};
   const std::string str2{"b"};
   {
@@ -931,12 +929,26 @@ TEST_F(ExtendTest, FromTupleToStrings) {
   }
 }
 
+TEST_F(ExtendTest, FromConversions) {
+  // You cannot directly initialize a std::string field with a std::string_view value, a conversion is needed.
+  struct TestStruct : Extend<TestStruct> {
+    std::string one;
+    std::string two;
+  };
+
+  constexpr std::string_view sv1{"aa"};
+  constexpr std::string_view sv2{"bb"};
+  {
+    const auto val2 = TestStruct::ConstructFromConversions(sv1, sv2);
+    static_assert((std::same_as<std::remove_cvref_t<decltype(val2)>, TestStruct>));
+    EXPECT_THAT(val2.one, sv1);
+    EXPECT_THAT(val2.two, sv2);
+  }
+}
+
 TEST_F(ExtendTest, MoveOnlyFromTuple) {
   static constexpr int kInt1{25};
   static constexpr int kInt2{33};
-  // TODO(helly25): Cases 1 and 3 entail a conversion from int to MoveOnly which does not work yet.
-  // const auto val1 = UseMoveOnly::FromTuple(std::make_tuple(kInt1, kInt2));
-  // static_assert((std::same_as<std::remove_cvref_t<decltype(val1)>, UseMoveOnly>));
   {
     const auto val2 = UseMoveOnly::ConstructFromTuple(std::make_tuple(MoveOnly(kInt1), MoveOnly(kInt2)));
     static_assert((std::same_as<std::remove_cvref_t<decltype(val2)>, UseMoveOnly>));

--- a/mbo/types/stringify.h
+++ b/mbo/types/stringify.h
@@ -173,17 +173,10 @@ concept IsFieldNameContainer = requires(const T& field_names) {
   { std::data(field_names)[1] } -> std::convertible_to<std::string_view>;
 };
 
-// TODO(helly25): Drop in version 0.3.0+
-template<typename T>
-concept Has_DEPRECATED_MboTypesExtendDoNotPrintFieldNames =
-    requires { typename std::remove_cvref_t<T>::MboTypesExtendDoNotPrintFieldNames; };
-
 // Whether Stringify should suppress field names.
 template<typename T>
-concept HasMboTypesStringifyDoNotPrintFieldNames = Has_DEPRECATED_MboTypesExtendDoNotPrintFieldNames<T> || requires {
-  // TODO(helly25): Drop `Has_DEPRECATED_MboTypesExtendDoNotPrintFieldNames`, see above
-  typename std::remove_cvref_t<T>::MboTypesStringifyDoNotPrintFieldNames;
-};
+concept HasMboTypesStringifyDoNotPrintFieldNames =
+    requires { typename std::remove_cvref_t<T>::MboTypesStringifyDoNotPrintFieldNames; };
 
 // This breaks `MboTypesStringifyOptions` lookup within this namespace.
 void MboTypesStringifyOptions();  // Has no implementation!

--- a/mbo/types/tuple_extras.h
+++ b/mbo/types/tuple_extras.h
@@ -89,6 +89,25 @@ concept HasVariantMember =
     ::mbo::types::CanCreateTuple<T>
     && types_internal::HasVariantMemberImpl<decltype(::mbo::types::StructToTuple(std::declval<T>()))>;
 
+namespace types_internal {
+
+template<typename Fields, typename Args, typename IS>
+struct TupleFieldsConstructibleImpl;
+
+template<typename Fields, typename Args, std::size_t... Idx>
+struct TupleFieldsConstructibleImpl<Fields, Args, std::index_sequence<Idx...>>
+    : std::bool_constant<(
+          std::constructible_from<std::tuple_element_t<Idx, Fields>, std::tuple_element_t<Idx, Args>> && ...)> {};
+
+}  // namespace types_internal
+
+// Determine whether each element in `Fields` can be constructed from their `Args` counterpart.
+template<typename Fields, typename Args>
+concept TupleFieldsConstructible =
+    IsTuple<Fields> && IsTuple<Args> && std::tuple_size_v<Fields> == std::tuple_size_v<Args>
+    && types_internal::TupleFieldsConstructibleImpl<Fields, Args, std::make_index_sequence<std::tuple_size_v<Fields>>>::
+        value;
+
 }  // namespace mbo::types
 
 #endif  // MBO_TYPES_TUPLE_EXTRAS_H_


### PR DESCRIPTION
Improve Extended type handling and prepare for version 0.4.0 (instead of 0.3.1)
* Added ability to construct Extended types from conversions (`ConstructFromConversions`).
* Removed support for type marker `MboTypesExtendDoNotPrintFieldNames`.
* Added additional checks to pre-commit.