### PR TITLE
Added field GlobOptions::recursive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-# 0.4.5
+# 0.5.0
 
-* Added LLVM-20.1.0 config for Linux-Arm64 and MacOs-Arm64 platforms.
+* Added CI config LLVM-20.1.0 for Linux-Arm64 and MacOs-Arm64 platforms.
 * Applied DWYU cleanup.
+* Added field `GlobOptions::recursive` to select between recursive and flat globbing.
 
 # 0.4.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 * Added CI config LLVM-20.1.0 for Linux-Arm64 and MacOs-Arm64 platforms.
 * Applied DWYU cleanup.
-* Added field `GlobOptions::recursive` to select between recursive and flat globbing.
+* Added field `mbo::file::GlobOptions::recursive` to select between recursive and flat globbing.
+* Added function `mbo::file::GlobSplit` that splits a pattern into root and pattern.
 
 # 0.4.4
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,7 +18,7 @@
 # Due to flag and test references to the repo name we use the old name for now.
 module(
     name = "helly25_mbo",
-    version = "0.4.5",
+    version = "0.5.0",
     repo_name = "com_helly25_mbo",
 )
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The C++ library is organized in functional groups each residing in their own dir
         * type `mbo::file::GlobEntryFunc`: Callback for acceptable glob entries.
         * function `mbo::file::GlobRe2`: Performs recursive glob functionality using a RE2 pattern.
         * function `mbo::file::Glob`: Performs recursive glob functionality using a `fnmatch` style pattern.
+        * function `mbo::file::GlobSplit`: Splits a pattern into root and pattern parts.
         * program `glob`: A recursive glob, see `glob --help`.
     * mbo/file/ini:ini_file_cc, mbo/file/ini/ini_file.h
         * class `IniFile`: A simple INI file reader.

--- a/mbo/file/BUILD.bazel
+++ b/mbo/file/BUILD.bazel
@@ -84,6 +84,7 @@ cc_test(
     srcs = ["glob_test.cc"],
     deps = [
         ":glob_cc",
+        "//mbo/status:status_macros_cc",
         "//mbo/testing:status_cc",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",

--- a/mbo/file/glob.cc
+++ b/mbo/file/glob.cc
@@ -488,6 +488,15 @@ absl::Status Glob(
   return GlobRe2(root, *regex, options, func);
 }
 
+absl::Status Glob(
+    const absl::StatusOr<RootAndPattern>& pattern,
+    const Glob2Re2Options& re2_convert_options,
+    const GlobOptions& options,
+    const GlobEntryFunc& func) {
+  MBO_RETURN_IF_ERROR(pattern);
+  return Glob(pattern->root, pattern->pattern, re2_convert_options, options, func);
+}
+
 absl::StatusOr<RootAndPattern> GlobSplit(std::string_view pattern, const Glob2Re2Options& options) {
   MBO_MOVE_TO_OR_RETURN(GlobNormalizeData(pattern, options), GlobData data);
   std::string_view root(data.pattern);

--- a/mbo/file/glob.cc
+++ b/mbo/file/glob.cc
@@ -269,11 +269,7 @@ MBO_ALWAYS_INLINE absl::StatusOr<GlobData> GlobNormalizeData(
     return result;
   }
   const bool star_star = result.pattern.find("**", slash_1) != std::string::npos;
-  if (star_star) {
-    result.path_len = result.pattern.size();
-  } else {
-    result.path_len = slash_1;
-  }
+  result.path_len = star_star ? result.pattern.size() : slash_1;
   return result;
 }
 
@@ -421,18 +417,18 @@ absl::StatusOr<RootAndPattern> GlobSplit(std::string_view pattern, const Glob2Re
 namespace {
 
 template<typename FileIterator>
-int FileIteratorDepth(const FileIterator& it) {
+int FileIteratorDepth(const FileIterator& file_iterator) {
   if constexpr (std::same_as<FileIterator, std::filesystem::recursive_directory_iterator>) {
-    return it.depth();
+    return file_iterator.depth();
   } else {
     return 0;
   }
 }
 
 template<typename FileIterator>
-void FileIteratorDisableRecursionPending(FileIterator& it) {
+void FileIteratorDisableRecursionPending(FileIterator& file_iterator) {
   if constexpr (std::same_as<FileIterator, std::filesystem::recursive_directory_iterator>) {
-    it.disable_recursion_pending();
+    file_iterator.disable_recursion_pending();
   }
 }
 

--- a/mbo/file/glob.h
+++ b/mbo/file/glob.h
@@ -37,6 +37,10 @@ struct GlobOptions {
   // the relative path as opposed to `entry.path`.
   bool use_rel_path : 1 = false;
 
+  // By default the globbing is done in recursive fashion. But that can be disabled in which case
+  // only the given root directory will be iteratoed.
+  bool recursive : 1 = true;
+
   // Options passed to the creation of the `std::filesystem::recursive_directory_iterator`.
   std::filesystem::directory_options dir_options = std::filesystem::directory_options::skip_permission_denied;
 };
@@ -95,7 +99,7 @@ struct GlobEntry : mbo::types::Extend<GlobEntry> {
   const std::filesystem::directory_entry entry;
   const int depth;
 
-  // Returns the path for the `entry` either as is or elative to `root` if that was requested using
+  // Returns the path for the `entry` either as is or relative to `root` if that was requested using
   // `GlobOptions.use_rel_path`.
   const std::filesystem::path& MaybeRelativePath() const noexcept {
     return rel_path.has_value() ? *rel_path : entry.path();

--- a/mbo/file/glob.h
+++ b/mbo/file/glob.h
@@ -153,6 +153,23 @@ absl::Status Glob(
     const GlobOptions& options,
     const GlobEntryFunc& func);
 
+// Recursive glob to be called with `GlobSplit` as pattern argument.
+//
+// Example:
+// ```
+// std::vector<std::string> found;
+// const auto result = mbo::file::Glob(
+//     mbo::file::GlobSplit("/home/you/*", {}, {}, [&](const GlobEntry& e) {
+//       found.push_back(e.entry.path().native());
+//       return mbo::file::GlobEntryAction::kContinue;
+//     }));
+// ```
+absl::Status Glob(
+    const absl::StatusOr<RootAndPattern>& pattern,
+    const Glob2Re2Options& re2_convert_options,
+    const GlobOptions& options,
+    const GlobEntryFunc& func);
+
 }  // namespace mbo::file
 
 #endif  // MBO_FILE_GLOB_H_

--- a/mbo/file/glob.h
+++ b/mbo/file/glob.h
@@ -66,7 +66,7 @@ struct GlobParts : mbo::types::Extend<GlobParts> {
 // - while a range `[/]` is normalized to a single `/` and handled as such,
 // - any other range that can accept a slash can either be a path or file name component. Those cases will
 //   be reported as just a path component with the `mixed = true`.
-absl::StatusOr<GlobParts> GlobSplit(std::string_view pattern, const Glob2Re2Options& options = {});
+absl::StatusOr<GlobParts> GlobSplitParts(std::string_view pattern, const Glob2Re2Options& options = {});
 
 // Convert `pattern` into a RE2 expression.
 // Supported syntax:
@@ -93,6 +93,13 @@ absl::StatusOr<std::string> Glob2Re2Expression(std::string_view pattern, const G
 absl::StatusOr<std::unique_ptr<const RE2>> Glob2Re2(std::string_view pattern, const Glob2Re2Options& options = {});
 
 }  // namespace file_internal
+
+struct RootAndPattern : mbo::types::Extend<RootAndPattern> {
+  std::string root;
+  std::string pattern;
+};
+
+absl::StatusOr<RootAndPattern> GlobSplit(std::string_view pattern, const Glob2Re2Options& options = {});
 
 struct GlobEntry : mbo::types::Extend<GlobEntry> {
   const std::optional<const std::filesystem::path> rel_path;  // Must be first

--- a/mbo/file/glob_test.cc
+++ b/mbo/file/glob_test.cc
@@ -15,24 +15,15 @@
 
 // If the macro `TEST_FNMATCH` is defined, and the <fnmatch.h> include is available, then the test
 // for `Glob2Re2` verifies that its result matches that of `fnmatch`.
-#include <initializer_list>
-
-#include "mbo/status/status_macros.h"
 #define TEST_FNMATCH
 
-#if !__has_include(<fnmatch.h>)
-# undef TEST_FNMATCH
-#endif
+#include "mbo/file/glob.h"
 
 #include <array>
 #include <cstdlib>
 #include <filesystem>
-
-#include "mbo/file/glob.h"
-#ifdef TEST_FNMATCH
-# include <fnmatch.h>
-#endif  // TEST_FNMATCH
 #include <fstream>
+#include <initializer_list>
 #include <memory>
 #include <source_location>
 #include <string_view>
@@ -42,8 +33,16 @@
 #include "absl/strings/str_split.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "mbo/status/status_macros.h"
 #include "mbo/testing/status.h"
 #include "re2/re2.h"
+
+#if !__has_include(<fnmatch.h>)
+# undef TEST_FNMATCH
+#endif
+#ifdef TEST_FNMATCH
+# include <fnmatch.h>
+#endif  // TEST_FNMATCH
 
 namespace mbo::file {
 namespace {
@@ -53,8 +52,8 @@ using namespace mbo::file::file_internal;
 using ::mbo::testing::IsOk;
 using ::mbo::testing::IsOkAndHolds;
 using ::mbo::testing::StatusIs;
-using ::testing::ElementsAreArray;
 using ::testing::NotNull;
+using ::testing::UnorderedElementsAreArray;
 
 struct GlobTest : ::testing::Test {
   static void Glob2Re2Match(
@@ -269,16 +268,18 @@ absl::StatusOr<std::filesystem::path> CreateFileSystemEntries(
 struct GlobFileTest : GlobTest {
   static void SetUpTestSuite() {
     MBO_ASSERT_OK_AND_ASSIGN(
-        root_glob_test, CreateFileSystemEntries(
-                            GetTempDir("glob_test"), {
-                                                         ":top",
-                                                         "dir",
-                                                         "sub/dir:file1",
-                                                         "sub/dir:file2",
-                                                         "sub/two/dir:file1",
-                                                         "sub/two/dir:file2",
-                                                         "sub/two/dir:file3",
-                                                     }));
+        root_glob_test,  //
+        CreateFileSystemEntries(
+            GetTempDir("glob_test"),  //
+            {
+                ":top",
+                "dir",
+                "sub/dir:file1",
+                "sub/dir:file2",
+                "sub/two/dir:file1",
+                "sub/two/dir:file2",
+                "sub/two/dir:file3",
+            }));
   }
 
   static std::filesystem::path root_glob_test;
@@ -293,7 +294,7 @@ TEST_F(GlobFileTest, GlobStopImmediately) {
     return GlobEntryAction::kStop;
   }));
   EXPECT_THAT(
-      found, ElementsAreArray({
+      found, UnorderedElementsAreArray({
                  "top",
              }));
 }
@@ -305,7 +306,7 @@ TEST_F(GlobFileTest, GlobStar) {
     return GlobEntryAction::kContinue;
   }));
   EXPECT_THAT(
-      found, ElementsAreArray({
+      found, UnorderedElementsAreArray({
                  "top",
                  "dir",
                  "sub",
@@ -319,7 +320,7 @@ TEST_F(GlobFileTest, GlobStarStar) {
     return GlobEntryAction::kContinue;
   }));
   EXPECT_THAT(
-      found, ElementsAreArray({
+      found, UnorderedElementsAreArray({
                  "top",
                  "dir",
                  "sub",
@@ -341,7 +342,7 @@ TEST_F(GlobFileTest, GlobStarStarNonRecursive) {
     return GlobEntryAction::kContinue;
   }));
   EXPECT_THAT(
-      found, ElementsAreArray({
+      found, UnorderedElementsAreArray({
                  "top",
                  "dir",
                  "sub",
@@ -355,7 +356,7 @@ TEST_F(GlobFileTest, GlobStarStarMatch) {
     return GlobEntryAction::kContinue;
   }));
   EXPECT_THAT(
-      found, ElementsAreArray({
+      found, UnorderedElementsAreArray({
                  "dir",
                  "sub/dir",
                  "sub/two/dir",
@@ -369,7 +370,7 @@ TEST_F(GlobFileTest, GlobStarStarMatchSquareBrackets) {
     return GlobEntryAction::kContinue;
   }));
   EXPECT_THAT(
-      found, ElementsAreArray({
+      found, UnorderedElementsAreArray({
                  "sub/dir/file2",
                  "sub/two/dir/file2",
                  "sub/two/dir/file3",

--- a/mbo/file/glob_test.cc
+++ b/mbo/file/glob_test.cc
@@ -195,45 +195,80 @@ MATCHER_P3(HasParts, path_matcher, file_matcher, is_mixed, "") {
       arg, result_listener);
 }
 
-TEST_F(GlobTest, GlobSplit) {
+TEST_F(GlobTest, GlobSplitParts) {
   EXPECT_THAT(
-      GlobSplit("\\"), StatusIs(absl::StatusCode::kInvalidArgument, "No character left to escape at end of pattern."));
-  EXPECT_THAT(GlobSplit(""), IsOkAndHolds(HasParts("", "", false)));
-  EXPECT_THAT(GlobSplit("/"), IsOkAndHolds(HasParts("/", "", false)));
-  EXPECT_THAT(GlobSplit("//"), IsOkAndHolds(HasParts("/", "", false)));
-  EXPECT_THAT(GlobSplit("a/b"), IsOkAndHolds(HasParts("a", "b", false)));
-  EXPECT_THAT(GlobSplit("a//b"), IsOkAndHolds(HasParts("a", "b", false)));
-  EXPECT_THAT(GlobSplit("a/b/c"), IsOkAndHolds(HasParts("a/b", "c", false)));
-  EXPECT_THAT(GlobSplit("a/**/c"), IsOkAndHolds(HasParts("a/**", "c", false)));
-  EXPECT_THAT(GlobSplit("a/b/**"), IsOkAndHolds(HasParts("a/b/**", "", false)));
+      GlobSplitParts("\\"),
+      StatusIs(absl::StatusCode::kInvalidArgument, "No character left to escape at end of pattern."));
+  EXPECT_THAT(GlobSplitParts(""), IsOkAndHolds(HasParts("", "", false)));
+  EXPECT_THAT(GlobSplitParts("/"), IsOkAndHolds(HasParts("/", "", false)));
+  EXPECT_THAT(GlobSplitParts("//"), IsOkAndHolds(HasParts("/", "", false)));
+  EXPECT_THAT(GlobSplitParts("a/b"), IsOkAndHolds(HasParts("a", "b", false)));
+  EXPECT_THAT(GlobSplitParts("a//b"), IsOkAndHolds(HasParts("a", "b", false)));
+  EXPECT_THAT(GlobSplitParts("a/b/c"), IsOkAndHolds(HasParts("a/b", "c", false)));
+  EXPECT_THAT(GlobSplitParts("a/**/c"), IsOkAndHolds(HasParts("a/**", "c", false)));
+  EXPECT_THAT(GlobSplitParts("a/b/**"), IsOkAndHolds(HasParts("a/b/**", "", false)));
 }
 
-TEST_F(GlobTest, GlobSplitWithRanges) {
-  EXPECT_THAT(GlobSplit("a[/]b/[/]c"), IsOkAndHolds(HasParts("a/b", "c", false)));
-  EXPECT_THAT(GlobSplit("a[/]b/[-/]c"), IsOkAndHolds(HasParts("a/b/[-/]c", "", true)));
-  EXPECT_THAT(GlobSplit("a[/]b/[!/]c"), IsOkAndHolds(HasParts("a/b", "[!/]c", false)));
-  EXPECT_THAT(GlobSplit("a[/]b/[/]/c"), IsOkAndHolds(HasParts("a/b", "c", false)));
-  EXPECT_THAT(GlobSplit("a[/]b/[-/]/c"), IsOkAndHolds(HasParts("a/b/[-/]", "c", false)));
-  EXPECT_THAT(GlobSplit("a[/]b/[!/]/c"), IsOkAndHolds(HasParts("a/b/[!/]", "c", false)));
-  EXPECT_THAT(GlobSplit("a[/]/b/[/]c"), IsOkAndHolds(HasParts("a/b", "c", false)));
-  EXPECT_THAT(GlobSplit("a[/]/b/[-/]c"), IsOkAndHolds(HasParts("a/b/[-/]c", "", true)));
-  EXPECT_THAT(GlobSplit("a[/]/b/[!/]c"), IsOkAndHolds(HasParts("a/b", "[!/]c", false)));
-  EXPECT_THAT(GlobSplit("a[/]/b/[/]/c"), IsOkAndHolds(HasParts("a/b", "c", false)));
-  EXPECT_THAT(GlobSplit("a[/]/b/[-/]/c"), IsOkAndHolds(HasParts("a/b/[-/]", "c", false)));
-  EXPECT_THAT(GlobSplit("a[/]/b/[!/]/c"), IsOkAndHolds(HasParts("a/b/[!/]", "c", false)));
+TEST_F(GlobTest, GlobSplitPartsWithRanges) {
+  EXPECT_THAT(GlobSplitParts("a[/]b/[/]c"), IsOkAndHolds(HasParts("a/b", "c", false)));
+  EXPECT_THAT(GlobSplitParts("a[/]b/[-/]c"), IsOkAndHolds(HasParts("a/b/[-/]c", "", true)));
+  EXPECT_THAT(GlobSplitParts("a[/]b/[!/]c"), IsOkAndHolds(HasParts("a/b", "[!/]c", false)));
+  EXPECT_THAT(GlobSplitParts("a[/]b/[/]/c"), IsOkAndHolds(HasParts("a/b", "c", false)));
+  EXPECT_THAT(GlobSplitParts("a[/]b/[-/]/c"), IsOkAndHolds(HasParts("a/b/[-/]", "c", false)));
+  EXPECT_THAT(GlobSplitParts("a[/]b/[!/]/c"), IsOkAndHolds(HasParts("a/b/[!/]", "c", false)));
+  EXPECT_THAT(GlobSplitParts("a[/]/b/[/]c"), IsOkAndHolds(HasParts("a/b", "c", false)));
+  EXPECT_THAT(GlobSplitParts("a[/]/b/[-/]c"), IsOkAndHolds(HasParts("a/b/[-/]c", "", true)));
+  EXPECT_THAT(GlobSplitParts("a[/]/b/[!/]c"), IsOkAndHolds(HasParts("a/b", "[!/]c", false)));
+  EXPECT_THAT(GlobSplitParts("a[/]/b/[/]/c"), IsOkAndHolds(HasParts("a/b", "c", false)));
+  EXPECT_THAT(GlobSplitParts("a[/]/b/[-/]/c"), IsOkAndHolds(HasParts("a/b/[-/]", "c", false)));
+  EXPECT_THAT(GlobSplitParts("a[/]/b/[!/]/c"), IsOkAndHolds(HasParts("a/b/[!/]", "c", false)));
 
-  EXPECT_THAT(GlobSplit("a[/]b[/]c"), IsOkAndHolds(HasParts("a/b", "c", false)));
-  EXPECT_THAT(GlobSplit("a[/]b[-/]c"), IsOkAndHolds(HasParts("a/b[-/]c", "", true)));
-  EXPECT_THAT(GlobSplit("a[/]b[!/]c"), IsOkAndHolds(HasParts("a", "b[!/]c", false)));
-  EXPECT_THAT(GlobSplit("a[/]b[/]/c"), IsOkAndHolds(HasParts("a/b", "c", false)));
-  EXPECT_THAT(GlobSplit("a[/]b[-/]/c"), IsOkAndHolds(HasParts("a/b[-/]", "c", false)));
-  EXPECT_THAT(GlobSplit("a[/]b[!/]/c"), IsOkAndHolds(HasParts("a/b[!/]", "c", false)));
-  EXPECT_THAT(GlobSplit("a[/]/b[/]c"), IsOkAndHolds(HasParts("a/b", "c", false)));
-  EXPECT_THAT(GlobSplit("a[/]/b[-/]c"), IsOkAndHolds(HasParts("a/b[-/]c", "", true)));
-  EXPECT_THAT(GlobSplit("a[/]/b[!/]c"), IsOkAndHolds(HasParts("a", "b[!/]c", false)));
-  EXPECT_THAT(GlobSplit("a[/]/b[/]/c"), IsOkAndHolds(HasParts("a/b", "c", false)));
-  EXPECT_THAT(GlobSplit("a[/]/b[-/]/c"), IsOkAndHolds(HasParts("a/b[-/]", "c", false)));
-  EXPECT_THAT(GlobSplit("a[/]/b[!/]/c"), IsOkAndHolds(HasParts("a/b[!/]", "c", false)));
+  EXPECT_THAT(GlobSplitParts("a[/]b[/]c"), IsOkAndHolds(HasParts("a/b", "c", false)));
+  EXPECT_THAT(GlobSplitParts("a[/]b[-/]c"), IsOkAndHolds(HasParts("a/b[-/]c", "", true)));
+  EXPECT_THAT(GlobSplitParts("a[/]b[!/]c"), IsOkAndHolds(HasParts("a", "b[!/]c", false)));
+  EXPECT_THAT(GlobSplitParts("a[/]b[/]/c"), IsOkAndHolds(HasParts("a/b", "c", false)));
+  EXPECT_THAT(GlobSplitParts("a[/]b[-/]/c"), IsOkAndHolds(HasParts("a/b[-/]", "c", false)));
+  EXPECT_THAT(GlobSplitParts("a[/]b[!/]/c"), IsOkAndHolds(HasParts("a/b[!/]", "c", false)));
+  EXPECT_THAT(GlobSplitParts("a[/]/b[/]c"), IsOkAndHolds(HasParts("a/b", "c", false)));
+  EXPECT_THAT(GlobSplitParts("a[/]/b[-/]c"), IsOkAndHolds(HasParts("a/b[-/]c", "", true)));
+  EXPECT_THAT(GlobSplitParts("a[/]/b[!/]c"), IsOkAndHolds(HasParts("a", "b[!/]c", false)));
+  EXPECT_THAT(GlobSplitParts("a[/]/b[/]/c"), IsOkAndHolds(HasParts("a/b", "c", false)));
+  EXPECT_THAT(GlobSplitParts("a[/]/b[-/]/c"), IsOkAndHolds(HasParts("a/b[-/]", "c", false)));
+  EXPECT_THAT(GlobSplitParts("a[/]/b[!/]/c"), IsOkAndHolds(HasParts("a/b[!/]", "c", false)));
+}
+
+MATCHER_P2(HasSplit, root_matcher, pattern_matcher, "") {
+  using ::testing::AllOf;
+  using ::testing::Field;
+  return ::testing::ExplainMatchResult(
+      AllOf(
+          Field("root", &RootAndPattern::root, root_matcher),
+          Field("pattern", &RootAndPattern::pattern, pattern_matcher)),
+      arg, result_listener);
+}
+
+TEST_F(GlobTest, GlobSplit) {
+  EXPECT_THAT(GlobSplit(""), IsOkAndHolds(HasSplit("", "")));
+  EXPECT_THAT(GlobSplit("a/?/c"), IsOkAndHolds(HasSplit("a", "?/c")));
+  EXPECT_THAT(GlobSplit("a/b/?/c"), IsOkAndHolds(HasSplit("a/b", "?/c")));
+  EXPECT_THAT(GlobSplit("a/*/c"), IsOkAndHolds(HasSplit("a", "*/c")));
+  EXPECT_THAT(GlobSplit("a/b/*/c"), IsOkAndHolds(HasSplit("a/b", "*/c")));
+  EXPECT_THAT(GlobSplit("a/**/c"), IsOkAndHolds(HasSplit("a", "**/c")));
+  EXPECT_THAT(GlobSplit("a/b/**/c"), IsOkAndHolds(HasSplit("a/b", "**/c")));
+  EXPECT_THAT(GlobSplit("/"), IsOkAndHolds(HasSplit("/", "")));
+  EXPECT_THAT(GlobSplit("/a/**/c"), IsOkAndHolds(HasSplit("/a", "**/c")));
+  EXPECT_THAT(GlobSplit("/a/b/**/c"), IsOkAndHolds(HasSplit("/a/b", "**/c")));
+  EXPECT_THAT(GlobSplit("//"), IsOkAndHolds(HasSplit("/", "")));
+  EXPECT_THAT(GlobSplit("//a//**//c"), IsOkAndHolds(HasSplit("/a", "**/c")));
+  EXPECT_THAT(GlobSplit("//a//b/**//c"), IsOkAndHolds(HasSplit("/a/b", "**/c")));
+  EXPECT_THAT(GlobSplit("a/[/]/c"), IsOkAndHolds(HasSplit("a", "c")));
+  EXPECT_THAT(GlobSplit("a/b/[/]/c"), IsOkAndHolds(HasSplit("a/b", "c")));
+  EXPECT_THAT(GlobSplit("a/[xy]/c"), IsOkAndHolds(HasSplit("a", "[xy]/c")));
+  EXPECT_THAT(GlobSplit("a/b/[xy]/c"), IsOkAndHolds(HasSplit("a/b", "[xy]/c")));
+  EXPECT_THAT(GlobSplit("a/x?y/c"), IsOkAndHolds(HasSplit("a", "x?y/c")));
+  EXPECT_THAT(GlobSplit("a/b/x?y/c"), IsOkAndHolds(HasSplit("a/b", "x?y/c")));
+  EXPECT_THAT(GlobSplit("a/x*y/c"), IsOkAndHolds(HasSplit("a", "x*y/c")));
+  EXPECT_THAT(GlobSplit("a/b/x*y/c"), IsOkAndHolds(HasSplit("a/b", "x*y/c")));
 }
 
 template<typename C = std::initializer_list<std::string_view>>
@@ -268,9 +303,9 @@ absl::StatusOr<std::filesystem::path> CreateFileSystemEntries(
 struct GlobFileTest : GlobTest {
   static void SetUpTestSuite() {
     MBO_ASSERT_OK_AND_ASSIGN(
-        root_glob_test,  //
+        root_glob_test,  // NL
         CreateFileSystemEntries(
-            GetTempDir("glob_test"),  //
+            GetTempDir("glob_test"),  // NL
             {
                 ":top",
                 "dir",

--- a/mbo/file/glob_test.cc
+++ b/mbo/file/glob_test.cc
@@ -400,7 +400,7 @@ TEST_F(GlobFileTest, GlobStarStarMatch) {
 
 TEST_F(GlobFileTest, GlobStarStarMatchSquareBrackets) {
   std::vector<std::string> found;
-  ASSERT_OK(Glob(root_glob_test, "**/file[23]", {}, {}, [&](const GlobEntry& entry) -> GlobEntryAction {
+  ASSERT_OK(Glob(GlobSplit(root_glob_test / "**/file[23]"), {}, {}, [&](const GlobEntry& entry) -> GlobEntryAction {
     found.push_back(entry.entry.path().lexically_relative(root_glob_test));
     return GlobEntryAction::kContinue;
   }));


### PR DESCRIPTION
* Added field `mbo::file::GlobOptions::recursive` to select between recursive and flat globbing.
* Added function `mbo::file::GlobSplit` that splits a pattern into root and pattern.
