### PR TITLE
Improve Stringify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
     * Added `Stringify` support for empty types and types that match `IsStringKeyedContainer`.
     * Fixed `Stringify` null* representations to stream as `'null'` as opposed to `0`.
     * Added ability to sort string keyed containers.
+    * Added function `SetStringifyOstreamOutputMode` which sets global Stringify stream options by mode.
+    * Added function `SetStringifyOstreamOptions` which sets global Stringify stream options.
+    * Changed `Stringify::ToString` and `Stringify::Stream` to not depend on any mutable member of `Stringify`.
 * Improved traits:
     * Added concept `ConstructibleFrom` implements a variant of `std::constructible_from` that works around its limitations to deal with array args.
     * Added concept `IsEmptyType` determines whether a type is empty (calls `std::is_empty_v`).
@@ -28,6 +31,8 @@
     * Added concept `IsReferenceWrapper` determines whether a type is a `std::reference_wrapper`.
     * Added concept `IsSameAsAnyOf` which determines whether a type is the same as one of a list of types. Similar to `IsSameAsAnyOfRaw` but using exact types.
     * Added template struct `TypedView` a wrapper for STL views that provides type definitions, most importantly `value_type`. That allows such views to be used with GoogleTest container matchers.
+    * Added concept `IsOptionalDataOrRef` which determines whether a type is a `OptionalDataOrRef`.
+    * Added concept `IsOptionalRef` which determines whether a type is a `OptionalRef`.
 * Added `Demangle` to log de-mangled typeid names.
 * Added struct `Overloaded` which implements an Overload handler for `std::visit(std::variant<...>)` and `std::variant::visit` (technically moved).
 * Added function `CompareFloat` which can compare two `float`, `double` or `long double` values returning `std::strong_ordering`.

--- a/README.md
+++ b/README.md
@@ -175,9 +175,11 @@ The library is tested with Clang (16+) and GCC (12+) on Ubuntu and MacOS (arm) u
         * struct `OpaqueValue` an `OpaquePtr` with direct access, comparison and hashing which will not allow a nullptr.
         * struct `OpaqueContainer` an `OpaqueValue` with direct container access.
     * mbo/types:optional_ref_cc, mbo/types/optional_data_or_ref.h
+        * concept `IsOptionalDataOrRef` which determines whether a type is a `OptionalDataOrRef`.
         * struct `OptionalDataOrRef` similar to `std::optional` but can hold `std::nullopt`, a type `T` or a reference `T&`/`const T&`.
         * struct `OptionalDataOrConstRef` similar to `std::optional` but can hold `std::nullopt`, a type `T` or a const reference `const T&`.
     * mbo/types:optional_ref_cc, mbo/types/optional_ref.h
+        * concept `IsOptionalRef` which determines whether a type is a `OptionalRef`.
         * struct `OptionalRef` similar to `std::optional` but can hold `std::nullopt` or a reference `T&`/`const T&`.
     * mbo/types:ref_wrap_cc, mbo/types/ref_wrap.h
         * template-type `RefWrap<T>`: similar to `std::reference_wrapper` but supports operators `->` and `*`.
@@ -199,6 +201,8 @@ The library is tested with Clang (16+) and GCC (12+) on Ubuntu and MacOS (arm) u
         * API extension point functoin `MboTypesStringifyValueAccess` which allows to replace a struct with a single value in `Stringify` processing.
     * mbo/types:stringify_ostream_cc, mbo/types/stringify_ostream.h
         * operator `std::ostream& operator<<(std::ostream&, const MboTypesStringifySupport auto& v)` - conditioanl automatic ostream support for structs using `Stringify`.
+        * function `SetStringifyOstreamOutputMode` which sets global Stringify stream options by mode.
+        * function `SetStringifyOstreamOptions` which sets global Stringify stream options.
     * mbo/types:traits_cc, mbo/types/traits.h
         * concept `ConstructibleFrom` implements a variant of `std::constructible_from` that works around its limitations to deal with array args.
         * concept `ConstructibleInto` determines whether one type can be constructed from another. Similar to `std::convertible_to` but with the argument order of `std::constructible_from`.

--- a/mbo/types/BUILD.bazel
+++ b/mbo/types/BUILD.bazel
@@ -294,9 +294,11 @@ cc_test(
 
 cc_library(
     name = "stringify_ostream_cc",
+    srcs = ["stringify_ostream.cc"],
     hdrs = ["stringify_ostream.h"],
     deps = [
         ":stringify_cc",
+        "@com_google_absl//absl/synchronization",
     ],
 )
 
@@ -305,8 +307,10 @@ cc_test(
     size = "small",
     srcs = ["stringify_ostream_test.cc"],
     deps = [
+        ":extend_cc",
         ":extender_cc",
         ":stringify_ostream_cc",
+        "//mbo/testing:matchers_cc",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],

--- a/mbo/types/optional_data_or_ref.h
+++ b/mbo/types/optional_data_or_ref.h
@@ -349,6 +349,13 @@ class OptionalDataOrRef {
 template<typename T>
 using OptionalDataOrConstRef = OptionalDataOrRef<T, const T>;
 
+template<typename T>
+concept IsOptionalDataOrRef = requires {
+  typename T::value_type;
+  typename T::reference;
+  requires std::same_as<T, OptionalDataOrRef<typename T::value_type, std::remove_reference_t<typename T::reference>>>;
+};
+
 // NOLINTEND(*-identifier-naming)
 
 }  // namespace mbo::types

--- a/mbo/types/optional_data_or_ref_test.cc
+++ b/mbo/types/optional_data_or_ref_test.cc
@@ -40,6 +40,7 @@ struct OptionalDataOrRefTest : ::testing::Test {};
 TEST_F(OptionalDataOrRefTest, Constexpr) {
   {
     constexpr OptionalDataOrRef<int> kRef;
+    static_assert(IsOptionalDataOrRef<std::remove_const_t<decltype(kRef)>>);
     EXPECT_THAT(kRef, std::nullopt);
     EXPECT_THAT(kRef, IsNullopt());
     EXPECT_THAT(kRef.has_value(), false);
@@ -50,6 +51,7 @@ TEST_F(OptionalDataOrRefTest, Constexpr) {
   {
     static constexpr std::string_view kStr = "test";
     constexpr OptionalDataOrConstRef<std::string_view> kRef{kStr};
+    static_assert(IsOptionalDataOrRef<std::remove_const_t<decltype(kRef)>>);
     EXPECT_THAT(kRef, "test");
     EXPECT_THAT(kRef, Not(IsNullopt()));
     EXPECT_THAT(kRef.has_value(), true);
@@ -256,6 +258,7 @@ TEST_F(OptionalDataOrRefTest, Compare) {
 
 TEST_F(OptionalDataOrRefTest, ConsRef) {
   OptionalDataOrConstRef<int> ref(42);
+  static_assert(IsOptionalDataOrRef<decltype(ref)>);
   EXPECT_THAT(ref, Eq(42));
   EXPECT_THAT(ref.has_value(), true);
   EXPECT_THAT(ref.HoldsData(), true);

--- a/mbo/types/optional_ref.h
+++ b/mbo/types/optional_ref.h
@@ -193,6 +193,13 @@ class OptionalRef {
   T* v_ = nullptr;
 };
 
+template<typename T>
+concept IsOptionalRef = requires {
+  typename T::value_type;
+  typename T::reference;
+  requires std::same_as<T, OptionalRef<std::remove_reference_t<typename T::value_type>>>;
+};
+
 }  // namespace mbo::types
 
 #endif  // MBO_TYPES_OPTIONAL_REF_H_

--- a/mbo/types/optional_ref_test.cc
+++ b/mbo/types/optional_ref_test.cc
@@ -33,6 +33,7 @@ struct OptionalRefTest : ::testing::Test {};
 
 TEST_F(OptionalRefTest, Null) {
   OptionalRef<int> ref;
+  static_assert(IsOptionalRef<decltype(ref)>);
   EXPECT_THAT(ref, IsNullopt());
 }
 

--- a/mbo/types/stringify.cc
+++ b/mbo/types/stringify.cc
@@ -21,6 +21,20 @@
 namespace mbo::types {
 
 std::string StringifyOptions::DebugStr() const {
+// NOLINTNEXTLINE(*-macro-usage)
+#define SHOW_DEFAULT(name)        \
+  if (this == &Stringify::name()) \
+  return "{} // " #name "\n"
+  SHOW_DEFAULT(OptionsDefault);
+  SHOW_DEFAULT(OptionsDefault);
+  SHOW_DEFAULT(OptionsDisabled);
+  SHOW_DEFAULT(OptionsCpp);
+  SHOW_DEFAULT(OptionsCppPretty);
+  SHOW_DEFAULT(OptionsJson);
+  SHOW_DEFAULT(OptionsJsonLine);
+  SHOW_DEFAULT(OptionsJsonPretty);
+#undef SHOW_DEFAULT
+
   std::ostringstream out;
   out << "{\n";
   ApplyAll(*this, [&out]<typename T>(const T& v) {

--- a/mbo/types/stringify_ostream.cc
+++ b/mbo/types/stringify_ostream.cc
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+
+#include "absl/synchronization/mutex.h"
+#include "mbo/types/stringify.h"
+
+namespace mbo::types {
+namespace {
+
+absl::Mutex g_mx(absl::kConstInit);                      // NOLINT(*-avoid-non-const-global-variables)
+std::shared_ptr<const Stringify> g_stringify = nullptr;  // NOLINT(*-avoid-non-const-global-variables)
+
+}  // namespace
+
+namespace types_internal {
+
+std::shared_ptr<const Stringify> GetStringifyForOstream() {
+  absl::MutexLock lock(&g_mx);
+  if (g_stringify == nullptr) {
+    g_stringify = std::make_shared<Stringify>();
+  }
+  return g_stringify;
+}
+
+}  // namespace types_internal
+
+void SetStringifyOstreamOutputMode(Stringify::OutputMode output_mode) {
+  absl::MutexLock lock(&g_mx);
+  g_stringify.reset(new Stringify(output_mode));  // NOLINT
+}
+
+void SetStringifyOstreamOptions(const StringifyOptions& options) {
+  absl::MutexLock lock(&g_mx);
+  g_stringify.reset(new Stringify(options));  // NOLINT
+}
+
+}  // namespace mbo::types

--- a/mbo/types/stringify_ostream.h
+++ b/mbo/types/stringify_ostream.h
@@ -22,13 +22,36 @@
 
 #include <concepts>  // IWYU pragma: keep
 #include <iostream>
+#include <memory>
+#include <ostream>
 
 #include "mbo/types/stringify.h"
 
+namespace mbo::types {
+namespace types_internal {
+
+std::shared_ptr<const Stringify> GetStringifyForOstream();
+
+}  // namespace types_internal
+
+// Set the global Stringify stream options by mode.
+//
+// While this is thread-safe, there is no guarantee that the same options will be used.
+// That is becasue the options could be changed before the intended stream call.
+void SetStringifyOstreamOutputMode(Stringify::OutputMode output_mode);
+
+// Set the global Stringify stream options by `StringifyOptions`.
+//
+// While this is thread-safe, there is no guarantee that the same options will be used.
+// That is becasue the options could be changed before the intended stream call.
+void SetStringifyOstreamOptions(const StringifyOptions& options);
+void SetStringifyOstreamOptions(const StringifyOptions&& options) = delete;
+
+}  // namespace mbo::types
+
 // Add `Stringify` ostream support to *ALL* types that claim support, see `HasMboTypesStringifySupport`.
 std::ostream& operator<<(std::ostream& os, const mbo::types::HasMboTypesStringifySupport auto& v) {
-  static mbo::types::Stringify sfy;
-  sfy.Stream(os, v);
+  mbo::types::types_internal::GetStringifyForOstream()->Stream(os, v);
   return os;
 }
 

--- a/mbo/types/stringify_ostream_test.cc
+++ b/mbo/types/stringify_ostream_test.cc
@@ -20,6 +20,8 @@
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "mbo/testing/matchers.h"
+#include "mbo/types/extend.h"
 #include "mbo/types/extender.h"
 
 namespace mbo_other {  // Not using namespace mbo::types
@@ -28,22 +30,60 @@ namespace {
 
 // NOLINTBEGIN(*-magic-numbers,*-named-parameter)
 
+using ::mbo::testing::EqualsText;
+using ::mbo::types::SetStringifyOstreamOutputMode;
+using ::mbo::types::Stringify;
 using ::mbo::types::types_internal::kStructNameSupport;
 using ::testing::Conditional;
 
 struct StringifyOstreamTest : ::testing::Test {};
 
+#if defined(__clang__)
+# pragma clang diagnostic push
+// Calng may get confused about ADL friends
+# pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
+#endif  // defined(__clang__)
+
+struct TestStruct {
+  int one = 11;
+  int two = 25;
+
+  using MboTypesStringifySupport = void;
+
+  friend constexpr auto MboTypesStringifyFieldNames(const TestStruct& /*unused*/) {
+    return std::array<std::string_view, 2>{"one", "two"};
+  }
+};
+
+#if defined(__clang__)
+# pragma clang diagnostic pop
+#endif  // defined(__clang__)
+
 TEST_F(StringifyOstreamTest, OStream) {
-  struct TestStruct {
-    int one = 11;
-    int two = 25;
-
-    using MboTypesStringifySupport = void;
-  };
-
-  std::stringstream os;
-  os << TestStruct{};
-  EXPECT_THAT(os.str(), Conditional(kStructNameSupport, R"({.one: 11, .two: 25})", R"({11, 25})"));
+  {
+    std::stringstream os;
+    os << TestStruct{};
+    EXPECT_THAT(os.str(), Conditional(kStructNameSupport, R"({.one: 11, .two: 25})", R"({11, 25})"));
+  }
+  {
+    SetStringifyOstreamOutputMode(Stringify::OutputMode::kCppPretty);
+    std::stringstream os;
+    os << TestStruct{};
+    EXPECT_THAT(
+        os.str(), Conditional(
+                      kStructNameSupport, EqualsText(R"({
+  .one = 11,
+  .two = 25
+}
+)"),
+                      R"({11, 25})"));
+  }
+  {
+    SetStringifyOstreamOutputMode(Stringify::OutputMode::kDefault);
+    std::stringstream os;
+    os << TestStruct{};
+    EXPECT_THAT(os.str(), Conditional(kStructNameSupport, R"({.one: 11, .two: 25})", R"({11, 25})"));
+  }
 }
 
 TEST_F(StringifyOstreamTest, Nested) {
@@ -122,5 +162,3 @@ TEST_F(StringifyOstreamTest, ExistingAbslStringify) {
 
 }  // namespace
 }  // namespace mbo_other
-
-// Not using namespace mbo::types

--- a/mbo/types/stringify_ostream_test.cc
+++ b/mbo/types/stringify_ostream_test.cc
@@ -63,26 +63,23 @@ TEST_F(StringifyOstreamTest, OStream) {
   {
     std::stringstream os;
     os << TestStruct{};
-    EXPECT_THAT(os.str(), Conditional(kStructNameSupport, R"({.one: 11, .two: 25})", R"({11, 25})"));
+    EXPECT_THAT(os.str(), R"({.one: 11, .two: 25})");
   }
   {
     SetStringifyOstreamOutputMode(Stringify::OutputMode::kCppPretty);
     std::stringstream os;
     os << TestStruct{};
-    EXPECT_THAT(
-        os.str(), Conditional(
-                      kStructNameSupport, EqualsText(R"({
+    EXPECT_THAT(os.str(), EqualsText(R"({
   .one = 11,
   .two = 25
 }
-)"),
-                      R"({11, 25})"));
+)"));
   }
   {
     SetStringifyOstreamOutputMode(Stringify::OutputMode::kDefault);
     std::stringstream os;
     os << TestStruct{};
-    EXPECT_THAT(os.str(), Conditional(kStructNameSupport, R"({.one: 11, .two: 25})", R"({11, 25})"));
+    EXPECT_THAT(os.str(), R"({.one: 11, .two: 25})");
   }
 }
 


### PR DESCRIPTION
* Added function `SetStringifyOstreamOutputMode` which sets global Stringify stream options by mode.
* Added function `SetStringifyOstreamOptions` which sets global Stringify stream options.
* Changed `Stringify::ToString` and `Stringify::Stream` to not depend on any mutable member of `Stringify`.
* Added concept `IsOptionalDataOrRef` which determines whether a type is a `OptionalDataOrRef`.
* Added concept `IsOptionalRef` which determines whether a type is a `OptionalRef`.