### PR TITLE
Fix copyright lines

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/.pre-commit/check_version.sh
+++ b/.pre-commit/check_version.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -30,7 +30,6 @@ include("//bazelmod:llvm.MODULE.bazel")
 
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "rules_cc", version = "0.1.1")
-bazel_dep(name = "rules_shell", version = "0.4.0")
 bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "abseil-cpp", version = "20250127.0", repo_name = "com_google_absl")
 bazel_dep(name = "re2", version = "2024-07-02.bcr.1", repo_name = "com_googlesource_code_re2")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -30,6 +30,7 @@ include("//bazelmod:llvm.MODULE.bazel")
 
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "rules_shell", version = "0.4.0")
 bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "abseil-cpp", version = "20250127.0", repo_name = "com_google_absl")
 bazel_dep(name = "re2", version = "2024-07-02.bcr.1", repo_name = "com_googlesource_code_re2")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/REPO.bazel
+++ b/REPO.bazel
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bazelmod/BUILD.bazel
+++ b/bazelmod/BUILD.bazel
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bazelmod/MODULE.0.6.0.bazel
+++ b/bazelmod/MODULE.0.6.0.bazel
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bazelmod/dev.MODULE.bazel
+++ b/bazelmod/dev.MODULE.bazel
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bazelmod/llvm.20.1.0.MODULE.bazel
+++ b/bazelmod/llvm.20.1.0.MODULE.bazel
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bazelmod/llvm.MODULE.bazel
+++ b/bazelmod/llvm.MODULE.bazel
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bzl/BUILD.bazel
+++ b/bzl/BUILD.bazel
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bzl/archive.bzl
+++ b/bzl/archive.bzl
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bzl/workspace/BUILD.bazel
+++ b/bzl/workspace/BUILD.bazel
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bzl/workspace/init_extras.bzl
+++ b/bzl/workspace/init_extras.bzl
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bzl/workspace/init_extras_llvm.bzl
+++ b/bzl/workspace/init_extras_llvm.bzl
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bzl/workspace/init_modules.bzl
+++ b/bzl/workspace/init_modules.bzl
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bzl/workspace/load_extras.bzl
+++ b/bzl/workspace/load_extras.bzl
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bzl/workspace/load_modules.bzl
+++ b/bzl/workspace/load_modules.bzl
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compile_commands-update.sh
+++ b/compile_commands-update.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/BUILD.bazel
+++ b/mbo/BUILD.bazel
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/config/BUILD.bazel
+++ b/mbo/config/BUILD.bazel
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/config/config.h
+++ b/mbo/config/config.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/config/internal/config.bzl
+++ b/mbo/config/internal/config.bzl
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/config/internal/config.h.in
+++ b/mbo/config/internal/config.h.in
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/config/require.h
+++ b/mbo/config/require.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/container/BUILD.bazel
+++ b/mbo/container/BUILD.bazel
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/container/any_scan.h
+++ b/mbo/container/any_scan.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/container/any_scan_test.cc
+++ b/mbo/container/any_scan_test.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/container/convert_container.h
+++ b/mbo/container/convert_container.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/container/convert_container_test.cc
+++ b/mbo/container/convert_container_test.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/container/internal/limited_ordered.h
+++ b/mbo/container/internal/limited_ordered.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/container/limited_map.h
+++ b/mbo/container/limited_map.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/container/limited_map_test.cc
+++ b/mbo/container/limited_map_test.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/container/limited_options.h
+++ b/mbo/container/limited_options.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/container/limited_ordered_test.cc
+++ b/mbo/container/limited_ordered_test.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/container/limited_set.h
+++ b/mbo/container/limited_set.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/container/limited_set_benchmark.h
+++ b/mbo/container/limited_set_benchmark.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/container/limited_set_benchmark_main.cc
+++ b/mbo/container/limited_set_benchmark_main.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/container/limited_set_test.cc
+++ b/mbo/container/limited_set_test.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/container/limited_vector.h
+++ b/mbo/container/limited_vector.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/container/limited_vector_test.cc
+++ b/mbo/container/limited_vector_test.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/diff/BUILD.bazel
+++ b/mbo/diff/BUILD.bazel
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/diff/diff.bzl
+++ b/mbo/diff/diff.bzl
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/diff/tests/BUILD.bazel
+++ b/mbo/diff/tests/BUILD.bazel
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/diff/tests/diff_test_test.bzl
+++ b/mbo/diff/tests/diff_test_test.bzl
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/diff/unified_diff.cc
+++ b/mbo/diff/unified_diff.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/diff/unified_diff.h
+++ b/mbo/diff/unified_diff.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/diff/unified_diff_main.cc
+++ b/mbo/diff/unified_diff_main.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/diff/unified_diff_test.cc
+++ b/mbo/diff/unified_diff_test.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/diff/update_absl_log_flags.cc
+++ b/mbo/diff/update_absl_log_flags.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/diff/update_absl_log_flags.h
+++ b/mbo/diff/update_absl_log_flags.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/file/BUILD.bazel
+++ b/mbo/file/BUILD.bazel
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/file/artefact.cc
+++ b/mbo/file/artefact.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/file/artefact.h
+++ b/mbo/file/artefact.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/file/file.cc
+++ b/mbo/file/file.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/file/file.h
+++ b/mbo/file/file.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/file/file_test.cc
+++ b/mbo/file/file_test.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/file/glob.cc
+++ b/mbo/file/glob.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/file/glob.h
+++ b/mbo/file/glob.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/file/glob_main.cc
+++ b/mbo/file/glob_main.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/file/glob_sh_test.sh
+++ b/mbo/file/glob_sh_test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/file/glob_test.cc
+++ b/mbo/file/glob_test.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/file/ini/BUILD.bazel
+++ b/mbo/file/ini/BUILD.bazel
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/file/ini/ini_file.cc
+++ b/mbo/file/ini/ini_file.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/file/ini/ini_file.h
+++ b/mbo/file/ini/ini_file.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/file/ini/ini_file_test.cc
+++ b/mbo/file/ini/ini_file_test.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/hash/BUILD.bazel
+++ b/mbo/hash/BUILD.bazel
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/hash/hash.h
+++ b/mbo/hash/hash.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/hash/hash_simple.h
+++ b/mbo/hash/hash_simple.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/hash/hash_test.cc
+++ b/mbo/hash/hash_test.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/log/BUILD.bazel
+++ b/mbo/log/BUILD.bazel
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/log/log_timing.cc
+++ b/mbo/log/log_timing.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/log/log_timing.h
+++ b/mbo/log/log_timing.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/log/log_timing_test.cc
+++ b/mbo/log/log_timing_test.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/mope/BUILD.bazel
+++ b/mbo/mope/BUILD.bazel
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/mope/ini.cc
+++ b/mbo/mope/ini.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/mope/ini.h
+++ b/mbo/mope/ini.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/mope/mope.bzl
+++ b/mbo/mope/mope.bzl
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/mope/mope.cc
+++ b/mbo/mope/mope.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/mope/mope.h
+++ b/mbo/mope/mope.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/mope/mope_main.cc
+++ b/mbo/mope/mope_main.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/mope/tests/args/BUILD.bazel
+++ b/mbo/mope/tests/args/BUILD.bazel
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/status/BUILD.bazel
+++ b/mbo/status/BUILD.bazel
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/status/status.h
+++ b/mbo/status/status.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/status/status_builder.cc
+++ b/mbo/status/status_builder.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/status/status_builder.h
+++ b/mbo/status/status_builder.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/status/status_builder_test.cc
+++ b/mbo/status/status_builder_test.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/status/status_macros.h
+++ b/mbo/status/status_macros.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/status/status_macros_test.cc
+++ b/mbo/status/status_macros_test.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/status/status_test.cc
+++ b/mbo/status/status_test.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/strings/BUILD.bazel
+++ b/mbo/strings/BUILD.bazel
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/strings/indent.cc
+++ b/mbo/strings/indent.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/strings/indent.h
+++ b/mbo/strings/indent.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/strings/indent_test.cc
+++ b/mbo/strings/indent_test.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/strings/numbers.h
+++ b/mbo/strings/numbers.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/strings/numbers_test.cc
+++ b/mbo/strings/numbers_test.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/strings/parse.cc
+++ b/mbo/strings/parse.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/strings/parse.h
+++ b/mbo/strings/parse.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/strings/parse_test.cc
+++ b/mbo/strings/parse_test.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/strings/split.h
+++ b/mbo/strings/split.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/strings/split_test.cc
+++ b/mbo/strings/split_test.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/strings/strip.cc
+++ b/mbo/strings/strip.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/strings/strip.h
+++ b/mbo/strings/strip.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/strings/strip_test.cc
+++ b/mbo/strings/strip_test.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/testing/BUILD.bazel
+++ b/mbo/testing/BUILD.bazel
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/testing/matchers.h
+++ b/mbo/testing/matchers.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/testing/matchers_test.cc
+++ b/mbo/testing/matchers_test.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/testing/runfiles_dir.cc
+++ b/mbo/testing/runfiles_dir.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/testing/runfiles_dir.h
+++ b/mbo/testing/runfiles_dir.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/testing/status.h
+++ b/mbo/testing/status.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/testing/status_test.cc
+++ b/mbo/testing/status_test.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/BUILD.bazel
+++ b/mbo/types/BUILD.bazel
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/cases.h
+++ b/mbo/types/cases.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/cases_test.cc
+++ b/mbo/types/cases_test.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/compare.h
+++ b/mbo/types/compare.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/container_proxy.h
+++ b/mbo/types/container_proxy.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/extend.h
+++ b/mbo/types/extend.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/extend_stringify_test.cc
+++ b/mbo/types/extend_stringify_test.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/extend_test.cc
+++ b/mbo/types/extend_test.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/extender.h
+++ b/mbo/types/extender.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/internal/BUILD.bazel
+++ b/mbo/types/internal/BUILD.bazel
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/internal/cases.h
+++ b/mbo/types/internal/cases.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/internal/decompose_count.h
+++ b/mbo/types/internal/decompose_count.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/internal/decompose_count.h.mope
+++ b/mbo/types/internal/decompose_count.h.mope
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/internal/extend.h
+++ b/mbo/types/internal/extend.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/internal/extender.h
+++ b/mbo/types/internal/extender.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/internal/is_braces_constructible.h
+++ b/mbo/types/internal/is_braces_constructible.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/internal/struct_names.h
+++ b/mbo/types/internal/struct_names.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/internal/struct_names_clang.h
+++ b/mbo/types/internal/struct_names_clang.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/internal/struct_names_test.cc
+++ b/mbo/types/internal/struct_names_test.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/internal/test_types.h
+++ b/mbo/types/internal/test_types.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/no_destruct.h
+++ b/mbo/types/no_destruct.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/no_destruct_test.cc
+++ b/mbo/types/no_destruct_test.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/opaque.h
+++ b/mbo/types/opaque.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/opaque_test.cc
+++ b/mbo/types/opaque_test.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/ref_wrap.h
+++ b/mbo/types/ref_wrap.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/ref_wrap_test.cc
+++ b/mbo/types/ref_wrap_test.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/required.h
+++ b/mbo/types/required.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/required_test.cc
+++ b/mbo/types/required_test.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/stringify.cc
+++ b/mbo/types/stringify.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/stringify.h
+++ b/mbo/types/stringify.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/stringify_ostream.h
+++ b/mbo/types/stringify_ostream.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/stringify_ostream_test.cc
+++ b/mbo/types/stringify_ostream_test.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/stringify_test.cc
+++ b/mbo/types/stringify_test.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/template_search.h
+++ b/mbo/types/template_search.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/template_search_test.cc
+++ b/mbo/types/template_search_test.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/traits.h
+++ b/mbo/types/traits.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/traits_test.cc
+++ b/mbo/types/traits_test.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/tstring.h
+++ b/mbo/types/tstring.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/tstring_test.cc
+++ b/mbo/types/tstring_test.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/tuple.h
+++ b/mbo/types/tuple.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/tuple_extras.h
+++ b/mbo/types/tuple_extras.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/mbo/types/tuple_extras_test.cc
+++ b/mbo/types/tuple_extras_test.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/check_headers.sh
+++ b/tools/check_headers.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/clang_format.sh
+++ b/tools/clang_format.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/clangd.sh
+++ b/tools/clangd.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/dwyu.bzl
+++ b/tools/dwyu.bzl
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/dwyu.sh
+++ b/tools/dwyu.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/header.txt
+++ b/tools/header.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/header_cpp.txt
+++ b/tools/header_cpp.txt
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/header_sh.txt
+++ b/tools/header_sh.txt
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Fix copyright lines: No reason to have `/mbo` in there.