### PR TITLE
Support Clang 20.1.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,16 +38,22 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         bazel_mode: [bzlmod]
         compiler: [clang]
-        llvm_version: [19.1.6, 17.0.4]
+        llvm_version: [20.1.0, 19.1.6, 17.0.4]
         bazel_config: [asan, opt, fastbuild]
         exclude:
           - os: macos-latest
             bazel_config: asan
           - os: macos-latest
             bazel_config: fastbuild
+          - os: macos-latest
+            llvm_version: 20.1.0
           - llvm_version: 17.0.4
             bazel_config: asan
           - llvm_version: 17.0.4
+            bazel_config: fastbuild
+          - llvm_version: 20.1.0
+            bazel_config: asan
+          - llvm_version: 20.1.0
             bazel_config: fastbuild
 
     uses: ./.github/workflows/test.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,9 @@ jobs:
           fi
           if [ "${{ inputs.compiler }}" == "clang" ]; then
             BAZEL_ARGS+=("--config=clang")
-            if [ "${{ inputs.llvm_version }}" != "19.1.6" ]; then
+            if [ -r "bazelmod/llvm.${{ inputs.llvm_version }}.MODULE.bazel" ]; then
+              cp "bazelmod/llvm.${{ inputs.llvm_version }}.MODULE.bazel" bazelmod/llvm.MODULE.bazel
+            elif [ "${{ inputs.llvm_version }}" != "19.1.6" ]; then
               CONTROL_FILE=bazelmod/llvm.MODULE.bazel
               sed -e 's,llvm_version = ".*",llvm_version = "${{ inputs.llvm_version }}",g' "${CONTROL_FILE}" > "${CONTROL_FILE}.new"
               mv "${CONTROL_FILE}.new" "${CONTROL_FILE}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,4 +99,6 @@ jobs:
           if [ -n "${{ inputs.module_version }}" ]; then
             cp "bazelmod/MODULE.${{ inputs.module_version }}.bazel" MODULE.bazel
           fi
+          echo "BAZEL_INIT: ${BAZEL_INIT[@]}"
+          echo "BAZEL_ARGS: ${BAZEL_ARGS[@]}"
           bazel "${BAZEL_INIT[@]}" test "${BAZEL_ARGS[@]}" //...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.4.3
+
+* Address const-ness issues in constexpr functions found by Clang 20.1.0.
+* Drop space in front of string-literal notation found by Clang 20.1.0.
+
 # 0.4.2
 
 * Tweaked automated release tooling.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,7 +18,7 @@
 # Due to flag and test references to the repo name we use the old name for now.
 module(
     name = "helly25_mbo",
-    version = "0.4.2",
+    version = "0.4.3",
     repo_name = "com_helly25_mbo",
 )
 

--- a/bazelmod/llvm.20.1.0.MODULE.bazel
+++ b/bazelmod/llvm.20.1.0.MODULE.bazel
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+bazel_dep(name = "toolchains_llvm", version = "1.3.0")
+git_override(
+    module_name = "toolchains_llvm",
+    commit = "e831f94a8b7f3a39391f5822adcab8e4d443c03b",  # Add more tools by default (#463)
+    remote = "https://github.com/bazel-contrib/toolchains_llvm",
+)
+
+llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm", dev_dependency = True)
+llvm.toolchain(
+    name = "llvm_toolchain_llvm",
+    llvm_version = "20.1.0",
+    sha256 = {"linux-x86_64": "954ac51498519f6ed9540714fb04bc401f70039b296a8160dd1559be380788d7"},
+    strip_prefix = {
+        "linux-x86_64": "LLVM-20.1.0-Linux-X64",
+    },
+    urls = {
+        "linux-x86_64": [
+            "https://github.com/llvm/llvm-project/releases/download/llvmorg-20.1.0/LLVM-20.1.0-Linux-X64.tar.xz",
+        ],
+    },
+)
+use_repo(llvm, "llvm_toolchain_llvm")
+
+register_toolchains(
+    "@llvm_toolchain_llvm//:all",
+    dev_dependency = True,
+)

--- a/mbo/container/internal/limited_ordered.h
+++ b/mbo/container/internal/limited_ordered.h
@@ -384,7 +384,7 @@ class [[nodiscard]] LimitedOrdered {
 
   constexpr LimitedOrdered(const LimitedOrdered& other) noexcept {
     for (; size_ < other.size_; ++size_) {
-      std::construct_at(&values_[size_].data, other.values_[size_].data);
+      std::construct_at(const_cast<Value*>(&values_[size_].data), other.values_[size_].data);
     }
   }
 
@@ -399,7 +399,7 @@ class [[nodiscard]] LimitedOrdered {
 
   constexpr LimitedOrdered(LimitedOrdered&& other) noexcept {
     for (; size_ < other.size_; ++size_) {
-      std::construct_at(&values_[size_].data, std::move(other.values_[size_].data));
+      std::construct_at(const_cast<Value*>(&values_[size_].data), std::move(other.values_[size_].data));
     }
     other.size_ = 0;
   }
@@ -407,7 +407,7 @@ class [[nodiscard]] LimitedOrdered {
   constexpr LimitedOrdered& operator=(LimitedOrdered&& other) noexcept {
     clear();
     for (; size_ < other.size_; ++size_) {
-      std::construct_at(&values_[size_].data, std::move(other.values_[size_].data));
+      std::construct_at(const_cast<Value*>(&values_[size_].data), std::move(other.values_[size_].data));
     }
     other.size_ = 0;
     return *this;
@@ -424,7 +424,7 @@ class [[nodiscard]] LimitedOrdered {
     }
     while (first < last) {
       if constexpr (Options::Has(LimitedOptionsFlag::kRequireSortedInput)) {
-        std::construct_at(&values_[size_++].data, *first);
+        std::construct_at(const_cast<Value*>(&values_[size_++].data), *first);
       } else {
         emplace(*first);
       }
@@ -773,9 +773,9 @@ class [[nodiscard]] LimitedOrdered {
     }
     MBO_CONFIG_REQUIRE(size_ < Capacity, "Called `emplace` at capacity.");
     for (iterator next = end(); next > dst; --next) {
-      std::construct_at(&*next, std::move(*std::prev(next)));
+      std::construct_at(const_cast<Value*>(&*next), std::move(*std::prev(next)));
     }
-    std::construct_at(&*dst, std::move(new_val));
+    std::construct_at(const_cast<Value*>(&*dst), std::move(new_val));
     ++size_;
     return std::make_pair(dst, true);
   }
@@ -788,7 +788,7 @@ class [[nodiscard]] LimitedOrdered {
     --size_;
     std::destroy_at(&*dst);
     for (; dst < end(); ++dst) {
-      std::construct_at(&*dst, std::move(*std::next(dst)));
+      std::construct_at(const_cast<Value*>(&*dst), std::move(*std::next(dst)));
     }
     return pos > end() ? end() : to_iterator(pos);
   }
@@ -861,10 +861,10 @@ class [[nodiscard]] LimitedOrdered {
     }
     MBO_CONFIG_REQUIRE(size_ < Capacity, "Called `try_emplace` at capacity.");
     for (iterator next = end(); next > dst; --next) {
-      std::construct_at(&*next, std::move(*std::prev(next)));
+      std::construct_at(const_cast<Value*>(&*next), std::move(*std::prev(next)));
     }
     std::construct_at(
-        &*dst, std::piecewise_construct, std::forward_as_tuple(key),
+        const_cast<Value*>(&*dst), std::piecewise_construct, std::forward_as_tuple(key),
         std::forward_as_tuple(std::forward<Args>(args)...));
     ++size_;
     return std::make_pair(dst, true);
@@ -880,11 +880,11 @@ class [[nodiscard]] LimitedOrdered {
     }
     MBO_CONFIG_REQUIRE(size_ < Capacity, "Called `try_emplace` at capacity.");
     for (iterator next = end(); next > dst; --next) {
-      std::construct_at(&*next, std::move(*std::prev(next)));
+      std::construct_at(const_cast<Value*>(&*next), std::move(*std::prev(next)));
     }
     // Should possibly use: std::piecewise_construct, std::move(key), std::forward_as_tuple(std::forward<Args>(args)...)
     // But that creates issues with conversion. However, we know the two types, so we do not need piecewise.
-    std::construct_at(&*dst, std::move(key), Mapped(std::forward<Args>(args)...));
+    std::construct_at(const_cast<Value*>(&*dst), std::move(key), Mapped(std::forward<Args>(args)...));
     ++size_;
     return std::make_pair(dst, true);
   }
@@ -899,9 +899,9 @@ class [[nodiscard]] LimitedOrdered {
     }
     MBO_CONFIG_REQUIRE(size_ < Capacity, "Called `insert_or_assign` at capacity.");
     for (iterator next = end(); next > dst; --next) {
-      std::construct_at(&*next, std::move(*std::prev(next)));
+      std::construct_at(const_cast<Value*>(&*next), std::move(*std::prev(next)));
     }
-    std::construct_at(&*dst, key, std::forward<V>(value));
+    std::construct_at(const_cast<Value*>(&*dst), key, std::forward<V>(value));
     ++size_;
     return std::make_pair(dst, true);
   }
@@ -916,9 +916,9 @@ class [[nodiscard]] LimitedOrdered {
     }
     MBO_CONFIG_REQUIRE(size_ < Capacity, "Called `emplace` at capacity.");
     for (iterator next = end(); next > dst; --next) {
-      std::construct_at(&*next, std::move(*std::prev(next)));
+      std::construct_at(const_cast<Value*>(&*next), std::move(*std::prev(next)));
     }
-    std::construct_at(&*dst, std::move(key), std::forward<V>(value));
+    std::construct_at(const_cast<Value*>(&*dst), std::move(key), std::forward<V>(value));
     ++size_;
     return std::make_pair(dst, true);
   }

--- a/mbo/types/internal/struct_names_clang.h
+++ b/mbo/types/internal/struct_names_clang.h
@@ -51,6 +51,7 @@ class StructMeta;
 template<typename T>
 class StructMetaBase {
  private:
+  using RawT = std::remove_const_t<T>;
   template<typename U, bool, bool>
   friend class StructMeta;
 
@@ -67,13 +68,13 @@ class StructMetaBase {
       Uninitialized& operator=(Uninitialized&&) = delete;
 
       char temp[sizeof(T)] = {0};  // NOLINT(*-avoid-c-arrays)
-      T value;
+      RawT value;
     };
 
    public:
     constexpr Storage() noexcept {
-      if constexpr (std::is_default_constructible_v<T>) {
-        std::construct_at(&storage_.value);
+      if constexpr (std::is_default_constructible_v<RawT>) {
+        std::construct_at(const_cast<RawT*>(&storage_.value));
       } else {
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
         memset(const_cast<char*>(&storage_.temp[0]), 0, sizeof(T));

--- a/mbo/types/no_destruct.h
+++ b/mbo/types/no_destruct.h
@@ -58,18 +58,20 @@ class NoDestruct final {
   };
 
  public:
-  constexpr NoDestruct() noexcept : data_(buf_) { std::construct_at(&data_.value); }
+  constexpr NoDestruct() noexcept : data_(buf_) { std::construct_at(const_cast<T*>(&data_.value)); }
 
-  constexpr explicit NoDestruct(T arg) noexcept : data_(buf_) { std::construct_at(&data_.value, std::move(arg)); }
+  constexpr explicit NoDestruct(T arg) noexcept : data_(buf_) {
+    std::construct_at(const_cast<T*>(&data_.value), std::move(arg));
+  }
 
   template<typename... Args>
   constexpr explicit NoDestruct(Args&&... args) noexcept : data_(buf_) {
-    std::construct_at(&data_.value, std::forward<Args>(args)...);
+    std::construct_at(const_cast<T*>(&data_.value), std::forward<Args>(args)...);
   }
 
   template<typename U>
   constexpr NoDestruct(const std::initializer_list<U>& args) noexcept : data_(buf_) {
-    std::construct_at(&data_.value, args);
+    std::construct_at(const_cast<T*>(&data_.value), args);
   }
 
   constexpr ~NoDestruct() noexcept = default;

--- a/mbo/types/tstring.h
+++ b/mbo/types/tstring.h
@@ -500,7 +500,7 @@ struct MakeTstringLiteralHelper {
 // [-Wgnu-string-literal-operator-template]
 template<typename T, T... chars>
 requires std::is_same_v<T, char>
-constexpr tstring<chars...> operator"" _ts() {
+constexpr tstring<chars...> operator""_ts() {
   return {};
 }
 #else


### PR DESCRIPTION
* Address const-ness issues in constexpr functions found by Clang 20.1.0.
* Drop space in front of string-literal notation found by Clang 20.1.0.