### PR TITLE
Added ConstructibleFrom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
     * Fixed `Stringify` null* representations to stream as `'null'` as opposed to `0`.
     * Added ability to sort string keyed containers.
 * Improved traits:
+    * Added concept `ConstructibleFrom` implements a variant of `std::constructible_from` that works around its limitations to deal with array args.
     * Added concept `IsEmptyType` determines whether a type is empty (calls `std::is_empty_v`).
     * Fixed concept `IsAggregate` (breaking change).
     * Added concept `IsStringKeyedContainer` which determines whether a type is a container whose elements are pairs and whose keys are convertible to a std::string_view.
@@ -28,7 +29,7 @@
     * Added concept `IsSameAsAnyOf` which determines whether a type is the same as one of a list of types. Similar to `IsSameAsAnyOfRaw` but using exact types.
 * Added `Demangle` to log de-mangled typeid names.
 * Added struct `Overloaded` which implements an Overload handler for `std::visit(std::variant<...>)` and `std::variant::visit` (technically moved).
-* Added function `CompareDouble` which can compare two `float`, `double` or `long double` values returning `std::strong_ordering`.
+* Added function `CompareFloat` which can compare two `float`, `double` or `long double` values returning `std::strong_ordering`.
 * Added function `WeakToStrong` which converts a `std::weak_ordering` to a `std::strong_ordering`.
 * Fixed some IWYU pragmas.
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The library is tested with Clang (16+) and GCC (12+) on Ubuntu and MacOS (arm) u
         * meta-type `IfFalseThenVoid`: Helper type that can be used to skip a case.
         * meta-type `IfTrueThenVoid`: Helper type to inject default cases and to ensure the required type expansion is always possible.
     * mbo/types:compare_cc, mbo/types/compare.h
-        * function `CompareDouble` which can compare two `float`, `double` or `long double` values returning `std::strong_ordering`.
+        * function `CompareFloat` which can compare two `float`, `double` or `long double` values returning `std::strong_ordering`.
         * comparator `CompareLess` which is compatible to std::Less but allows container optimizations.
         * function `WeakToStrong` which converts a `std::weak_ordering` to a `std::strong_ordering`.
     * mbo/types:container_proxy_cc, mbo/types/container_proxy.h
@@ -200,7 +200,8 @@ The library is tested with Clang (16+) and GCC (12+) on Ubuntu and MacOS (arm) u
     * mbo/types:stringify_ostream_cc, mbo/types/stringify_ostream.h
         * operator `std::ostream& operator<<(std::ostream&, const MboTypesStringifySupport auto& v)` - conditioanl automatic ostream support for structs using `Stringify`.
     * mbo/types:traits_cc, mbo/types/traits.h
-        * concept `ConstructibleInto` determined whether one type can be constructed from another. Similar to `std::convertible_to` but with the argument order of `std::constructible_from`.
+        * concept `ConstructibleFrom` implements a variant of `std::constructible_from` that works around its limitations to deal with array args.
+        * concept `ConstructibleInto` determines whether one type can be constructed from another. Similar to `std::convertible_to` but with the argument order of `std::constructible_from`.
         * type alias `ContainerConstIteratorValueType` returned the value-type of the const_iterator of a container.
         * concept `ContainerIsForwardIteratable` determines whether a types can be used in forward iteration.
         * concept `ContainerHasEmplace` determines whether a container has `emplace`.

--- a/mbo/types/BUILD.bazel
+++ b/mbo/types/BUILD.bazel
@@ -172,6 +172,7 @@ cc_library(
     name = "optional_data_or_ref_cc",
     hdrs = ["optional_data_or_ref.h"],
     deps = [
+        ":traits_cc",
         "//mbo/config:require_cc",
         "//mbo/log:demangle_cc",
         "@com_google_absl//absl/hash",

--- a/mbo/types/compare.h
+++ b/mbo/types/compare.h
@@ -92,7 +92,7 @@ template<typename T>
 concept IsStdLess = types_internal::IsStdLess<T>::value;
 
 template<IsSameAsAnyOf<float, double, long double> Double>
-std::strong_ordering CompareDouble(Double lhs, Double rhs) {
+std::strong_ordering CompareFloat(Double lhs, Double rhs) {
   const std::partial_ordering comp = lhs <=> rhs;
   if (comp == std::partial_ordering::less) {
     return std::strong_ordering::less;

--- a/mbo/types/optional_data_or_ref.h
+++ b/mbo/types/optional_data_or_ref.h
@@ -26,6 +26,7 @@
 #include "absl/strings/str_format.h"
 #include "mbo/config/require.h"
 #include "mbo/log/demangle.h"
+#include "mbo/types/traits.h"  // IWYU pragma: keep
 
 namespace mbo::types {
 
@@ -148,7 +149,7 @@ class OptionalDataOrRef {
     return *this;
   }
 
-  template<typename... Args, typename = decltype(::new(std::declval<void*>()) T(std::declval<Args>()...))>
+  template<typename... Args, typename = std::enable_if_t<ConstructibleFrom<T, Args...>>>
   constexpr OptionalDataOrRef& emplace(Args&&... args) noexcept {
     if (is_val_) {
       std::destroy_at(&union_.val);
@@ -196,7 +197,7 @@ class OptionalDataOrRef {
   // * is `std::nullopt`, then a default value will be emplace and is reference returned.
   // * contains a value, then its reference will be returned.
   // * contains a reference, then that reference is emplace and then its reference returned.
-  template<typename... Args, typename = decltype(::new(std::declval<void*>()) T(std::declval<Args>()...))>
+  template<typename... Args, typename = std::enable_if_t<ConstructibleFrom<T, Args...>>>
   constexpr value_type& as_data(Args&&... args) noexcept {
     if (!is_val_) {
       if (union_.ptr != nullptr) {


### PR DESCRIPTION
* Added concept `ConstructibleFrom` implements a variant of `std::constructible_from` that works around its limitations to deal with array args.