### PR TITLE
Implement direct diff algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * Renamed diff tooling options `ignore_space_change` to `ignore_trailing_space.
 * Renamed `lhs_regex_replace` and `rhs_regex_replace` to `regex_replace_lhs` and `regex_replace_rhs` respectively.
 * Added `regex_replace_lhs` and `regex_replace_rhs` to bzl rules `//mbo/diff:diff_test` and `//mbo/diff/tests:diff_test_test`.
+* Renamed `mbo::diff::UnifiedDiff` to `mbo::diff::Diff`.
+* Implemented diff algorithm `kDirect` which performs a direct side by side comparison.
+* Renamed //mbo/diff/unified_diff.cc/h to diff.cc/h.
 
 # 0.7.0
 

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ The library is tested with Clang and GCC on Ubuntu and MacOS (arm) using continu
         * class `LimitedVector`: A space limited, constexpr compliant `vector`.
 * Diff
     * `namespace mbo::diff`
-    * mbo/diff:unified_dff_cc, mbo/diff/unified_diff.h
-        * class `UnifiedDiff`: A class that implements unified-diffing.
-    * mbo/diff:unified_diff
+    * mbo/diff:dff_cc, mbo/diff/diff.h
+        * class `Diff`: A class that implements unified-diffing.
+    * mbo/diff:diff
         * binary `unfied_diff`: A binary that performs a unified-diff on two files.
     * mbo/diff:diff_bzl, mbo/diff/diff.bzl
         * bzl-macro `difftest`: A test rule that compares an output versus a golden file.

--- a/mbo/diff/BUILD.bazel
+++ b/mbo/diff/BUILD.bazel
@@ -33,9 +33,9 @@ cc_library(
 )
 
 cc_library(
-    name = "unified_diff_cc",
-    srcs = ["unified_diff.cc"],
-    hdrs = ["unified_diff.h"],
+    name = "diff_cc",
+    srcs = ["diff.cc"],
+    hdrs = ["diff.h"],
     visibility = ["//visibility:public"],
     deps = [
         "//mbo/file:artefact_cc",
@@ -57,7 +57,7 @@ cc_binary(
     srcs = ["unified_diff_main.cc"],
     visibility = ["//visibility:public"],
     deps = [
-        ":unified_diff_cc",
+        ":diff_cc",
         ":update_absl_log_flags_cc",
         "//mbo/file:artefact_cc",
         "//mbo/strings:indent_cc",
@@ -74,11 +74,11 @@ cc_binary(
 )
 
 cc_test(
-    name = "unified_diff_test",
+    name = "diff_test",
     size = "small",
-    srcs = ["unified_diff_test.cc"],
+    srcs = ["diff_test.cc"],
     deps = [
-        ":unified_diff_cc",
+        ":diff_cc",
         "//mbo/container:convert_container_cc",
         "//mbo/file:artefact_cc",
         "//mbo/strings:indent_cc",

--- a/mbo/diff/diff.bzl
+++ b/mbo/diff/diff.bzl
@@ -134,7 +134,7 @@ if ! {diff_tool} "${{OLD}}" "${{NEW}}" \
     --strip_file_header_prefix="external/com_helly25_mbo/" \
     --strip_parsed_comments={strip_parsed_comments} \
 ; then
-  echo >&2 "FAIL: files \"{file_old}\" and \"{file_new}\" differ. "{failure_message}
+  echo >&2 "FAIL: files \"{file_old}\" and \"{file_new}\" differ. " {failure_message}
   exit 1
 fi
 """.format(
@@ -175,7 +175,9 @@ _diff_test = rule(
             doc = "The diff algorithm to use.",
             values = ["", "direct", "unified"],
         ),
-        "failure_message": attr.string(),
+        "failure_message": attr.string(
+            doc = "An extra failure message to append to diff failure lines.",
+        ),
         "file_new": attr.label(
             allow_single_file = True,
             doc = "The new (right) file of the comparison.",

--- a/mbo/diff/diff.h
+++ b/mbo/diff/diff.h
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef MBO_DIFF_UNIFIED_DIFF_H_
-#define MBO_DIFF_UNIFIED_DIFF_H_
+#ifndef MBO_DIFF_DIFF_H_
+#define MBO_DIFF_DIFF_H_
 
 #include <cstddef>
 #include <memory>
@@ -47,7 +47,7 @@ namespace mbo::diff {
 // The complexity of the algorithm used is O(L*R) in the worst case. In practise
 // the algorithm is closer to O(max(L,R)) for small differences. In detail the
 // algorithm has a complexity of O(max(L,R)+dL*R+L*dR).
-class UnifiedDiff final {
+class Diff final {
  public:
   struct NoCommentStripping final {};
 
@@ -66,6 +66,18 @@ class UnifiedDiff final {
       kBoth = 0,   // In header both file names are used (left uses left file name and right uses right file name).
       kLeft = 1,   // In header left and right file both use left file name.
       kRight = 2,  // In header left and right file both use right file name.
+    };
+
+    enum class Algorithm {
+      // Unified diff like `diff -u` or `git diff`.
+      kUnified = 0,
+
+      // Compare two inputs and output in direct side by side format.
+      // That is similar to unified format, but it is assumed that the left and
+      // right content are meant to line up with only changed lines and no added
+      // or removed lines. The changes are then presented next to each other.
+      // This mode does not allow for context.
+      kDirect = 1,
     };
 
     static const Options& Default() noexcept;
@@ -89,16 +101,32 @@ class UnifiedDiff final {
     std::size_t max_diff_chunk_length = 1'337'000;  // NOLINT(*-magic-numbers)
 
     std::string time_format = "%F %H:%M:%E3S %z";
+
+    Algorithm algorithm = Algorithm::kUnified;
   };
 
-  static absl::StatusOr<std::string> Diff(
+  // Compare two inputs and output differences in unified format.
+  static absl::StatusOr<std::string> DiffUnified(
       const file::Artefact& lhs,
       const file::Artefact& rhs,
       const Options& options = Options::Default());
 
-  UnifiedDiff() = delete;
+  // Compare two inputs and output in direct side by side format.
+  // See `Algorithm::kDirect`.
+  static absl::StatusOr<std::string> DiffDirect(
+      const file::Artefact& lhs,
+      const file::Artefact& rhs,
+      const Options& options = Options::Default());
+
+  // Algorithm selected by `options.algorithm`.
+  static absl::StatusOr<std::string> DiffSelect(
+      const file::Artefact& lhs,
+      const file::Artefact& rhs,
+      const Options& options = Options::Default());
+
+  Diff() = delete;
 };
 
 }  // namespace mbo::diff
 
-#endif  // MBO_DIFF_UNIFIED_DIFF_H_
+#endif  // MBO_DIFF_DIFF_H_

--- a/mbo/diff/tests/diff_test_test.bzl
+++ b/mbo/diff/tests/diff_test_test.bzl
@@ -23,6 +23,7 @@ def diff_test_test(
         file_old,
         file_new,
         expected_diff,
+        algorithm = "",
         ignore_all_space = False,
         ignore_consecutive_space = False,
         ignore_blank_lines = False,
@@ -44,6 +45,7 @@ def diff_test_test(
         file_old:                 The old file.
         file_new:                 The new file.
         expected_diff:            The expected diff result.
+        algorithm:                Algorithm to use ('unified', 'direct', etc).
         ignore_all_space:         Ignore all leading, trailing, and consecutive internal whitespace changes.
         ignore_consecutive_space: Ignore all whitespace changes, even if one line has whitespace where the other line has none.
         ignore_blank_lines:       Ignore chunks which include only blank lines.
@@ -68,6 +70,7 @@ def diff_test_test(
         cmd = """
             $(location //mbo/diff:unified_diff) --skip_time \\
                 $(location {file_old}) $(location {file_new}) > $@ \\
+                --algorithm={algorithm} \\
                 --ignore_all_space={ignore_all_space} \\
                 --ignore_consecutive_space={ignore_consecutive_space} \\
                 --ignore_blank_lines={ignore_blank_lines} \\
@@ -84,6 +87,7 @@ def diff_test_test(
         """.format(
             file_old = file_old,
             file_new = file_new,
+            algorithm = shell.quote(algorithm),
             ignore_all_space = bool_arg(ignore_all_space),
             ignore_consecutive_space = bool_arg(ignore_consecutive_space),
             ignore_blank_lines = bool_arg(ignore_blank_lines),

--- a/mbo/file/ini/BUILD.bazel
+++ b/mbo/file/ini/BUILD.bazel
@@ -42,7 +42,7 @@ cc_test(
     ]),
     deps = [
         "ini_file_cc",
-        "//mbo/diff:unified_diff_cc",
+        "//mbo/diff:diff_cc",
         "//mbo/file:artefact_cc",
         "//mbo/file:file_cc",
         "//mbo/testing:runfiles_dir_cc",

--- a/mbo/file/ini/ini_file_test.cc
+++ b/mbo/file/ini/ini_file_test.cc
@@ -28,7 +28,7 @@
 #include "absl/strings/str_cat.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "mbo/diff/unified_diff.h"
+#include "mbo/diff/diff.h"
 #include "mbo/file/artefact.h"
 #include "mbo/file/file.h"
 #include "mbo/testing/runfiles_dir.h"
@@ -91,7 +91,7 @@ TEST_F(IniFileTest, TestGolden) {
     ++file_count;
     MBO_ASSERT_OK_AND_ASSIGN(const auto dst_artefact, Artefact::Read(dst_fn));
     MBO_ASSERT_OK_AND_ASSIGN(const auto exp_artefact, Artefact::Read(exp_fn));
-    MBO_ASSERT_OK_AND_ASSIGN(const std::string diff, mbo::diff::UnifiedDiff::Diff(exp_artefact, dst_artefact));
+    MBO_ASSERT_OK_AND_ASSIGN(const std::string diff, mbo::diff::Diff::DiffSelect(exp_artefact, dst_artefact));
     if (base == "empty") {
       EXPECT_THAT(ini, IsEmpty());
       EXPECT_THAT(ini, SizeIs(Eq(0)));


### PR DESCRIPTION
* Renamed `mbo::diff::UnifiedDiff` to `mbo::diff::Diff`.
* Implemented diff algorithm `kDirect` which performs a direct side by side comparison.
* Renamed //mbo/diff/unified_diff.cc/h to diff.cc/h.
