### PR TITLE
Improved Stringify control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # 0.10.0
 
 * Improved control for `Stringify` with Json output.
+* Updated `StringifyOptions` (breaking change, but no field renames).
+* Updated `StringifyWithFieldNames` (breaking change).
+* Modified `MboTypesStringifyOptions` (breaking change) to be more flexible - but users must deal with the change.
+* Added ability to detect bad `MboTypesStringifyOptions` signatures.
+* Added `StringifyFieldOptions` which holds outer and inner `StringifyOptions`.
 * Added `Stringify::AsJsonPretty()` and `StringifyOptions::AsJsonPretty()`.
 
 # 0.9.0

--- a/bazelmod/llvm.20.1.0.MODULE.bazel
+++ b/bazelmod/llvm.20.1.0.MODULE.bazel
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""LLVM"""
+
 bazel_dep(name = "toolchains_llvm", version = "1.3.0")
 git_override(
     module_name = "toolchains_llvm",

--- a/mbo/types/BUILD.bazel
+++ b/mbo/types/BUILD.bazel
@@ -230,6 +230,7 @@ cc_test(
         "//mbo/container:limited_vector_cc",
         "//mbo/testing:matchers_cc",
         "//mbo/types/internal:struct_names_cc",
+        "@com_google_absl//absl/container:btree",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/hash:hash_testing",
         "@com_google_absl//absl/log:absl_check",

--- a/mbo/types/extender.h
+++ b/mbo/types/extender.h
@@ -299,10 +299,8 @@ namespace extender {
 //   }
 //
 //   friend mbo::types::StringifyOptions MboTypesStringifyOptions(
-//       const TestType& /* unused */,
-//       std::size_t field_index,
-//       std::string_view field_name,
-//       const StringifyOptions& default_options) {
+//       const TestType& /* unused object */,
+//       const StringifyFieldInfo& /* unused field */) {
 //     return {
 //       .value_max_length = 42,
 //     };

--- a/mbo/types/internal/is_braces_constructible.h
+++ b/mbo/types/internal/is_braces_constructible.h
@@ -18,6 +18,7 @@
 
 // IWYU pragma: private, include "mbo/types/traits.h"
 
+#include <concepts>  // IWYU pragma: keep
 #include <type_traits>
 
 namespace mbo::types::types_internal {
@@ -29,7 +30,14 @@ namespace mbo::types::types_internal {
 
 struct AnyType {
   template<typename T>
-  constexpr operator T() const noexcept;  // NOLINT(*-explicit-constructor, *-explicit-conversions)
+  constexpr operator T() const noexcept;  // NOLINT(*-explicit-*)
+};
+
+template<typename T>
+struct AnyOtherType {
+  template<typename U>
+  requires(!std::same_as<std::remove_cvref_t<T>, std::remove_cvref_t<U>>)
+  constexpr operator U() const noexcept;  // NOLINT(*-explicit-*)
 };
 
 template<std::size_t kIndex>
@@ -39,14 +47,14 @@ template<typename D>
 struct AnyBaseType {
   using RawD = std::remove_cvref_t<D>;
   template<typename T, typename = std::enable_if_t<std::is_base_of_v<std::remove_cvref_t<T>, RawD>>>
-  constexpr operator T() const noexcept;  // NOLINT(*-explicit-constructor, *-explicit-conversions)
+  constexpr operator T() const noexcept;  // NOLINT(*-explicit-*)
 };
 
 template<typename D>
 struct AnyNonBaseType {
   using RawD = std::remove_cvref_t<D>;
   template<typename T, typename = std::enable_if_t<!std::is_base_of_v<std::remove_cvref_t<T>, RawD>>>
-  constexpr operator T() const noexcept;  // NOLINT(*-explicit-constructor, *-explicit-conversions)
+  constexpr operator T() const noexcept;  // NOLINT(*-explicit-*)
 };
 
 template<std::size_t kIndex, typename D>
@@ -60,7 +68,7 @@ struct AnyTypeIf {
       typename = std::enable_if_t<                                         //
           (kBaseOrNot == std::is_base_of_v<std::remove_cvref_t<T>, RawD>)  //
           &&(!kBaseOrNot || !kRequireNonEmpty || (!std::is_empty_v<std::remove_cvref_t<T>> && kAllowNonEmpty))>>
-  constexpr operator T() const noexcept;  // NOLINT(*-explicit-constructor, *-explicit-conversions)
+  constexpr operator T() const noexcept;  // NOLINT(*-explicit-*)
 };
 
 template<std::size_t kIndex, typename D, bool kBaseOrNot, bool kRequireNonEmpty, bool kAllowNonEmpty = kRequireNonEmpty>
@@ -73,7 +81,7 @@ struct AnyEmptyBase {
       typename T,
       typename =
           std::enable_if_t<std::is_base_of_v<std::remove_cvref_t<T>, RawD> && std::is_empty_v<std::remove_cvref_t<T>>>>
-  constexpr operator T() const noexcept;  // NOLINT(*-explicit-constructor, *-explicit-conversions)
+  constexpr operator T() const noexcept;  // NOLINT(*-explicit-*)
 };
 
 template<std::size_t kIndex, typename D>
@@ -86,7 +94,7 @@ struct AnyEmptyBaseOrNonBase {
       typename T,
       typename =
           std::enable_if_t<!std::is_base_of_v<std::remove_cvref_t<T>, RawD> || std::is_empty_v<std::remove_cvref_t<T>>>>
-  constexpr operator T() const noexcept;  // NOLINT(*-explicit-constructor, *-explicit-conversions)
+  constexpr operator T() const noexcept;  // NOLINT(*-explicit-*)
 };
 
 template<std::size_t kIndex, typename D>
@@ -101,7 +109,7 @@ struct AnyBaseMaybeEmpty {
           std::is_base_of_v<std::remove_cvref_t<T>, RawD>
           && (kIsEmpty == std::is_empty_v<std::remove_cvref_t<T>>
               || (kAllowNonEmpty && !std::is_empty_v<std::remove_cvref_t<T>>))>>
-  constexpr operator T() const noexcept;  // NOLINT(*-explicit-constructor, *-explicit-conversions)
+  constexpr operator T() const noexcept;  // NOLINT(*-explicit-*)
 };
 
 template<std::size_t kIndex, typename D, bool kIsEmpty, bool kAllowNonEmpty = false>

--- a/mbo/types/stringify.cc
+++ b/mbo/types/stringify.cc
@@ -24,6 +24,7 @@ const StringifyOptions& StringifyOptions::AsDefault() noexcept {
 
 const StringifyOptions& StringifyOptions::AsCpp() noexcept {
   static constexpr StringifyOptions kCpp{
+      .field_disabled = "{/*MboTypesStringifyDisable*/}",
       .key_prefix = ".",
       .key_value_separator = " = ",
       .value_pointer_prefix = "",
@@ -63,7 +64,7 @@ const StringifyOptions& StringifyOptions::AsJson() noexcept {
 const StringifyOptions& StringifyOptions::AsJsonPretty() noexcept {
   static const StringifyOptions kJson = [] {
     StringifyOptions json = AsJson();
-    json.message_end = "\n";
+    json.message_suffix = "\n";
     json.field_indent = "  ";
     json.field_separator = ",";
     return json;


### PR DESCRIPTION
Improved Stringify control:
* Ability to control inner and outer formatting indenpendently.
* Changed `MboTypesStringifyOptions` to be more flexible - but users must deal with the change.
* Added ability to detect bad `MboTypesStringifyOptions` signatures.