### PR TITLE
Improve Stringify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@
 * Added concept `IsEmptyType` determines whether a type is empty (calls `std::is_empty_v`).
 * Fixed concept `IsAggregate`.
 * Fixed some IWYU pragmas.
+* Added struct `Overloaded` which implements an Overload handler for `std::visit(std::variant<...>)` and `std::variant::visit` (technically moved).
+* Added function `CompareDouble` which can compare two `float`, `double` or `long double` values returning `std::strong_ordering`.
+* Added function `WeakToStrong` which converts a `std::weak_ordering` to a `std::strong_ordering`.
+* Added concept `IsStringKeyedContainer` which determines whether a type is a container whose elements are pairs and whose keys are convertible to a std::string_view.
+* Added API extension point functoin `MboTypesStringifyValueAccess` which allows to replace a struct with a single value in `Stringify` processing.
+* Added `Stringify` support for empty types and types that match `IsStringKeyedContainer`.
+* Fixed `Stringify` null* epresentations to stream as `null` as opposed to `0`.
 
 # 0.9.0
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,9 @@ The library is tested with Clang (16+) and GCC (12+) on Ubuntu and MacOS (arm) u
         * meta-type `IfFalseThenVoid`: Helper type that can be used to skip a case.
         * meta-type `IfTrueThenVoid`: Helper type to inject default cases and to ensure the required type expansion is always possible.
     * mbo/types:compare_cc, mbo/types/compare.h
+        * function `CompareDouble` which can compare two `float`, `double` or `long double` values returning `std::strong_ordering`.
         * comparator `CompareLess` which is compatible to std::Less but allows container optimizations.
+        * function `WeakToStrong` which converts a `std::weak_ordering` to a `std::strong_ordering`.
     * mbo/types:container_proxy_cc, mbo/types/container_proxy.h
         * struct `ContainerProxy` which allows to add container access to other types including smart pointers of containers.
     * mbo/types:extend_cc, mbo/types/extend.h
@@ -188,12 +190,13 @@ The library is tested with Clang (16+) and GCC (12+) on Ubuntu and MacOS (arm) u
         * struct `StringifyOptions` which can be used to control `Stringify` formatting.
         * struct `StringifyRootOptions` which can be used to control outer/root options for streaming/printing structs.
         * API extension point type `MboTypesStringifySupport` which enables `Stringify` support even if not otherwise enabled (disables Abseil stringify support in `Stringify`).
+        * API extension point function `MboTypesStringifyConvert(I, T, V)` allows to control conversion based on field types via a static call to the owning type, receiving the field index, the object and the field value.
         * API extension point type `MboTypesStringifyDisable` which disables `Stringify` support. This allows to prevent
         complex classes (and more importantly fields of complex types) from being printed/streamed using `Stringify`
         * API extension point type `MboTypesStringifyDoNotPrintFieldNames` which if present disables field names in `Stringify`.
         * API extension point function `MboTypesStringifyFieldNames` which adds field names to `Stringify`.
         * API extension point function `MboTypesStringifyOptions` which adds full format control to `Stringify`.
-        * API extension point function `MboTypesStringifyConvert(I, T, V)` allows to control conversion based on field types via a static call to the owning type, receiving the field index, the object and the field value.
+        * API extension point functoin `MboTypesStringifyValueAccess` which allows to replace a struct with a single value in `Stringify` processing.
     * mbo/types:stringify_ostream_cc, mbo/types/stringify_ostream.h
         * operator `std::ostream& operator<<(std::ostream&, const MboTypesStringifySupport auto& v)` - conditioanl automatic ostream support for structs using `Stringify`.
     * mbo/types:traits_cc, mbo/types/traits.h
@@ -216,13 +219,13 @@ The library is tested with Clang (16+) and GCC (12+) on Ubuntu and MacOS (arm) u
         * concept `IsBracesConstructibleV` determines whether a type can be constructe from given argument types.
         * concept `IsOptional` determines whether a type is a `std::optional` type.
         * concept `IsPair` determines whether a type is a `std::pair` type.
-        * concept `IsSet` determines whether a type is a `std::set` type.
         * concept `IsSameAsAnyOf` which determines whether a type is the same as one of a list of types. Similar to `IsSameAsAnyOfRaw` but using exact types.
         * concept `IsSameAsAnyOfRaw` / `NotSameAsAnyOfRaw` which determines whether a type is one of a list of types. Similar to `IsSameAsAnyOf` but applies `std::remove_cvref_t` on all types.
+        * concept `IsSet` determines whether a type is a `std::set` type.
         * concept `IsSmartPtr` determines whether a type is a `std::shared_ptr`, `std::unique_ptr` or `std::weak_ptr`.
           * Can be extended with other smart pointers through `IsSmartPtrImpl`.
+        * concept `IsStringKeyedContainer` which determines whether a type is a container whose elements are pairs and whose keys are convertible to a std::string_view.
         * concept `IsTuple` determines whether a type is a `std::tuple` type.
-        * concept `IsVariant` determines whether a type is a `std::variant` type.
         * concept `IsVector` determines whether a type is a `std::vector` type.
     * mbo/types:template_search_cc, mbo/types/template_search.h:
         * template struct `BinarySearch` implements templated binary search algorithm.
@@ -234,6 +237,10 @@ The library is tested with Clang (16+) and GCC (12+) on Ubuntu and MacOS (arm) u
         * operator `operator"" _ts`: String literal support for Clang, GCC and derived compilers.
     * mbo/types:tuple_cc, mbo/types/tuple.h
         * template struct `TupleCat` which concatenates tuple types.
+    * mbo/types:variant_cc, mbo/types/variant.h
+        * concept `IsVariant` determines whether a type is a `std::variant` type.
+        * concept `IsVariantMemberType` determine whether a `Type` is any of the types in a `Variant`.
+        * struct `Overloaded` which implements an Overload handler for `std::visit(std::variant<...>)` and `std::variant::visit`.
 
 ## In addition some Bazel macros are implemented that are not direct part of the library:
 

--- a/mbo/config/BUILD.bazel
+++ b/mbo/config/BUILD.bazel
@@ -58,7 +58,7 @@ cc_library(
 cc_library(
     name = "require_cc",
     hdrs = ["require.h"],
-    visibility = ["//mbo:__subpackages__"],
+    visibility = ["//:__subpackages__"],
     deps = [
         ":config_cc",
         "@com_google_absl//absl/log:absl_log",

--- a/mbo/mope/BUILD.bazel
+++ b/mbo/mope/BUILD.bazel
@@ -55,6 +55,7 @@ cc_library(
         "//mbo/status:status_macros_cc",
         "//mbo/strings:parse_cc",
         "//mbo/types:extend_cc",
+        "//mbo/types:variant_cc",
         "@com_google_absl//absl/cleanup",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:node_hash_map",

--- a/mbo/mope/mope.h
+++ b/mbo/mope/mope.h
@@ -27,15 +27,9 @@
 #include "absl/status/statusor.h"
 #include "mbo/container/any_scan.h"
 #include "mbo/types/extend.h"
+#include "mbo/types/variant.h"
 
 namespace mbo::mope {
-
-template<class... Ts>
-struct overloaded : Ts... {
-  using Ts::operator()...;
-};
-template<class... Ts>
-overloaded(Ts...) -> overloaded<Ts...>;
 
 // MOPE: Mope Over Pump Ends - Is a simple templating system.
 //
@@ -117,10 +111,11 @@ class Template {
 
   friend std::ostream& operator<<(std::ostream& os, const Data& data) {
     std::visit(
-        overloaded{
-            [&os](const TagData<Section>& arg) { os << "Section"; },
-            [&os](const TagData<Range>& arg) { os << "Range"; },
-            [&os](const TagData<std::string>& arg) { os << "String: '" << arg.data << "'"; }},
+        mbo::types::Overloaded{
+            [&os](const TagData<Section>& /*arg*/) { os << "Section"; },
+            [&os](const TagData<Range>& /*arg*/) { os << "Range"; },
+            [&os](const TagData<std::string>& arg) { os << "String: '" << arg.data << "'"; },
+        },
         data);
     return os;
   }

--- a/mbo/types/BUILD.bazel
+++ b/mbo/types/BUILD.bazel
@@ -331,6 +331,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":tuple_cc",
+        ":variant_cc",
         "//mbo/types/internal:traits_cc",
     ],
 )
@@ -398,4 +399,10 @@ cc_test(
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
+)
+
+cc_library(
+    name = "variant_cc",
+    hdrs = ["variant.h"],
+    visibility = ["//visibility:public"],
 )

--- a/mbo/types/compare.h
+++ b/mbo/types/compare.h
@@ -16,9 +16,12 @@
 #ifndef MBO_TYPES_COMPARE_H_
 #define MBO_TYPES_COMPARE_H_
 
+#include <cmath>
 #include <compare>  // IWYU pragma: keep
 #include <functional>
 #include <type_traits>
+
+#include "mbo/types/traits.h"  // IWYU pragma: keep
 
 namespace mbo::types {
 
@@ -87,6 +90,31 @@ concept IsCompareLess = types_internal::IsCompareLess<T>::value;
 
 template<typename T>
 concept IsStdLess = types_internal::IsStdLess<T>::value;
+
+template<IsSameAsAnyOf<float, double, long double> Double>
+std::strong_ordering CompareDouble(Double lhs, Double rhs) {
+  const std::partial_ordering comp = lhs <=> rhs;
+  if (comp == std::partial_ordering::less) {
+    return std::strong_ordering::less;
+  } else if (comp == std::partial_ordering::equivalent) {
+    return std::strong_ordering::equivalent;
+  } else if (comp == std::partial_ordering::greater) {
+    return std::strong_ordering::greater;
+  }
+  bool lhs_nan = std::isnan(lhs);
+  bool rhs_nan = std::isnan(rhs);
+  return lhs_nan <=> rhs_nan;
+}
+
+inline std::strong_ordering WeakToStrong(std::weak_ordering order) {
+  if (order == std::weak_ordering::less) {
+    return std::strong_ordering::less;
+  }
+  if (order == std::weak_ordering::greater) {
+    return std::strong_ordering::greater;
+  }
+  return std::strong_ordering::equivalent;
+}
 
 }  // namespace mbo::types
 

--- a/mbo/types/traits.h
+++ b/mbo/types/traits.h
@@ -26,13 +26,13 @@
 #include <string_view>
 #include <type_traits>
 #include <utility>
-#include <variant>
 #include <vector>
 
 #include "mbo/types/internal/decompose_count.h"          // IWYU pragma: export
 #include "mbo/types/internal/is_braces_constructible.h"  // IWYU pragma: export
 #include "mbo/types/internal/traits.h"                   // IWYU pragma: export
 #include "mbo/types/tuple.h"                             // IWYU pragma: export
+#include "mbo/types/variant.h"                           // IWYU pragma: export
 
 namespace mbo::types {
 
@@ -355,20 +355,6 @@ concept NotSameAsAnyOfRaw = !IsSameAsAnyOfRaw<std::remove_cvref_t<SameAs>, Ts...
 template<typename SameAs, typename T>
 concept IsSameAsRaw = IsSameAsAnyOfRaw<SameAs, T>;
 
-namespace types_internal {
-
-template<typename T>
-struct IsVariantImpl : std::false_type {};
-
-template<typename... Args>
-struct IsVariantImpl<std::variant<Args...>> : std::true_type {};
-
-}  // namespace types_internal
-
-// Determine whether `T` is a `std::variant<...>` type.
-template<typename T>
-concept IsVariant = types_internal::IsVariantImpl<T>::value;
-
 // Determines whether `T` can be constructed from an empty base and `Args`.
 //
 // This is used in mbo::types::Extend<...>::ConstructFrom{Tuple|Args}.
@@ -433,6 +419,12 @@ concept IsOptional = requires {
 // ```
 template<typename From, typename Into>
 concept ConstructibleInto = std::constructible_from<Into, From>;
+
+// Test whether a type is a container whose elements are pairs and whose keys
+// are convertible to a std::string_view.
+template<typename T>
+concept IsStringKeyedContainer =
+    ContainerIsForwardIteratable<T> && IsPairFirstStr<std::remove_cvref_t<typename T::value_type>>;
 
 }  // namespace mbo::types
 

--- a/mbo/types/variant.h
+++ b/mbo/types/variant.h
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MBO_TYPES_VARIANT_H
+#define MBO_TYPES_VARIANT_H
+
+#include <type_traits>
+#include <variant>
+
+namespace mbo::types {
+namespace types_internal {
+
+template<typename T>
+struct IsVariantImpl : std::false_type {};
+
+template<typename... Args>
+struct IsVariantImpl<std::variant<Args...>> : std::true_type {};
+
+}  // namespace types_internal
+
+// Determine whether `T` is a `std::variant<...>` type.
+template<typename T>
+concept IsVariant = types_internal::IsVariantImpl<T>::value;
+
+namespace types_internal {
+
+template<
+    typename V,
+    typename T,
+    std::size_t Index,
+    bool = Index<std::variant_size_v<V>> struct IsVariantMemberType : std::false_type {};
+
+template<typename V, typename T, std::size_t Index>
+struct IsVariantMemberType<V, T, Index, false>
+    : std::bool_constant<
+          std::same_as<T, std::variant_alternative_t<Index, V>> || IsVariantMemberType<V, T, Index + 1>::value> {};
+
+}  // namespace types_internal
+
+// Determine whether a `Type` is any of the types in a `Variant`.
+template<typename Variant, typename Type>
+concept IsVariantMemberType = types_internal::IsVariantMemberType<Variant, Type, 0>::value;
+
+// Overload handler for `std::visit(std::variant<...>)` and `std::variant::visit`.
+//
+// Example:
+// ```
+// std::visit(
+//   ::mbo::types::Overloaded{
+//     [&](const VariantType0& val) {},
+//     [&](const VariantType1& val) {},
+//     // ...
+//   },
+//   variant_value
+// )
+// ```
+template<class... Ts>
+struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template<class... Ts>
+Overloaded(Ts...) -> Overloaded<Ts...>;
+
+}  // namespace mbo::types
+
+#endif  // MBO_TYPES_VARIANT_H


### PR DESCRIPTION
* Added struct `Overloaded` which implements an Overload handler for `std::visit(std::variant<...>)` and `std::variant::visit` (technically moved).
* Added function `CompareDouble` which can compare two `float`, `double` or `long double` values returning `std::strong_ordering`.
* Added function `WeakToStrong` which converts a `std::weak_ordering` to a `std::strong_ordering`.
* Added concept `IsStringKeyedContainer` which determines whether a type is a container whose elements are pairs and whose keys are convertible to a std::string_view.
* Added API extension point functoin `MboTypesStringifyValueAccess` which allows to replace a struct with a single value in `Stringify` processing.
* Added `Stringify` support for empty types and types that match `IsStringKeyedContainer`.
* Fixed `Stringify` null* epresentations to stream as `null` as opposed to `0`.