### PR TITLE
Cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,6 @@
 * Added function `WeakToStrong` which converts a `std::weak_ordering` to a `std::strong_ordering`.
 * Fixed some IWYU pragmas.
 * Fixed some template requirements.
-* Added concept `IsAnyOfSameAs` which determines whether a type is the same as one of a list of types. Unlike `IsSameAsAnyOf` this has the searched typed on the right, so it can be bound in template clauses. The inversion is available as `NotAnyOfSameAs`.
-* Added concept `IsAnyOfSameAsRaw` which determines whether a type is the same as one of a list of types (when const, volatile and reference are removed). Unlike `IsSameAsAnyOfRaw` this has the searched typed on the right, so it can be bound in template clauses. Similar to `IsSameAsAnyOf` but applies `std::remove_cvref_t` on all types. The inversion is available as `NotAnyOfSameAsRaw`.
 
 # 0.9.0
 

--- a/README.md
+++ b/README.md
@@ -220,8 +220,6 @@ The library is tested with Clang (16+) and GCC (12+) on Ubuntu and MacOS (arm) u
         * concept `ContainerHasInputIterator` determines whether a container has `begin`, `end` and `std::input_iterator` compliant iterators.
         * type alias `GetDifferenceType` is either set to the type's `difference_type` or `std::ptrdiff_t`.
         * concept `HasDifferenceType` determines whether a type has a `difference_type`.
-        * concept `IsAnyOfSameAs` which determines whether a type is the same as one of a list of types. Unlike `IsSameAsAnyOf` this has the searched typed on the right, so it can be bound in template clauses. The inversion is available as `NotAnyOfSameAs`.
-        * concept `IsAnyOfSameAsRaw` which determines whether a type is the same as one of a list of types (when const, volatile and reference are removed). Unlike `IsSameAsAnyOfRaw` this has the searched typed on the right, so it can be bound in template clauses. Similar to `IsSameAsAnyOf` but applies `std::remove_cvref_t` on all types. The inversion is available as `NotAnyOfSameAsRaw`.
         * concept `IsAggregate` determines whether a type is an aggregate.
         * concept `IsArithmetic` uses `std::is_arithmetic_v<T>`.
         * concept `IsBracesConstructibleV` determines whether a type can be constructed from given argument types.

--- a/mbo/container/internal/limited_ordered.h
+++ b/mbo/container/internal/limited_ordered.h
@@ -383,6 +383,8 @@ class [[nodiscard]] LimitedOrdered {
 
   constexpr explicit LimitedOrdered(const Compare& key_comp) noexcept : key_comp_(key_comp) {}
 
+  // NOLINTBEGIN(cppcoreguidelines-pro-type-const-cast)
+
   constexpr LimitedOrdered(const LimitedOrdered& other) noexcept {
     for (; size_ < other.size_; ++size_) {
       std::construct_at(const_cast<RawValue*>(&values_[size_].data), other.values_[size_].data);
@@ -748,7 +750,6 @@ class [[nodiscard]] LimitedOrdered {
       if constexpr (kKeyOnly) {
         std::swap(values_[pos].data, other.values_[pos].data);
       } else {
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
         std::swap(const_cast<Key&>(values_[pos].data.first), const_cast<Key&>(other.values_[pos].data.first));
         std::swap(values_[pos].data.second, other.values_[pos].data.second);
       }
@@ -923,6 +924,8 @@ class [[nodiscard]] LimitedOrdered {
     ++size_;
     return std::make_pair(dst, true);
   }
+
+  // NOLINTEND(cppcoreguidelines-pro-type-const-cast)
 
   // Read/write access
 

--- a/mbo/container/limited_map.h
+++ b/mbo/container/limited_map.h
@@ -81,6 +81,12 @@ class LimitedMap final
 
   constexpr explicit LimitedMap(const KeyComp& key_comp) noexcept : LimitedBase(key_comp) {}
 
+  template<types::IsPair... Args>
+  requires(sizeof...(Args) <= kCapacity)
+  constexpr explicit LimitedMap(Args&&... args) {
+    (emplace(std::forward<Args>(args)), ...);
+  }
+
   constexpr LimitedMap(const LimitedMap& other) noexcept : LimitedBase(other) {}
 
   constexpr LimitedMap& operator=(const LimitedMap& other) noexcept {
@@ -342,7 +348,7 @@ constexpr auto ToLimitedMap(KV (&array)[N], const KComp& key_comp = KComp()) {
 
 template<typename KV, std::size_t N, typename KComp = types::CompareLess<typename std::remove_cvref_t<KV>::first_type>>
 requires(types::IsPair<std::remove_cvref_t<KV>>)
-constexpr auto ToLimitedMap(KV (&&array)[N], const KComp& key_comp = KComp()) {
+constexpr auto ToLimitedMap(KV (&&array)[N], const KComp& key_comp = KComp()) {  // NOLINT(*-not-moved)
   LimitedMap<typename std::remove_cvref_t<KV>::first_type, typename std::remove_cvref_t<KV>::second_type, N, KComp>
       result(key_comp);
   for (std::size_t idx = 0; idx < N; ++idx) {
@@ -363,7 +369,7 @@ constexpr auto ToLimitedMap(std::pair<K, V> (&array)[N], const KComp& key_comp =
 
 template<typename K, typename V, std::size_t N, typename KComp = types::CompareLess<K>>
 requires(!types::IsPair<std::remove_cvref_t<K>>)
-constexpr auto ToLimitedMap(std::pair<K, V> (&&array)[N], const KComp& key_comp = KComp()) {
+constexpr auto ToLimitedMap(std::pair<K, V> (&&array)[N], const KComp& key_comp = KComp()) {  // NOLINT(*-not-moved)
   LimitedMap<K, V, N, KComp> result(key_comp);
   for (std::size_t idx = 0; idx < N; ++idx) {
     result.emplace(std::move(array[idx]));

--- a/mbo/container/limited_map_test.cc
+++ b/mbo/container/limited_map_test.cc
@@ -18,9 +18,9 @@
 #include <array>
 #include <cstdint>
 #include <functional>
-#include <iterator>
-#include <ranges>
-#include <stdexcept>
+#include <iterator>   // IWYU pragma: keep
+#include <ranges>     // IWYU pragma: keep
+#include <stdexcept>  // IWYU pragma: keep
 #include <string>
 #include <string_view>
 #include <utility>

--- a/mbo/container/limited_set.h
+++ b/mbo/container/limited_set.h
@@ -238,6 +238,14 @@ constexpr inline bool operator<(
   return lhs.size() < rhs.size();
 }
 
+template<typename Key, typename... Args>
+requires((types::NotInitializerList<Args> && types::ConstructibleFrom<Key, Args>) && ...)
+inline constexpr auto MakeLimitedSetOf(Args&&... args) noexcept {
+  auto result = LimitedSet<Key, sizeof...(Args)>();
+  (result.emplace(std::forward<Args>(args)), ...);
+  return result;
+}
+
 template<typename Key, auto N = 0, typename Compare = std::less<Key>>
 inline constexpr auto MakeLimitedSet() noexcept {  // Parameter `key_comp` would create a conflict.
   return LimitedSet<Key, N, Compare>();

--- a/mbo/types/stringify.h
+++ b/mbo/types/stringify.h
@@ -474,10 +474,12 @@ void MboTypesStringifyOptions();  // Has no implementation!
 //
 // Note that caching is fairly expensive since both supported object types are large.
 template<typename T>
+concept IsValidMboTypesStringifyOptionsResultType =
+    IsSameAsAnyOf<T, StringifyOptions, const StringifyOptions&, StringifyFieldOptions, const StringifyFieldOptions&>;
+
+template<typename T>
 concept HasMboTypesStringifyOptions = requires(const T& v, const StringifyFieldInfo& opts) {
-  {
-    MboTypesStringifyOptions(v, opts)
-  } -> IsSameAsAnyOf<StringifyOptions, const StringifyOptions&, StringifyFieldOptions, const StringifyFieldOptions&>;
+  { MboTypesStringifyOptions(v, opts) } -> IsValidMboTypesStringifyOptionsResultType;
 };
 
 namespace types_internal {

--- a/mbo/types/traits_test.cc
+++ b/mbo/types/traits_test.cc
@@ -46,8 +46,7 @@ struct TraitsTest : ::testing::Test {
   }
 };
 
-template<typename T>
-requires IsSameAsAnyOfRaw<T, int, short>
+template<IsSameAsAnyOfRaw<int, short> T>
 constexpr bool Tester() noexcept {
   return true;
 }
@@ -78,14 +77,6 @@ TEST_F(TraitsTest, Concepts) {
   static_assert(IsSameAsAnyOf<int, unsigned, double, int>);  // Uses the first type parameter as the type to check.
   static_assert(!IsSameAsAnyOf<unsigned, double, int, int>);
   static_assert(!IsSameAsAnyOf<unsigned, int, double, int>);
-
-  static_assert(!IsAnyOfSameAs<int, unsigned, double>);
-  static_assert(!IsAnyOfSameAs<int, unsigned, int, double>);
-  static_assert(!IsAnyOfSameAs<unsigned, double, int>);
-  static_assert(!IsAnyOfSameAs<unsigned, double, short, int>);
-  static_assert(IsAnyOfSameAs<int, unsigned, double, int>);  // Uses the last type parameter as the type to check.
-  static_assert(IsAnyOfSameAs<unsigned, int, double, int>);  // Uses the last type parameter as the type to check.
-  static_assert(IsAnyOfSameAs<unsigned, double, int, int>);  // Uses the last type parameter as the type to check.
 }
 
 template<typename TestType>
@@ -336,13 +327,13 @@ struct B;
 struct A {
   int a;
 
-  std::weak_ordering operator<=>(B /*unused*/) const = delete;
+  std::weak_ordering operator<=>(const B& /*unused*/) const = delete;
 };
 
 struct B {
   std::string b;
 
-  std::weak_ordering operator<=>(A /*unused*/) const { return std::weak_ordering::equivalent; }
+  std::weak_ordering operator<=>(const A& /*unused*/) const { return std::weak_ordering::equivalent; }
 };
 
 // `A <=> B` is deleted, so it is not supported.
@@ -358,12 +349,16 @@ static_assert(ThreeWayComparableTo<B, A, std::partial_ordering>);
 struct C {
   std::unique_ptr<int> c;
 
-  std::weak_ordering operator<=>(B /*unused*/) const { return std::weak_ordering::equivalent; }
+  std::weak_ordering operator<=>(const B& /*unused*/) const { return std::weak_ordering::equivalent; }
 };
 
 static_assert(!ThreeWayComparableTo<C, B, std::strong_ordering>);
 static_assert(ThreeWayComparableTo<C, B, std::weak_ordering>);
 static_assert(ThreeWayComparableTo<C, B, std::partial_ordering>);
+
+static_assert(!ThreeWayComparableTo<B, C, std::strong_ordering>);
+static_assert(ThreeWayComparableTo<B, C, std::weak_ordering>);
+static_assert(ThreeWayComparableTo<B, C, std::partial_ordering>);
 
 template<ThreeWayComparableTo<B> T>
 struct X {};


### PR DESCRIPTION
* Droped all of (Not|Is)AnyOfSameAs(Raw)? -> In practice too confusing and not truly helpful.
* Added nolint comments.
* Added missing constructor for LimitedMap.
* Added missing IWYU pragma comments.
* Added conversion construction for LimitedSet -> MakeLimitedSetOf.
* Extended Compare*() to correctly handle boolean comparisons.