### PR TITLE
Update actions.

### DIFF
--- a/.github/workflows/cache_cleanup.yml
+++ b/.github/workflows/cache_cleanup.yml
@@ -9,18 +9,34 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cleanup caches from current PR
+        # We could fetch the prefix list and per prefix keep only one.
+        # But for simplicity and safety we only work on the reported branch.
+        # On the main branch this `cache_cleanup` workflow may not delete the last version as that
+        # that would mean that the `test` workflow triggered for the same state will not find any
+        # caches. That is because the the `cache_cleanup` workflow is much faster and will most
+        # likely finish during the initial `pre-commit` job of the `test` workflow.
+        # Not that last version for the head ref means last cache version per cache key prefix.
         run: |
           set -euo pipefail
-
-          # We could fetch the prefix list and per prefix keep one. But main cannot see the feature branch cahce :-(
           echo "Fetching list of cache keys for head ref '${HEAD_REF}' on PR '${PULL_REQUEST}'."
-          cacheKeysForPR=$(gh cache list --ref "${HEAD_REF}" --limit 100 --json id --jq '.[].id')
-
-          echo "Deleting caches..."
-          for cacheKey in ${cacheKeysForPR}; do
-            echo "Deleting cache: ${cacheKey}"
-            gh cache delete "${cacheKey}" || echo "Error deleting: ${cacheKey}."
-          done
+          if [ "${HEAD_REF}" == "refs/heads/main" ]; then
+            cacheKeyPrefixList=$(gh cache list --ref refs/heads/main  --limit 250 --json id,key,ref,createdAt --jq "[map((.ref as \$ref|.key|split(\"-\")|index(\$ref) as \$idx|select(.|\$idx)|.[0:\$idx+1]|join(\"-\")) as \$prefix|.prefix=\$prefix)|.[]|.prefix]|sort|unique|.[]")
+            echo "Deleting all but last cache per key prefix for 'refs/heads/main'..."
+            for cacheKeyPrefix in ${cacheKeyPrefixList}; do
+              cacheKeyList=$(gh cache list --ref "${HEAD_REF}" --limit 250 --json id,key,createdAt --jq 'map(select(.key|startswith(\"${cacheKeyPrefix}\")))|sort_by(.createdAt)|.[:-1]|.[].id')
+              for cacheKey in ${cacheKeyList}; do
+                echo "Deleting cache: ${cacheKey}"
+                gh cache delete "${cacheKey}" || echo "Error deleting: ${cacheKey}."
+              done
+            done
+          else
+            cacheKeyList=$(gh cache list --ref "${HEAD_REF}" --limit 250 --json id --jq '.[].id')
+            echo "Deleting all caches for '${HEAD_REF}'..."
+            for cacheKey in ${cacheKeyList}; do
+              echo "Deleting cache: ${cacheKey}"
+              gh cache delete "${cacheKey}" || echo "Error deleting: ${cacheKey}."
+            done
+          fi
           echo "Done"
         env:
           GH_TOKEN: ${{secrets.CACHE_ACCESS}}
@@ -31,10 +47,10 @@ jobs:
       - name: Cleanup caches from old PRs
         run: |
           set -euo pipefail
-
           closedBeforeDate="$(date -Iminutes --date=-4hours)"
+          closedAfterDate="$(date -Iminutes --date=-14days)"
           echo "Fetching list of branch names for PRs closed before: ${closedBeforeDate}."
-          closedPrList=$(gh pr list -s closed --json headRefName,closedAt --jq "map(select(.closedAt < \"${closedBeforeDate}\"))|.[].headRefName")
+          closedPrList=$(gh pr list -s closed --json headRefName,closedAt --jq "map(select(.closedAt > \"${closedAfterDate}\" and .closedAt < \"${closedBeforeDate}\"))|.[].headRefName")
           for closedPr in ${closedPrList}; do
             echo "Deleting caches for '${closedPr}'..."
             cacheKeyList=$(gh cache list --ref "refs/heads/${closedPr}" --limit 250 --json id --jq '.[].id')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,10 +28,10 @@ jobs:
             gcc_version: 11
           - bazel_mode: workspace
             gcc_version: 13
-          - gcc_version: 11
-            bazel_config: cpp23
-          - gcc_version: 12
-            bazel_config: cpp23
+          - bazel_config: cpp23
+            gcc_version: 11
+          - bazel_config: cpp23
+            gcc_version: 12
 
     uses: ./.github/workflows/test.yml
     with:
@@ -87,10 +87,16 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         bazel_mode: [bzlmod]
-        compiler: [clang]
+        compiler: [gcc, native]
+        gcc_version: [11]
         llvm_version: [19.1.6]
         bazel_config: [opt]
         module_version: [0.4.2]
+        exclude:
+          - os: ubuntu-latest
+            compiler: native
+          - os: macos-latest
+            compiler: gcc
 
     uses: ./.github/workflows/test.yml
     with:
@@ -98,6 +104,7 @@ jobs:
       os: ${{ matrix.os }}
       bazel_mode: ${{ matrix.bazel_mode }}
       compiler: ${{ matrix.compiler }}
+      gcc_version: ${{ matrix.gcc_version }}
       llvm_version: ${{ matrix.llvm_version }}
       bazel_config: ${{ matrix.bazel_config }}
       module_version: ${{ matrix.module_version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,12 +47,16 @@ on:
         type: string
         default: opt
       module_version:
-        description: 'Version string for the MODULE.$ver.bazel to be copied from the bzlmod directory.'
+        description: 'Version string for the "MODULE.${module_version}.bazel" to be copied from the bzlmod directory.'
+        type: string
+        default: ''
+      module_default:
+        description: 'If the "module_version" has this value, then no "MODULE.${module_version}.bazel" will be copied.'
         type: string
         default: ''
 
 env:
-  CACHE_KEY_PREFIX: ${{inputs.os}}-${{inputs.bazel_mode}}_${{inputs.compiler}}_${{inputs.llvm_version}}_${{inputs.gcc_version}}_${{inputs.bazel_config}}_${{inputs.module_version}}
+  CACHE_KEY_PREFIX: ${{inputs.os}}-${{inputs.bazel_mode}}_${{inputs.compiler}}_${{inputs.compiler == 'clang' && inputs.llvm_version || ''}}_${{inputs.compiler == 'gcc' && inputs.gcc_version || ''}}_${{inputs.bazel_config}}_${{inputs.module_version}}
 
 jobs:
   test:
@@ -62,7 +66,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: bazelbuild/setup-bazelisk@v3
       - uses: egor-tensin/setup-gcc@v1
-        if: ${{inputs.compiler == 'gcc'}}
+        if: ${{inputs.compiler == 'gcc' && inputs.gcc_version != ''}}
         with:
           version: ${{inputs.gcc_version}}
           platform: ${{runner.arch}}
@@ -75,7 +79,12 @@ jobs:
               ${{env.CACHE_KEY_PREFIX}}-${{github.ref}}
               ${{env.CACHE_KEY_PREFIX}}-refs/heads/main
               ${{env.CACHE_KEY_PREFIX}}
-      - run: |
+      - name: Build and Test
+        run: |
+          if [ "${{inputs.compiler}}:${{inputs.gcc_version}}" == "gcc:" ]; then
+            echo "ERROR: When compiler=='gcc', then a valid 'compiler_version' must be given."
+            exit 1
+          fi
           declare -a BAZEL_INIT=()
           declare -a BAZEL_ARGS=()
           CACHE_ROOT=~/.cache
@@ -103,8 +112,12 @@ jobs:
           elif [ "${{inputs.compiler}}" == "gcc" ]; then
             export CC=/usr/local/bin/gcc
             export CXX=/usr/local/bin/g++
+          elif [ "${{inputs.compiler}}" == "native" ]; then
+            # Use whatever is found!
+            [ -n "${CC}" ] && [ -x "${CC}" ] && echo "CC: $(${CC} --version)"
+            [ -n "${CXX}" ] && [ -x "${CXX}" ] && echo "CXX: $(${CXX} --version)"
           else
-            echo "ERROR: Matrix/Input var 'compiler' must be one of [clang, gcc]."
+            echo "ERROR: Matrix/Input var 'compiler' must be one of [clang, gcc, native]."
           fi
           if [ "${{inputs.bazel_config}}" == "asan" ]; then
             BAZEL_ARGS+=("-c" "dbg" "--config=asan")
@@ -118,7 +131,9 @@ jobs:
             echo "ERROR: Matrix/Input var 'bazel_config' must be one of [asan, cpp23, fastbuild, opt]."
           fi
           if [ -n "${{inputs.module_version}}" ]; then
-            cp "bazelmod/MODULE.${{inputs.module_version}}.bazel" MODULE.bazel
+            if [ "${{inputs.module_version}}" != "${{inputs.module_default}}" ]; then
+              cp "bazelmod/MODULE.${{inputs.module_version}}.bazel" MODULE.bazel
+            fi
           fi
           echo "BAZEL_INIT: ${BAZEL_INIT[@]}"
           echo "BAZEL_ARGS: ${BAZEL_ARGS[@]}"


### PR DESCRIPTION
* For refs/heads/main delete per cache key prefix all but the last cache version.
* For other branches delete all cachees.
* For older branches limit the date range to consider.
* Switch test-bcr to ubuntu=gcc, macos=native.
* Add `input.module_default` to allow passing defaults in `input.module_version` by value which will be skipped.
* In cache keys only provide `gcc_version` if compiler is `gcc` and `llvm_version` only if compiler is `clang`.