### PR TITLE
Added expect_* functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,16 @@ The C++ library is organized in functional groups each residing in their own dir
     * `namespace mbo::testing`
     * mbo/testing:bashtest_sh, mbo/testing/bashtest.sh
         * (experimental) sh_library `bashtest.sh` which provides a test runner for complex shell tests involving golden files that provides built-in golden update functionality (see `(. mbo/testing/bashtest.sh --help)`).
+          * status helper `test_has_erro`: Returns whether a test function has had an error.
+          * status helper `test_has_failed_tests`: Returns whether a test program had previous failing test functions.
+          * expectation `expect_eq` "\${LHS}" "\${RHS}": Asserts that two strings are the same.
+          * expectation`expect_ne` "\${LHS}" "\${RHS}": Asserts that two strings are different.
+          * expectation`expect_files_eq` "\${LHS}" "\${RHS}": Asserts that two file are the same (supports golden updates).
+          * expectation`expect_contains` "\${EXPECTED}" "\${ARRAY[@]}": Assert that one string is present in an array.
+          * special test function `test::test_init`: If present, then this function runs first! Tests will only be executed if it succeeds.
+          * special test function `test::test_done`: If present, then this function runs last!
+
+
     * mbo/testing:matchers_cc, mbo/testing/matchers.h
         * gMock-Matcher `CapacityIs` which checks the capacity of a container.
         * gmock-matcher `WhenTransformedBy` which allows to compare containers after transforming them. This sometimes allows for much more concise comparisons where a golden expectation is already available that only differs in a simple transformation.

--- a/mbo/file/glob_sh_test.sh
+++ b/mbo/file/glob_sh_test.sh
@@ -63,7 +63,7 @@ function _test_glob_and_diff() {
     NAME="${1}"
     shift
     "${GLOB}" "${@}" > "${TEST_TMPDIR}/${NAME}.out" 2>&1
-    expect_file_eq "${TESTDATA}/${NAME}.txt" "${TEST_TMPDIR}/${NAME}.out"
+    expect_files_eq "${TESTDATA}/${NAME}.txt" "${TEST_TMPDIR}/${NAME}.out"
 }
 
 function test::default() {

--- a/mbo/testing/tests/BUILD.bazel
+++ b/mbo/testing/tests/BUILD.bazel
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//visibility:private"])
+
+sh_test(
+    name = "bashtest_test",
+    srcs = ["bashtest_test.sh"],
+    deps = ["//mbo/testing:bashtest_sh"],
+)
+
+sh_test(
+    name = "bashtest_init_test",
+    srcs = ["bashtest_init_test.sh"],
+    deps = ["//mbo/testing:bashtest_sh"],
+)
+
+sh_test(
+    name = "bashtest_done_test",
+    srcs = ["bashtest_done_test.sh"],
+    deps = ["//mbo/testing:bashtest_sh"],
+)

--- a/mbo/testing/tests/bashtest_done_test.sh
+++ b/mbo/testing/tests/bashtest_done_test.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# shellcheck disable=SC2317 # Functions are called bashtest
+
+set -euo pipefail
+
+# shellcheck disable=SC1091
+source "mbo/testing/bashtest.sh"
+
+bad_bashtest() {
+    echo >&2 "FATAL: Test functionality broken: ${*}"
+    exit 1
+}
+
+_DONE_CALLED=0
+_INIT_CALLED=0
+
+test::test_init() {
+    echo "Hello World of tests."
+    _INIT_CALLED=1
+    return 0
+}
+
+test::test_done() {
+    echo "The world is ending."
+    _DONE_CALLED=1
+    return 1
+}
+
+test::test_1() {
+    return 0
+}
+
+test::test_2() {
+    return 0
+}
+
+test::test_3() {
+    return 0
+}
+
+test_runner && bad_bashtest "Test was meant to fail but did not."
+
+[[ "${_INIT_CALLED}" == "1" ]] || bad_bashtest "Test init (test::test_init) was not called."
+[[ "${_DONE_CALLED}" == "1" ]] || bad_bashtest "Test done (test::test_done) was not called."
+
+[[ "${_BASHTEST_NUM_PASS}" == "3" ]] || bad_bashtest "Test has unexpected _BASHTEST_NUM_PASS."
+[[ "${_BASHTEST_NUM_FAIL}" == "0" ]] || bad_bashtest "Test has unexpected _BASHTEST_NUM_FAIL."
+[[ "${_BASHTEST_NUM_SKIP}" == "0" ]] || bad_bashtest "Test has unexpected _BASHTEST_NUM_SKIP."
+[[ "${_BASHTEST_INIT_FAILED}" == "0" ]] || bad_bashtest "Test has unexpected _BASHTEST_INIT_FAILED."
+[[ "${_BASHTEST_DONE_FAILED}" == "1" ]] || bad_bashtest "Test has unexpected _BASHTEST_DONE_FAILED."

--- a/mbo/testing/tests/bashtest_init_test.sh
+++ b/mbo/testing/tests/bashtest_init_test.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# shellcheck disable=SC2317 # Functions are called bashtest
+
+set -euo pipefail
+
+# shellcheck disable=SC1091
+source "mbo/testing/bashtest.sh"
+
+bad_bashtest() {
+    echo >&2 "FATAL: Test functionality broken: ${*}"
+    exit 1
+}
+
+_DONE_CALLED=0
+_INIT_CALLED=0
+
+test::test_init() {
+    echo "Hello World of tests."
+    _INIT_CALLED=1
+    return 1
+}
+
+test::test_done() {
+    echo "The world is ending."
+    _DONE_CALLED=1
+}
+
+test::test_1() {
+    return 1
+}
+
+test::test_2() {
+    return 1
+}
+
+test::test_3() {
+    return 1
+}
+
+test_runner && bad_bashtest "Test was meant to fail but did not."
+
+[[ "${_INIT_CALLED}" == "1" ]] || bad_bashtest "Test init (test::test_init) was not called."
+[[ "${_DONE_CALLED}" == "1" ]] || bad_bashtest "Test done (test::test_done) was not called."
+
+[[ "${_BASHTEST_NUM_PASS}" == "0" ]] || bad_bashtest "Test has unexpected _BASHTEST_NUM_PASS."
+[[ "${_BASHTEST_NUM_FAIL}" == "0" ]] || bad_bashtest "Test has unexpected _BASHTEST_NUM_FAIL."
+[[ "${_BASHTEST_NUM_SKIP}" == "3" ]] || bad_bashtest "Test has unexpected _BASHTEST_NUM_SKIP."
+[[ "${_BASHTEST_INIT_FAILED}" == "1" ]] || bad_bashtest "Test has unexpected _BASHTEST_INIT_FAILED."
+[[ "${_BASHTEST_DONE_FAILED}" == "0" ]] || bad_bashtest "Test has unexpected _BASHTEST_DONE_FAILED."

--- a/mbo/testing/tests/bashtest_test.sh
+++ b/mbo/testing/tests/bashtest_test.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# shellcheck disable=SC2317 # Functions are called bashtest
+
+set -euo pipefail
+
+# shellcheck disable=SC1091
+source "mbo/testing/bashtest.sh"
+
+bad_bashtest() {
+    echo >&2 "FATAL: Test functionality broken: ${*}"
+    exit 1
+}
+
+_DONE_CALLED=0
+_INIT_CALLED=0
+
+test::test_init() {
+    echo "Hello World of tests."
+    _INIT_CALLED=1
+}
+
+test::test_done() {
+    echo "The world is ending."
+    _DONE_CALLED=1
+}
+
+test::expect_eq() {
+    [[ "${_BASHTEST_HAS_ERROR}" == "0" ]] || bad_bashtest "Test starts with _BASHTEST_HAS_ERROR != 0, got '${_BASHTEST_HAS_ERROR}'."
+
+    NUM_PASS="${_BASHTEST_NUM_PASS}"
+    NUM_FAIL="${_BASHTEST_NUM_FAIL}"
+    NUM_SKIP="${_BASHTEST_NUM_SKIP}"
+
+    expect_eq "Hello" "Hello"
+    test_has_error && bad_bashtest "expect_eq with same values."
+    _BASHTEST_HAS_ERROR=0
+
+    expect_eq "Hello" "World"
+    test_has_error || bad_bashtest "expect_eq with different values."
+    _BASHTEST_HAS_ERROR=0
+
+    expect_eq "Hello" "City"
+    test_has_error || bad_bashtest "expect_eq with different values."
+    _BASHTEST_HAS_ERROR=0
+
+    expect_eq "Meow" "Meow"
+    test_has_error && bad_bashtest "expect_eq with different values."
+    _BASHTEST_HAS_ERROR=0
+
+    [[ "${_BASHTEST_NUM_PASS}" == "${NUM_PASS}" ]] || bad_bashtest "Test modified _BASHTEST_NUM_PASS."
+    [[ "${_BASHTEST_NUM_FAIL}" == "${NUM_FAIL}" ]] || bad_bashtest "Test modified _BASHTEST_NUM_FAIL."
+    [[ "${_BASHTEST_NUM_SKIP}" == "${NUM_SKIP}" ]] || bad_bashtest "Test modified _BASHTEST_NUM_SKIP."
+    _BASHTEST_NUM_PASS="${NUM_PASS}"
+    _BASHTEST_NUM_FAIL="${NUM_FAIL}"
+    _BASHTEST_NUM_SKIP="${NUM_SKIP}"
+}
+
+test::expect_ne() {
+    [[ "${_BASHTEST_HAS_ERROR}" == "0" ]] || bad_bashtest "Test starts with _BASHTEST_HAS_ERROR != 0, got '${_BASHTEST_HAS_ERROR}'."
+
+    NUM_PASS="${_BASHTEST_NUM_PASS}"
+    NUM_FAIL="${_BASHTEST_NUM_FAIL}"
+    NUM_SKIP="${_BASHTEST_NUM_SKIP}"
+
+    expect_ne "Hello" "Hello"
+    test_has_error || bad_bashtest "expect_ne with same values."
+    _BASHTEST_HAS_ERROR=0
+
+    expect_ne "Hello" "World"
+    test_has_error && bad_bashtest "expect_ne with different values."
+    _BASHTEST_HAS_ERROR=0
+
+    expect_ne "Hello" "City"
+    test_has_error && bad_bashtest "expect_ne with different values."
+    _BASHTEST_HAS_ERROR=0
+
+    expect_ne "Meow" "Meow"
+    test_has_error || bad_bashtest "expect_ne with different values."
+    _BASHTEST_HAS_ERROR=0
+
+    [[ "${_BASHTEST_NUM_PASS}" == "${NUM_PASS}" ]] || bad_bashtest "Test modified _BASHTEST_NUM_PASS."
+    [[ "${_BASHTEST_NUM_FAIL}" == "${NUM_FAIL}" ]] || bad_bashtest "Test modified _BASHTEST_NUM_FAIL."
+    [[ "${_BASHTEST_NUM_SKIP}" == "${NUM_SKIP}" ]] || bad_bashtest "Test modified _BASHTEST_NUM_SKIP."
+    _BASHTEST_NUM_PASS="${NUM_PASS}"
+    _BASHTEST_NUM_FAIL="${NUM_FAIL}"
+    _BASHTEST_NUM_SKIP="${NUM_SKIP}"
+}
+
+test::expect_ne() {
+    [[ "${_BASHTEST_HAS_ERROR}" == "0" ]] || bad_bashtest "Test starts with _BASHTEST_HAS_ERROR != 0, got '${_BASHTEST_HAS_ERROR}'."
+
+    NUM_PASS="${_BASHTEST_NUM_PASS}"
+    NUM_FAIL="${_BASHTEST_NUM_FAIL}"
+    NUM_SKIP="${_BASHTEST_NUM_SKIP}"
+
+    EMPTY=()
+    expect_contains "foo" "${EMPTY[@]}" && bad_bashtest "Element is not present, yet test passed."
+    _BASHTEST_HAS_ERROR=0
+
+    expect_contains "" "${EMPTY[@]}" && bad_bashtest "Element is not present, yet test passed."
+    _BASHTEST_HAS_ERROR=0
+
+    FOO_BAR=("foo" "bar")
+    expect_contains "foo" "${FOO_BAR[@]}" || bad_bashtest "Element is present, yet test failed."
+    _BASHTEST_HAS_ERROR=0
+
+    expect_contains "bar" "${FOO_BAR[@]}" || bad_bashtest "Element is present, yet test failed."
+    _BASHTEST_HAS_ERROR=0
+
+    expect_contains "baz" "${FOO_BAR[@]}" && bad_bashtest "Element is not present, yet test passed."
+    _BASHTEST_HAS_ERROR=0
+
+    expect_contains "" "${FOO_BAR[@]}" && bad_bashtest "Element is not present, yet test passed."
+    _BASHTEST_HAS_ERROR=0
+
+    FOO_BAR+=("")
+
+    expect_contains "" "${FOO_BAR[@]}" || bad_bashtest "Element is present, yet test failed."
+    _BASHTEST_HAS_ERROR=0
+
+    [[ "${_BASHTEST_NUM_PASS}" == "${NUM_PASS}" ]] || bad_bashtest "Test modified _BASHTEST_NUM_PASS."
+    [[ "${_BASHTEST_NUM_FAIL}" == "${NUM_FAIL}" ]] || bad_bashtest "Test modified _BASHTEST_NUM_FAIL."
+    [[ "${_BASHTEST_NUM_SKIP}" == "${NUM_SKIP}" ]] || bad_bashtest "Test modified _BASHTEST_NUM_SKIP."
+    _BASHTEST_NUM_PASS="${NUM_PASS}"
+    _BASHTEST_NUM_FAIL="${NUM_FAIL}"
+    _BASHTEST_NUM_SKIP="${NUM_SKIP}"
+}
+
+test_runner || bad_bashtest "Test was meant to pass but did not."
+
+[[ "${_INIT_CALLED}" == "1" ]] || bad_bashtest "Test init (test::test_init) was not called."
+[[ "${_DONE_CALLED}" == "1" ]] || bad_bashtest "Test done (test::test_done) was not called."


### PR DESCRIPTION
* status helper `test_has_erro`: Returns whether a test function has had an error.
* status helper `test_has_failed_tests`: Returns whether a test program had previous failing test functions.
* expectation `expect_eq` "\${LHS}" "\${RHS}": Asserts that two strings are the same.
* expectation`expect_ne` "\${LHS}" "\${RHS}": Asserts that two strings are different.
* expectation`expect_files_eq` "\${LHS}" "\${RHS}": Asserts that two file are the same (supports golden updates).
* expectation`expect_contains` "\${EXPECTED}" "\${ARRAY[@]}": Assert that one string is present in an array.
* special test function `test::test_init`: If present, then this function runs first! Tests will only be executed if it succeeds.
* special test function `test::test_done`: If present, then this function runs last!