### PR TITLE
Improve UnifiedDiff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # 0.6.1
 
+* Added caching for unified `mbo::diff::UnifiedDiff` algorithm.
+* Added `--lhs_regex_replace` and `--rhs_regex_replace` flags to `//mbo/diff:unified_diff`.
+
 # 0.6.0
 
 * Moved bashtest out into `@com_helly25_bashtest` and used it from there.

--- a/mbo/diff/BUILD.bazel
+++ b/mbo/diff/BUILD.bazel
@@ -42,6 +42,7 @@ cc_library(
         "//mbo/strings:strip_cc",
         "//mbo/types:no_destruct_cc",
         "@com_google_absl//absl/cleanup",
+        "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/log:absl_log",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",

--- a/mbo/diff/BUILD.bazel
+++ b/mbo/diff/BUILD.bazel
@@ -67,6 +67,7 @@ cc_binary(
         "@com_google_absl//absl/log:absl_log",
         "@com_google_absl//absl/log:initialize",
         "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
         "@com_googlesource_code_re2//:re2",
     ],
 )

--- a/mbo/diff/diff.bzl
+++ b/mbo/diff/diff.bzl
@@ -48,7 +48,7 @@ def diff_test(
         ignore_consecutive_space: Ignore all whitespace changes, even if one line has whitespace where the other line has none.
         ignore_blank_lines:       Ignore chunks which include only blank lines.
         ignore_case:              Whether to ignore letter case.
-        ignore_matching_chunks:   Whether `ignore_matching_lines` applies to chanks or single lines.
+        ignore_matching_chunks:   Whether `ignore_matching_lines` applies to chunks or single lines.
         ignore_matching_lines:    Ignore lines that match this regexp (https://github.com/google/re2/wiki/Syntax).
         ignore_space_change:      Ignore traling whitespace changes.
         strip_comments:           Strip out anything starting from `strip_comments`.

--- a/mbo/diff/unified_diff.cc
+++ b/mbo/diff/unified_diff.cc
@@ -17,6 +17,7 @@
 
 #include <cstddef>
 #include <list>
+#include <memory>
 #include <string>
 #include <string_view>
 #include <tuple>

--- a/mbo/diff/unified_diff.h
+++ b/mbo/diff/unified_diff.h
@@ -17,6 +17,7 @@
 #define MBO_DIFF_UNIFIED_DIFF_H_
 
 #include <cstddef>
+#include <memory>
 #include <optional>
 #include <string>
 #include <variant>

--- a/mbo/diff/unified_diff.h
+++ b/mbo/diff/unified_diff.h
@@ -19,6 +19,7 @@
 #include <cstddef>
 #include <optional>
 #include <string>
+#include <variant>
 
 #include "absl/status/statusor.h"
 #include "mbo/file/artefact.h"
@@ -55,6 +56,13 @@ class UnifiedDiff final {
   using StripCommentOptions =
       std::variant<NoCommentStripping, mbo::strings::StripCommentArgs, mbo::strings::StripParsedCommentArgs>;
 
+  struct RegexReplace {
+    std::unique_ptr<RE2> regex;
+    std::string replace;
+  };
+
+  static std::optional<RegexReplace> ParseRegexReplaceFlag(std::string_view flag);
+
   struct Options final {
     enum class FileHeaderUse {
       kBoth = 0,   // In header both file names are used (left uses left file name and right uses right file name).
@@ -76,6 +84,8 @@ class UnifiedDiff final {
     bool ignore_space_change = false;
     bool skip_left_deletions = false;
     StripCommentOptions strip_comments = NoCommentStripping{};
+    std::optional<RegexReplace> lhs_regex_replace;
+    std::optional<RegexReplace> rhs_regex_replace;
     std::string strip_file_header_prefix;
 
     std::size_t max_diff_chunk_length = 1'337'000;  // NOLINT(*-magic-numbers)

--- a/mbo/diff/unified_diff_main.cc
+++ b/mbo/diff/unified_diff_main.cc
@@ -16,7 +16,6 @@
 #include <cstddef>
 #include <filesystem>
 #include <iostream>
-#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -25,11 +24,9 @@
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
 #include "absl/flags/usage.h"
-#include "absl/log/absl_check.h"
 #include "absl/log/absl_log.h"
 #include "absl/log/initialize.h"
 #include "absl/status/statusor.h"
-#include "absl/strings/str_split.h"
 #include "mbo/diff/unified_diff.h"
 #include "mbo/diff/update_absl_log_flags.h"
 #include "mbo/file/artefact.h"

--- a/mbo/diff/unified_diff_main.cc
+++ b/mbo/diff/unified_diff_main.cc
@@ -16,6 +16,7 @@
 #include <cstddef>
 #include <filesystem>
 #include <iostream>
+#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -24,9 +25,11 @@
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
 #include "absl/flags/usage.h"
+#include "absl/log/absl_check.h"
 #include "absl/log/absl_log.h"
 #include "absl/log/initialize.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/str_split.h"
 #include "mbo/diff/unified_diff.h"
 #include "mbo/diff/update_absl_log_flags.h"
 #include "mbo/file/artefact.h"
@@ -91,11 +94,28 @@ and custom escapes for any of '(){}[]<>,;&'). If the substring is found, then al
 its right will be removed and any remaining trailing line whitespace will be stripped. In the \
 latter form of simple substring finding, the substring will be searched for as is.");
 ABSL_FLAG(std::size_t, unified, 3, "Produces a diff with number lines of context");
+ABSL_FLAG(
+    std::string,
+    lhs_regex_replace,
+    "",
+    "\
+Regular expression and replace value. The format consisted of a separator character (e.g. '/') \
+followed by the regular expression, followed by the separator, followed by the replacement string, \
+followed by the separator. Example: /foo/bar/.");
+ABSL_FLAG(
+    std::string,
+    rhs_regex_replace,
+    "",
+    "\
+Regular expression and replace value. The format consisted of a separator character (e.g. '/') \
+followed by the regular expression, followed by the separator, followed by the replacement string, \
+followed by the separator. Example: /foo/bar/.");
 
 // NOLINTEND(*avoid-non-const-global-variables,*abseil-no-namespace)
 
 namespace {
 
+using mbo::diff::UnifiedDiff;
 using mbo::file::Artefact;
 
 absl::StatusOr<Artefact> Read(std::string_view file_name) {
@@ -109,15 +129,15 @@ absl::StatusOr<Artefact> Read(std::string_view file_name) {
   return result;
 }
 
-mbo::diff::UnifiedDiff::Options::FileHeaderUse GetFileHeaderUse() {
+UnifiedDiff::Options::FileHeaderUse GetFileHeaderUse() {
   const std::string mode = absl::GetFlag(FLAGS_file_header_use);
   if (mode == "left") {
-    return mbo::diff::UnifiedDiff::Options::FileHeaderUse::kLeft;
+    return UnifiedDiff::Options::FileHeaderUse::kLeft;
   }
   if (mode == "right") {
-    return mbo::diff::UnifiedDiff::Options::FileHeaderUse::kRight;
+    return UnifiedDiff::Options::FileHeaderUse::kRight;
   }
-  return mbo::diff::UnifiedDiff::Options::FileHeaderUse::kBoth;
+  return UnifiedDiff::Options::FileHeaderUse::kBoth;
 }
 
 int Diff(std::string_view lhs_name, std::string_view rhs_name) {
@@ -130,7 +150,7 @@ int Diff(std::string_view lhs_name, std::string_view rhs_name) {
     return 1;
   }
   const std::string strip_comments = absl::GetFlag(FLAGS_strip_comments);
-  const mbo::diff::UnifiedDiff::Options diff_options{
+  const UnifiedDiff::Options diff_options{
       .context_size = absl::GetFlag(FLAGS_unified),
       .file_header_use = GetFileHeaderUse(),
       .ignore_blank_lines = absl::GetFlag(FLAGS_ignore_blank_lines),
@@ -146,7 +166,7 @@ int Diff(std::string_view lhs_name, std::string_view rhs_name) {
       .ignore_consecutive_space = absl::GetFlag(FLAGS_ignore_consecutive_space),
       .ignore_space_change = absl::GetFlag(FLAGS_ignore_space_change),
       .skip_left_deletions = absl::GetFlag(FLAGS_skip_left_deletions),
-      .strip_comments = [&]() -> mbo::diff::UnifiedDiff::StripCommentOptions {
+      .strip_comments = [&]() -> UnifiedDiff::StripCommentOptions {
         if (strip_comments.empty()) {
           return {};
         } else if (absl::GetFlag(FLAGS_strip_parsed_comments)) {
@@ -161,9 +181,11 @@ int Diff(std::string_view lhs_name, std::string_view rhs_name) {
           };
         }
       }(),
+      .lhs_regex_replace{UnifiedDiff::ParseRegexReplaceFlag(absl::GetFlag(FLAGS_lhs_regex_replace))},
+      .rhs_regex_replace{UnifiedDiff::ParseRegexReplaceFlag(absl::GetFlag(FLAGS_rhs_regex_replace))},
       .strip_file_header_prefix = absl::GetFlag(FLAGS_strip_file_header_prefix),
   };
-  const auto result = mbo::diff::UnifiedDiff::Diff(*lhs, *rhs, diff_options);
+  const auto result = UnifiedDiff::Diff(*lhs, *rhs, diff_options);
   if (!result.ok()) {
     ABSL_LOG(ERROR) << "ERROR: " << result.status();
     return 1;


### PR DESCRIPTION
Improve UnifiedDiff:
* Added caching for unified `mbo::diff::UnifiedDiff` algorithm.
* Added `--lhs_regex_replace` and `--rhs_regex_replace` flags to `//mbo/diff:unified_diff`.