### PR TITLE
Added TypedView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
     * Added concept `IsStringKeyedContainer` which determines whether a type is a container whose elements are pairs and whose keys are convertible to a std::string_view.
     * Added concept `IsReferenceWrapper` determines whether a type is a `std::reference_wrapper`.
     * Added concept `IsSameAsAnyOf` which determines whether a type is the same as one of a list of types. Similar to `IsSameAsAnyOfRaw` but using exact types.
+    * Added template struct `TypedView` a wrapper for STL views that provides type definitions, most importantly `value_type`. That allows such views to be used with GoogleTest container matchers.
 * Added `Demangle` to log de-mangled typeid names.
 * Added struct `Overloaded` which implements an Overload handler for `std::visit(std::variant<...>)` and `std::variant::visit` (technically moved).
 * Added function `CompareFloat` which can compare two `float`, `double` or `long double` values returning `std::strong_ordering`.

--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ The library is tested with Clang (16+) and GCC (12+) on Ubuntu and MacOS (arm) u
         * operator `operator"" _ts`: String literal support for Clang, GCC and derived compilers.
     * mbo/types:tuple_cc, mbo/types/tuple.h
         * template struct `TupleCat` which concatenates tuple types.
+    * mbo/types:typed_view_cc, mbo/types/typed_view.h
+        * template struct `TypedView` a wrapper for STL views that provides type definitions, most importantly `value_type`. That allows such views to be used with GoogleTest container matchers.
     * mbo/types:variant_cc, mbo/types/variant.h
         * concept `IsVariant` determines whether a type is a `std::variant` type.
         * concept `IsVariantMemberType` determine whether a `Type` is any of the types in a `Variant`.

--- a/mbo/container/internal/limited_ordered.h
+++ b/mbo/container/internal/limited_ordered.h
@@ -178,7 +178,6 @@ class [[nodiscard]] LimitedOrdered {
     using value_type = LimitedOrdered::value_type;
     using pointer = LimitedOrdered::const_pointer;
     using reference = LimitedOrdered::const_reference;
-    using element_type = LimitedOrdered::value_type;
 
     constexpr const_iterator() noexcept : pos_(nullptr) {}  // Needed for STL
 
@@ -273,7 +272,6 @@ class [[nodiscard]] LimitedOrdered {
     using value_type = LimitedOrdered::value_type;
     using pointer = LimitedOrdered::pointer;
     using reference = LimitedOrdered::reference;
-    using element_type = LimitedOrdered::value_type;
 
     constexpr iterator() noexcept : pos_(nullptr) {}  // Needed for STL
 

--- a/mbo/types/BUILD.bazel
+++ b/mbo/types/BUILD.bazel
@@ -404,6 +404,12 @@ cc_test(
 )
 
 cc_library(
+    name = "typed_view_cc",
+    hdrs = ["typed_view.h"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
     name = "variant_cc",
     hdrs = ["variant.h"],
     visibility = ["//visibility:public"],

--- a/mbo/types/typed_view.h
+++ b/mbo/types/typed_view.h
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MBO_TYPES_TYPED_VIEW_H
+#define MBO_TYPES_TYPED_VIEW_H
+
+#include <iterator>
+#include <utility>
+
+// NOLINTBEGIN(readability-identifier-naming)
+
+namespace mbo::types {
+
+// Wrapper for STL views that provides type definitions, most importantly `value_type`.
+// That allows such views to be used with GoogleTest container matchers.
+template<typename View>
+class TypedView {
+ private:
+  using iterator = decltype(std::declval<View&>().begin());
+
+ public:
+  using value_type = std::iter_value_t<iterator>;
+  using reference = std::iter_reference_t<iterator>;
+  using difference_t = std::iter_difference_t<iterator>;
+
+  TypedView() = delete;
+
+  explicit TypedView(View&& view) : view_(std::move(view)) {}
+
+  auto begin() { return view_.begin(); }
+
+  auto begin() const { return view_.begin(); }
+
+  auto end() { return view_.end(); }
+
+  auto end() const { return view_.end(); }
+
+ private:
+  View view_;
+};
+
+}  // namespace mbo::types
+
+// NOLINTEND(readability-identifier-naming)
+
+#endif  // MBO_TYPES_TYPED_VIEW_H


### PR DESCRIPTION
* Added template struct `TypedView` a wrapper for STL views that provides type definitions, most importantly `value_type`. That allows such views to be used with GoogleTest container matchers.