### PR TITLE
Add concept ConstructibleInto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 * Moved bashtest out into `@com_helly25_bashtest` and used it from there.
 * Added dependency on `@com_helly25_bashtest`.
-* Dropped all remaining bashtest component.
+* Dropped all remaining bashtest components.
+* Added concept `ConstructibleInto` determined whether one type can be constructed from another. Similar to `std::convertible_to` but with the argument order of `std::constructible_from`.
 
 # 0.5.0
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ The library is tested with Clang and GCC on Ubuntu and MacOS (arm) using continu
     * mbo/types:stringify_ostream_cc, mbo/types/stringify_ostream.h
         * operator `std::ostream& operator<<(std::ostream&, const MboTypesStringifySupport auto& v)` - conditioanl automatic ostream support for structs using `Stringify`.
     * mbo/types:traits_cc, mbo/types/traits.h
+        * concept `ConstructibleInto` determined whether one type can be constructed from another. Similar to `std::convertible_to` but with the argument order of `std::constructible_from`.
         * type alias `ContainerConstIteratorValueType` returned the value-type of the const_iterator of a container.
         * concept `ContainerIsForwardIteratable` determines whether a types can be used in forward iteration.
         * concept `ContainerHasEmplace` determines whether a container has `emplace`.

--- a/mbo/types/traits.h
+++ b/mbo/types/traits.h
@@ -397,8 +397,9 @@ concept IsOptional = requires {
 
 // Verify whether `From` can used used to construct a `Into`.
 // That allows the concept to be used for in-place/auto template parameters.
+// See Compiler Explorer debug: https://godbolt.org/z/5vMEeGMMP
 //
-// Motivating example (https://godbolt.org/z/zhzcqqnWv):
+// Motivating example:
 //
 // A function that is meant to handle any string-like type (std::string/_view,
 // char*, ...). That still supports perfect forwarding (or move). In order to

--- a/mbo/types/traits.h
+++ b/mbo/types/traits.h
@@ -16,8 +16,8 @@
 #ifndef MBO_TYPES_TRAITS_H_
 #define MBO_TYPES_TRAITS_H_
 
-#include <concepts>  // IWYU pragma: keep
-#include <cstddef>   // IWYU pragma: keep
+#include <concepts>
+#include <cstddef>  // IWYU pragma: keep
 #include <initializer_list>
 #include <iterator>
 #include <memory>
@@ -394,6 +394,37 @@ concept IsOptional = requires {
   typename T::value_type;
   requires std::same_as<std::optional<typename T::value_type>, T>;
 };
+
+// Verify whether `From` can used used to construct a `Into`.
+// That allows the concept to be used for in-place/auto template parameters.
+//
+// Motivating example (https://godbolt.org/z/zhzcqqnWv):
+//
+// A function that is meant to handle any string-like type (std::string/_view,
+// char*, ...). That still supports perfect forwarding (or move). In order to
+// have a short notation we need the `std::constructible_from` parameter order
+// switched. That is what this concept does.
+//
+// ```
+// struct Type {
+//   Type(ConstructibleInto<std::string> auto&& v) : name_(std::forward<decltype(v)>(v)) {}
+//
+//   const std::string name;
+// };
+// ```
+//
+// Second variant, doing the same:
+//
+// ```
+// struct Type {
+//   template<ConstructibleInto<std::string> Str>
+//   Type(Str&& v) : name_(int, std::forward<decltype(v)>(v)) {}
+//
+//   const std::string name;
+// };
+// ```
+template<typename From, typename Into>
+concept ConstructibleInto = std::constructible_from<Into, From>;
 
 }  // namespace mbo::types
 

--- a/mbo/types/traits_test.cc
+++ b/mbo/types/traits_test.cc
@@ -265,6 +265,17 @@ TYPED_TEST(GenTraitsTest, IsBracesContructibleGenerateDerived) {
   EXPECT_THAT((IsBracesConstructibleV<Type, AnyBaseType<Type>, AnyType, AnyType, AnyType>), kDerived >= 3);
 }
 
+TEST_F(TraitsTest, ConstructInto) {
+  EXPECT_TRUE((ConstructibleInto<std::string, std::string>));
+  EXPECT_TRUE((ConstructibleInto<std::string, std::string_view>));
+  EXPECT_TRUE((ConstructibleInto<std::string_view, std::string>));
+  EXPECT_TRUE((ConstructibleInto<std::string_view, std::string_view>));
+  EXPECT_FALSE((ConstructibleInto<std::string, int>));
+  EXPECT_FALSE((ConstructibleInto<std::string_view, int>));
+  EXPECT_FALSE((ConstructibleInto<int, std::string>));
+  EXPECT_FALSE((ConstructibleInto<int, std::string_view>));
+}
+
 // NOLINTEND(*-runtime-int)
 
 }  // namespace


### PR DESCRIPTION
* Added concept `ConstructibleInto` determined whether one type can be constructed from another. Similar to `std::convertible_to` but with the argument order of `std::constructible_from`.