### PR TITLE
Improved comparison support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,11 @@
     * Added template struct `TypedView` a wrapper for STL views that provides type definitions, most importantly `value_type`. That allows such views to be used with GoogleTest container matchers.
     * Added concept `IsOptionalDataOrRef` which determines whether a type is a `OptionalDataOrRef`.
     * Added concept `IsOptionalRef` which determines whether a type is a `OptionalRef`.
-    * Added function `CompareArithmetic` which compares two values that are numbers (not including pointers).
-    * Added function `CompareScalar` which compares two values that are numbers/scalar (including pointers).
+    * Added function `CompareArithmetic` which compares two values that are scalar-numbers (including foat/double and pointers, but not allowing references).
+    * Added function `CompareIntegral` which compares two values that are integral-numbers (no float/double, no pointers, no references).
+    * Added function `CompareScalar` which compares two values that are numbers/scalar (including pointers, no references).
     * Added concept `IsArithmetic` uses `std::is_arithmetic_v<T>`.
+    * Added concept `IsIntegral` uses `std::is_integral_v<T>`.
     * Added concept `IsScalar` uses `std::is_scalar_v<T>`.
 * Added `Demangle` to log de-mangled typeid names.
 * Added struct `Overloaded` which implements an Overload handler for `std::visit(std::variant<...>)` and `std::variant::visit` (technically moved).

--- a/README.md
+++ b/README.md
@@ -149,10 +149,11 @@ The library is tested with Clang (16+) and GCC (12+) on Ubuntu and MacOS (arm) u
         * meta-type `IfFalseThenVoid`: Helper type that can be used to skip a case.
         * meta-type `IfTrueThenVoid`: Helper type to inject default cases and to ensure the required type expansion is always possible.
     * mbo/types:compare_cc, mbo/types/compare.h
-        * function `CompareArithmetic` which compares two values that are numbers (not including pointers).
+        * function `CompareArithmetic` which compares two values that are scalar-numbers (including foat/double and pointers, but not allowing references).
         * function `CompareFloat` which can compare two `float`, `double` or `long double` values returning `std::strong_ordering`.
+        * function `CompareIntegral` which compares two values that are integral-numbers (no float/double, no pointers, no references).
         * comparator `CompareLess` which is compatible to std::Less but allows container optimizations.
-        * function `CompareScalar` which compares two values that are numbers/scalar (including pointers).
+        * function `CompareScalar` which compares two values that are scalar-numbers (including float/double, pointers and references).
         * function `WeakToStrong` which converts a `std::weak_ordering` to a `std::strong_ordering`.
     * mbo/types:container_proxy_cc, mbo/types/container_proxy.h
         * struct `ContainerProxy` which allows to add container access to other types including smart pointers of containers.
@@ -220,11 +221,12 @@ The library is tested with Clang (16+) and GCC (12+) on Ubuntu and MacOS (arm) u
         * concept `HasDifferenceType` determines whether a type has a `difference_type`.
         * concept `IsAggregate` determines whether a type is an aggregate.
         * concept `IsArithmetic` uses `std::is_arithmetic_v<T>`.
+        * concept `IsBracesConstructibleV` determines whether a type can be constructed from given argument types.
         * concept `IsCharArray` determines whether a type is a `char*` or `char[]` related type.
         * concept `IsDecomposable` determines whether a type can be used in static-bindings.
         * concept `IsEmptyType` determines whether a type is empty (calls `std::is_empty_v`).
         * concept `IsInitializerList` determines whether a type is `std::initializer<T> type.
-        * concept `IsBracesConstructibleV` determines whether a type can be constructed from given argument types.
+        * concept `IsScalar` uses `std::is_scalar_v<T>`.
         * concept `IsOptional` determines whether a type is a `std::optional` type.
         * concept `IsPair` determines whether a type is a `std::pair` type.
         * concept `IsReferenceWrapper` determines whether a type is a `std::reference_wrapper`.

--- a/mbo/types/compare.h
+++ b/mbo/types/compare.h
@@ -107,7 +107,7 @@ std::strong_ordering CompareFloat(Double lhs, Double rhs) {
   return lhs_nan <=> rhs_nan;
 }
 
-// Compare two values that are numbers/scalar (includes pointers).
+// Compares two values that are scalar-numbers (including float/double, pointers and references).
 template<IsScalar Lhs, IsScalar Rhs>
 inline std::strong_ordering CompareScalar(Lhs lhs, Rhs rhs) {
   // if constexpr (IsSameAsAnyOf<Lhs, float, double, long double> || IsSameAsAnyOf<Rhs, float, double, long double>) {
@@ -140,9 +140,15 @@ inline std::strong_ordering CompareScalar(Lhs lhs, Rhs rhs) {
   }
 }
 
-// Compare two values that are numbers/scalar (includes pointers).
+// Compares two values that are scalar-numbers (including foat/double and pointers, but not allowing references).
 template<IsArithmetic Lhs, IsArithmetic Rhs>
 inline std::strong_ordering CompareArithmetic(Lhs lhs, Rhs rhs) {
+  return CompareScalar(lhs, rhs);
+}
+
+// Compares two values that are integral-numbers (no float/double, no pointers, no references).
+template<IsIntegral Lhs, IsIntegral Rhs>
+inline std::strong_ordering CompareIntegral(Lhs lhs, Rhs rhs) {
   return CompareScalar(lhs, rhs);
 }
 

--- a/mbo/types/traits.h
+++ b/mbo/types/traits.h
@@ -40,6 +40,9 @@ template<typename T>
 concept IsArithmetic = std::is_arithmetic_v<T>;
 
 template<typename T>
+concept IsIntegral = std::is_integral_v<T>;
+
+template<typename T>
 concept IsScalar = std::is_scalar_v<T>;
 
 // Determines whether `std::is_aggrgate_v<T> == true`.


### PR DESCRIPTION
* Added function `CompareArithmetic` which compares two values that are scalar-numbers (including foat/double and pointers, but not allowing references).
* Added function `CompareIntegral` which compares two values that are integral-numbers (no float/double, no pointers, no references).
* Added function `CompareScalar` which compares two values that are numbers/scalar (including pointers, no references).
* Added concept `IsArithmetic` uses `std::is_arithmetic_v<T>`.
* Added concept `IsIntegral` uses `std::is_integral_v<T>`.
* Added concept `IsScalar` uses `std::is_scalar_v<T>`.