### PR TITLE
ci: Node 24 actions + tighten trunk vs pre-commit lint ownership

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -7,9 +7,7 @@
       "github": "helly25"
     }
   ],
-  "repository": [
-    "github:helly25/mbo"
-  ],
+  "repository": ["github:helly25/mbo"],
   "versions": [],
   "yanked_versions": {}
 }

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,19 +1,19 @@
 matrix:
   bazel:
-  - 7.x
-  - 8.x
+    - 7.x
+    - 8.x
   platform:
-  - ubuntu2404
-  - macos
+    - ubuntu2404
+    - macos
 tasks:
   verify_targets:
     name: Verify build targets
     platform: ${{ platform }}
     bazel: ${{ bazel }}
     build_flags:
-    - '--cxxopt=-std=c++20'
+      - "--cxxopt=-std=c++20"
     #bazel query 'kind(cc_binary,//...) - rdeps(//mbo/mope:mope,//...)'
     build_targets:
-      - '@helly25_mbo//mbo/container:limited_set_benchmark'
-      - '@helly25_mbo//mbo/diff:diff'
-      - '@helly25_mbo//mbo/file:glob'
+      - "@helly25_mbo//mbo/container:limited_set_benchmark"
+      - "@helly25_mbo//mbo/diff:diff"
+      - "@helly25_mbo//mbo/file:glob"

--- a/.github/workflows/cache_cleanup.yml
+++ b/.github/workflows/cache_cleanup.yml
@@ -4,6 +4,11 @@ on:
     types:
       - closed
 
+# Cache deletion uses secrets.CACHE_ACCESS (a custom PAT), so the default
+# GITHUB_TOKEN does not need write scopes here. Declared explicitly to satisfy
+# checkov CKV2_GHA_1.
+permissions: read-all
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,14 +7,14 @@ jobs:
   trunk:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Trunk Check
         uses: trunk-io/trunk-action@v1
 
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
     tags:
       - "*.*.*"
 
+permissions: read-all
+
 jobs:
   release:
     uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
     runs-on: ${{inputs.os}}
     continue-on-error: ${{inputs.continue-on-error}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: bazelbuild/setup-bazelisk@v3
       - name: Install GCC
         if: ${{inputs.compiler == 'gcc' && inputs.gcc_version != ''}}
@@ -69,7 +69,7 @@ jobs:
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{inputs.gcc_version}} 100 --slave /usr/bin/g++ g++ /usr/bin/g++-${{inputs.gcc_version}} --slave /usr/bin/gcov gcov /usr/bin/gcov-${{inputs.gcc_version}}
           sudo update-alternatives --set gcc /usr/bin/gcc-${{inputs.gcc_version}}
 
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v5
         id: cache_restore
         with:
           path: "~/.cache/bazel"
@@ -138,7 +138,7 @@ jobs:
           bazel "${BAZEL_INIT[@]}" run "${BAZEL_ARGS[@]}" //tools:show_compiler || echo "Cannot determine compiler version!"
           bazel "${BAZEL_INIT[@]}" test "${BAZEL_ARGS[@]}" //...
 
-      - uses: actions/cache/save@v4
+      - uses: actions/cache/save@v5
         if: ${{!startsWith(github.ref, 'refs/tags/')}}
         id: cache_save
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,8 @@
 
 name: Reusable Test Runner
 
+permissions: read-all
+
 on:
   workflow_call:
     inputs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -118,6 +118,10 @@ repos:
     rev: v19.1.6
     hooks:
       - id: clang-format
+        # The default `types_or` for this hook includes `json`, where
+        # clang-format fights with trunk's prettier (multi-line vs single-line
+        # arrays). Restrict to actual C/C++/CUDA sources.
+        types_or: [c, c++, cuda]
 
   - repo: https://github.com/scop/pre-commit-shfmt
     rev: v3.11.0-1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,139 +1,131 @@
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v5.0.0
-  hooks:
-  - id: check-added-large-files
-  - id: check-merge-conflict
-  - id: check-yaml
-  - id: end-of-file-fixer
-    exclude: |
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: end-of-file-fixer
+        exclude: |
           (?x)(
             ^mbo/diff/tests/abc_whitespace.*$|
             ^mbo/diff/tests/numbers_blanks.*|
             .*[.]patch
           )
-  - id: trailing-whitespace
-    exclude: |
+      - id: trailing-whitespace
+        exclude: |
           (?x)(
             ^mbo/diff/tests/abc_whitespace.*$|
             ^mbo/diff/tests/numbers_blanks.*|
             .*[.]patch
           )
 
-- repo: https://github.com/rhysd/actionlint
-  rev: v1.7.7
-  hooks:
-  - id: actionlint
-    name: Lint GitHub Actions workflow files
-    description: Runs actionlint to lint GitHub Actions workflow files
-    language: golang
-    types: ["yaml"]
-    files: ^\.github/workflows/
-    entry: actionlint
-    args: ["-shellcheck", ""]
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.7
+    hooks:
+      - id: actionlint
+        name: Lint GitHub Actions workflow files
+        description: Runs actionlint to lint GitHub Actions workflow files
+        language: golang
+        types: ["yaml"]
+        files: ^\.github/workflows/
+        entry: actionlint
+        args: ["-shellcheck", ""]
 
-- repo: local
-  hooks:
-  - id: mope-uses-external-clang
-    name: mope-uses-external-clang
-    description: |
-      File //mbo/mope/mope.bzl can be configured to find clang-format automatically.
-      However, the repo version must set `_CLANG_FORMAT_BINARY = ""` so that it uses
-      the repo provided version which does not work for Bazel module use.
-    language: pygrep
-    entry: _CLANG_FORMAT_BINARY\s+=\s+"[^"]+"
-    files: mbo/mope/mope.bzl
-  - id: uncomment-bazelmod-includes
-    name: uncomment-bazelmod-includes
-    description: |
-      The repo version of MODULE.bazel may not have commented out includes.
-    language: pygrep
-    entry: \s*#\s*include
-    files: MODULE.bazel
-  - id: bcr-bazelmod-patch-applies
-    name: bcr-bazelmod-patch-applies
-    description: |
-      The patch in .bcr/patches/bazelmod.patch can be applied
-    language: system
-    entry: patch
-    args: ["-p1", "--dry-run", "-fi", ".bcr/patches/bazelmod.patch"]
-    pass_filenames: False
-    types: [text]
-  - id: github-bazelmod-patch-applies
-    name: github-bazelmod-patch-applies
-    description: |
-      The patch in .github/workflows/bazelmod.patch can be applied
-    language: system
-    entry: patch
-    args: ["-p1", "--dry-run", "-fi", ".github/workflows/bazelmod.patch"]
-    pass_filenames: False
-    types: [text]
-  - id: compare-versions
-    name: compare-versions
-    description: |
-      Compare the versions in CHANGELOG.md and MODULES.bazel.
-    language: system
-    entry: .pre-commit/check_version.sh
-    pass_filenames: False
-    types: [text]
-  - id: no-do-not-merge
-    name: No 'DO NOT MERGE'
-    description: |
-      * You can add 'DONOTMERGE', 'DONOTSUBMIT', 'DO NOT MERGE', 'DO NOT SUBMIT', 'DON'T MERGE',
-        'DON'T SUBMIT' or the same with underscores instead of spaces to prevent merging.
-      * To run `pre-commit` without this hook, run `SKIP="no-do-not-merge" pre-commit`.
-    language: pygrep
-    args: [-i]
-    entry: DO([ _]?NOT|N'T)[ _]?(SUBMIT|MERGE)
-    exclude: ^.pre-commit-config.yaml$
-    types: [text]
-  - id: no-todos-without-context
-    name: No TODOs without context
-    description: |
-      * Use descriptive, referenceable TODOs. Examples:
-        * `// TODO(nero.windstriker@helly25.com)`
-        * `# FIXME(https://github.com/helly25/bzl/issues/42)`
-      * From the google style guide:
-        Use FIXME/TODO comments for code that is temporary, a short-term solution.
-        FIXME/TODOs should include the string `FIXME` or `TODO` in all caps, followed by a person's
-        e-mail address, or url with the best context about the problem referenced by the FIXME/TODO.
-      * A bug or other URL reference is better than a person, as the person may become unavailable.
-      * If a developer is referenced then it does not need to be the one writing the FIXME/TODO.
-        * It is more important to note the most knowledgable person.
-        * If you add someone else, first clarify with them.
-      * Concretely, FIXMEs and TODOs without a context are rather pointless. That is, sooner or
-        later noone knows why they were introduced and they will simply get deleted.
-      * It is impossible to systematically find your own TODOs, someone else' or perform any other
-        kind of statictics on them. The issue is that the blame tool tracks the last change, so you
-        would need a tool that can follow the history to the actual introduction of the FIXME/TODOs.
-      * To run `pre-commit` without this hook, run `SKIP="no-todos-without-context" pre-commit`
-    language: pygrep
-    args: [-i]
-    exclude: ^[.]pre-commit-config.yaml$
-    entry: (#|//|/[*]).*(FIXME|TODO)[(](?!(((\w|\w[.-]\w)+@(\w|-)+([.](\w|-)+)*)|(https?://[^)]+))(,[^)]+)?)[)]
-    #      1         1  1          1   1  234           4  4    4 4   5    5 4 3 3              322      2 1
-    types: [text]
+  - repo: local
+    hooks:
+      - id: mope-uses-external-clang
+        name: mope-uses-external-clang
+        description: |
+          File //mbo/mope/mope.bzl can be configured to find clang-format automatically.
+          However, the repo version must set `_CLANG_FORMAT_BINARY = ""` so that it uses
+          the repo provided version which does not work for Bazel module use.
+        language: pygrep
+        entry: _CLANG_FORMAT_BINARY\s+=\s+"[^"]+"
+        files: mbo/mope/mope.bzl
+      - id: uncomment-bazelmod-includes
+        name: uncomment-bazelmod-includes
+        description: |
+          The repo version of MODULE.bazel may not have commented out includes.
+        language: pygrep
+        entry: \s*#\s*include
+        files: MODULE.bazel
+      - id: bcr-bazelmod-patch-applies
+        name: bcr-bazelmod-patch-applies
+        description: |
+          The patch in .bcr/patches/bazelmod.patch can be applied
+        language: system
+        entry: patch
+        args: ["-p1", "--dry-run", "-fi", ".bcr/patches/bazelmod.patch"]
+        pass_filenames: False
+        types: [text]
+      - id: github-bazelmod-patch-applies
+        name: github-bazelmod-patch-applies
+        description: |
+          The patch in .github/workflows/bazelmod.patch can be applied
+        language: system
+        entry: patch
+        args: ["-p1", "--dry-run", "-fi", ".github/workflows/bazelmod.patch"]
+        pass_filenames: False
+        types: [text]
+      - id: compare-versions
+        name: compare-versions
+        description: |
+          Compare the versions in CHANGELOG.md and MODULES.bazel.
+        language: system
+        entry: .pre-commit/check_version.sh
+        pass_filenames: False
+        types: [text]
+      - id: no-do-not-merge
+        name: No 'DO NOT MERGE'
+        description: |
+          * You can add 'DONOTMERGE', 'DONOTSUBMIT', 'DO NOT MERGE', 'DO NOT SUBMIT', 'DON'T MERGE',
+            'DON'T SUBMIT' or the same with underscores instead of spaces to prevent merging.
+          * To run `pre-commit` without this hook, run `SKIP="no-do-not-merge" pre-commit`.
+        language: pygrep
+        args: [-i]
+        entry: DO([ _]?NOT|N'T)[ _]?(SUBMIT|MERGE)
+        exclude: ^.pre-commit-config.yaml$
+        types: [text]
+      - id: no-todos-without-context
+        name: No TODOs without context
+        description: |
+          * Use descriptive, referenceable TODOs. Examples:
+            * `// TODO(nero.windstriker@helly25.com)`
+            * `# FIXME(https://github.com/helly25/bzl/issues/42)`
+          * From the google style guide:
+            Use FIXME/TODO comments for code that is temporary, a short-term solution.
+            FIXME/TODOs should include the string `FIXME` or `TODO` in all caps, followed by a person's
+            e-mail address, or url with the best context about the problem referenced by the FIXME/TODO.
+          * A bug or other URL reference is better than a person, as the person may become unavailable.
+          * If a developer is referenced then it does not need to be the one writing the FIXME/TODO.
+            * It is more important to note the most knowledgable person.
+            * If you add someone else, first clarify with them.
+          * Concretely, FIXMEs and TODOs without a context are rather pointless. That is, sooner or
+            later noone knows why they were introduced and they will simply get deleted.
+          * It is impossible to systematically find your own TODOs, someone else' or perform any other
+            kind of statictics on them. The issue is that the blame tool tracks the last change, so you
+            would need a tool that can follow the history to the actual introduction of the FIXME/TODOs.
+          * To run `pre-commit` without this hook, run `SKIP="no-todos-without-context" pre-commit`
+        language: pygrep
+        args: [-i]
+        exclude: ^[.]pre-commit-config.yaml$
+        entry: (#|//|/[*]).*(FIXME|TODO)[(](?!(((\w|\w[.-]\w)+@(\w|-)+([.](\w|-)+)*)|(https?://[^)]+))(,[^)]+)?)[)]
+        #      1         1  1          1   1  234           4  4    4 4   5    5 4 3 3              322      2 1
+        types: [text]
 
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v19.1.6
+    hooks:
+      - id: clang-format
 
-- repo: https://github.com/keith/pre-commit-buildifier
-  rev: 8.2.0
-  hooks:
-  - id: buildifier
-  - id: buildifier-lint
-    args: ["--warnings=all"]
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: v3.11.0-1
+    hooks:
+      - id: shfmt
+        args: ["-bn", "-ci", "-i=2", "-w"]
 
-- repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v19.1.6
-  hooks:
-  - id: clang-format
-
-- repo: https://github.com/scop/pre-commit-shfmt
-  rev: v3.11.0-1
-  hooks:
-    - id: shfmt
-      args: ["-bn", "-ci", "-i=2", "-w"]
-
-- repo: https://github.com/koalaman/shellcheck-precommit
-  rev: v0.10.0
-  hooks:
-  - id: shellcheck
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: v0.10.0
+    hooks:
+      - id: shellcheck

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,10 @@
+source-path=SCRIPTDIR
+# SC2154 ("referenced but not assigned") fires on env vars injected by the
+# Bazel sh_test runner (BASHTEST_TMPDIR, TEST_SRCDIR, TEST_WORKSPACE,
+# TEST_TMPDIR) and on the GitHub Actions runner (GITHUB_REF_NAME). All
+# legitimately set from outside the script.
+disable=SC2154
+
+# If you're having issues with shellcheck following source, disable the errors via:
+# disable=SC1090
+# disable=SC1091

--- a/.trunk/configs/.shellcheckrc
+++ b/.trunk/configs/.shellcheckrc
@@ -1,7 +1,0 @@
-enable=all
-source-path=SCRIPTDIR
-disable=SC2154
-
-# If you're having issues with shellcheck following source, disable the errors via:
-# disable=SC1090
-# disable=SC1091

--- a/.trunk/configs/.yamllint.yaml
+++ b/.trunk/configs/.yamllint.yaml
@@ -1,7 +1,8 @@
 rules:
-  quoted-strings:
-    required: only-when-needed
-    extra-allowed: ["{|}"]
+  # `quoted-strings: only-when-needed` collides with prettier (which prefers
+  # double quotes for many string values) and creates noise without any
+  # functional difference. Disable it; yamllint's other checks remain.
+  quoted-strings: disable
   empty-values:
     forbid-in-block-mappings: true
     forbid-in-flow-mappings: true

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -48,28 +48,13 @@ lint:
       version_command:
         parse_regex: ${semver}
         run: buildifier --version
-    # Default shfmt config uses -s flag to simplify code but this can cause
-    # unwanted semantic changes
-    - name: shfmt
-      commands:
-        - name: format
-          output: shfmt
-          run: shfmt -w ${target}
-          success_codes: [0, 1]
-          cache_results: true
-          formatter: true
-          batch: true
-          in_place: true
   enabled:
-    - actionlint@1.7.12
     - buildifier@8.5.1
     - checkov@3.2.529
     - clang-tidy@16.0.3
     - git-diff-check
     - markdownlint@0.48.0
     - prettier@3.8.3
-    - shellcheck@0.11.0
-    - shfmt@3.6.0
     - trivy@0.70.0
     - trufflehog@3.95.3
     - yamllint@1.38.0

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -48,6 +48,21 @@ lint:
       version_command:
         parse_regex: ${semver}
         run: buildifier --version
+    # clang-tidy is fundamentally useless without a compile_commands.json. Local
+    # devs generate it via `bazel run @hedron_compile_commands//:refresh_all`;
+    # CI does not. Override the plugin's `run_when` to skip CI so trunk's CI
+    # job doesn't bomb on "<header> file not found".
+    - name: clang-tidy
+      commands:
+        - name: lint
+          output: llvm
+          run: clang-tidy --export-fixes=${tmpfile} ${target} -p ${compile_commands_dir}
+          success_codes: [0, 1]
+          cache_results: true
+          run_from: ${compile_command}
+          read_output_from: tmp_file
+          run_when: [cli, monitor]
+          max_concurrency: 4
   enabled:
     - buildifier@8.5.1
     - checkov@3.2.529

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -17,23 +17,23 @@ diverse, inclusive, and healthy community.
 Examples of behavior that contributes to a positive environment for our
 community include:
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
   and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the
+- Focusing on what is best not just for us as individuals, but for the
   overall community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or
+- The use of sexualized language or imagery, and sexual attention or
   advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
   address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Enforcement Responsibilities
@@ -106,7 +106,7 @@ Violating these terms may lead to a permanent ban.
 ### 4. Permanent Ban
 
 **Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior,  harassment of an
+standards, including sustained inappropriate behavior, harassment of an
 individual, or aggression toward or disparagement of classes of individuals.
 
 **Consequence**: A permanent ban from any sort of public interaction within

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,13 +10,13 @@ All code must adhere to the [RULES.dm](RULES.md) and mostly follows the [Google 
 
 All changes will be verified by the pre-commit rules. In order to check these before committing changes install the tool:
 
-```
+```sh
 pre-commit install
 ```
 
 Once installed the verification can be triggered for all files as follows:
 
-```
+```sh
 pre-commit run -a
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ with [Google's Abseil library](https://abseil.io/).
 
 The library is tested with Clang (16+) and GCC (12+) on Ubuntu and MacOS (arm) using continuous integration: [![Test](https://github.com/helly25/mbo/actions/workflows/main.yml/badge.svg)](https://github.com/helly25/mbo/actions/workflows/main.yml).
 
-## The C++ library is organized in functional groups each residing in their own directory.
+## Library organization
+
+The C++ library is organized in functional groups each residing in their own directory:
 
 - Config
   - `namespace mbo::config`
@@ -261,7 +263,9 @@ The library is tested with Clang (16+) and GCC (12+) on Ubuntu and MacOS (arm) u
     - concept `IsVariantMemberType` determine whether a `Type` is any of the types in a `Variant`.
     - struct `Overloaded` which implements an Overload handler for `std::visit(std::variant<...>)` and `std::variant::visit`.
 
-## In addition some Bazel macros are implemented that are not direct part of the library:
+## Bazel macros not in library
+
+Some additional Bazel macros are implemented that are not direct part of the library:
 
 - bzl:archive.bzl
   - `http_archive`: Simple wrapper that tests whether the archive was already loaded.
@@ -281,7 +285,7 @@ Lint and format are driven by [Trunk](https://docs.trunk.io/cli). Devs are **req
 
 Checkout [Releases](https://github.com/helly25/mbo/releases) or use head ref as follows:
 
-```
+```starlark
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
@@ -295,7 +299,7 @@ http_archive(
 
 Check [Releases](https://github.com/helly25/mbo/releases) for details. All that is needed is a `bazel_dep` instruction with the correct version.
 
-```
+```starlark
 bazel_dep(name = "helly25_mbo", version = "0.0.0")
 ```
 
@@ -315,4 +319,4 @@ Presented at [C++ On Sea 2024](https://cpponsea.uk/2024/session/practical-produc
 Slides are available at:
 <br/>
 <br/>
-[<img src="https://helly25.com/wp-content/uploads/2024/07/Practical-Production-proven-Constexpr-API-Elements_TitleCard-copy-980x551.png">](https://helly25.com/practical-production-proven-constexpr-api-elements/)
+[<img src="https://helly25.com/wp-content/uploads/2024/07/Practical-Production-proven-Constexpr-API-Elements_TitleCard-copy-980x551.png" alt="Practical Production Proven constexpr slides">](https://helly25.com/practical-production-proven-constexpr-api-elements/)

--- a/RULES.md
+++ b/RULES.md
@@ -1,60 +1,62 @@
+# Rules
+
 Some rules for the code layout and its development.
 
-* Everything is under Apache 2 license, see fle `LICENSE`.
-* All sources must be unix-text files: https://en.wikipedia.org/wiki/Text_file
-  * Lines end in {LF}.
-  * The files are either empty or end in {LF}.
-* API changes that are not backwards compatible should not occur in minor version changes.
-* Undocumented and private/internal APIs may be changed in any way at any time.
-* This library uses C++20 and is intended to be compiled with `clang`.
-  * Reasonable effort is performed to ensure compilation with GCC is functional.
-* All (C++) code must be formatted using `clang-format` with '.clang-format'.
-  * This provides consistent formatting.
-  * The choices are meant to enable fast structural reading by humans.
-  * It cares less about writing because there is auto formatting and code is
+- Everything is under Apache 2 license, see fle `LICENSE`.
+- All sources must be unix-text files: https://en.wikipedia.org/wiki/Text_file
+  - Lines end in {LF}.
+  - The files are either empty or end in {LF}.
+- API changes that are not backwards compatible should not occur in minor version changes.
+- Undocumented and private/internal APIs may be changed in any way at any time.
+- This library uses C++20 and is intended to be compiled with `clang`.
+  - Reasonable effort is performed to ensure compilation with GCC is functional.
+- All (C++) code must be formatted using `clang-format` with '.clang-format'.
+  - This provides consistent formatting.
+  - The choices are meant to enable fast structural reading by humans.
+  - It cares less about writing because there is auto formatting and code is
     read much more often then written.
-  * Auto formatting also prevents pointless discussions like where '*' goes.
-  * The guide mostly follows Google style: https://google.github.io/styleguide/
-* All exported library code is in the directory 'mbo'.
-* Directory 'mbo' has no actual library rules, but may have test rules.
-* No namespace may be named 'internal'.
-* Each subdirectory:
-  * has all its code in a namespace: "mbo::{dir}"
-  * there may be functional sub-namespace, e.g.: "mbo::{dir}::{sub}"
-  * internal code goes into special sub-namespace:
-    * Code in these namespace is not allowed to be used outside their library
-    * "mbo::{dir}::{dir}_internal
-    * "mbo::{dir}::{sub}_internal
-    * "mbo::{dir}::{sub}::{sub}_internal
-    * This ensures that "internal" namespace do not conflict.
-    * No namespace component `internal` is otherwise allowed.
-  * Sub namespaces 'detail' are allowed.
-    * Such sub-namespaces imply usable (exported) functionality
-    * "mbo::{dir}::detail
-    * "mbo::{dir}::{sub}::detail
-    * In contrast to internal namespaces the detail namespaces use just "detail"
+  - Auto formatting also prevents pointless discussions like where '\*' goes.
+  - The guide mostly follows Google style: https://google.github.io/styleguide/
+- All exported library code is in the directory 'mbo'.
+- Directory 'mbo' has no actual library rules, but may have test rules.
+- No namespace may be named 'internal'.
+- Each subdirectory:
+  - has all its code in a namespace: "mbo::{dir}"
+  - there may be functional sub-namespace, e.g.: "mbo::{dir}::{sub}"
+  - internal code goes into special sub-namespace:
+    - Code in these namespace is not allowed to be used outside their library
+    - "mbo::{dir}::{dir}\_internal
+    - "mbo::{dir}::{sub}\_internal
+    - "mbo::{dir}::{sub}::{sub}\_internal
+    - This ensures that "internal" namespace do not conflict.
+    - No namespace component `internal` is otherwise allowed.
+  - Sub namespaces 'detail' are allowed.
+    - Such sub-namespaces imply usable (exported) functionality
+    - "mbo::{dir}::detail
+    - "mbo::{dir}::{sub}::detail
+    - In contrast to internal namespaces the detail namespaces use just "detail"
       which can result in namespace conflicts. To avoid that they have to be
       fully qualified.
-* Forward declared symbols must be fully implemented in the same source file.
-  * The exception are 'Impl' classes / structs in a header's class when the
+- Forward declared symbols must be fully implemented in the same source file.
+  - The exception are 'Impl' classes / structs in a header's class when the
     actual implementation is in a name-corresponding implementation file. This
     is useful for visibility and name resolution.
-* All public / exported code must:
-  * be tested,
-  * have a documentaion.
-* All headers must have macro-guards: "{PATH}_{FILE}_". That is path and filename in all caps, with all non alphanumeric chars replaced with '_' and followed by a final '_'.
-  * A '__' betwen {PATH} and {FILE} would be better, but C++ does not allow it.
-  * Filnames may not start with the basename of any directory in their same
+- All public / exported code must:
+  - be tested,
+  - have a documentaion.
+- All headers must have macro-guards: "{PATH}_{FILE}_". That is path and filename in all caps, with all non alphanumeric chars replaced with '_' and followed by a final '_'.
+  - A '\_\_' betwen {PATH} and {FILE} would be better, but C++ does not allow it.
+  - Filnames may not start with the basename of any directory in their same
     directory followed by an '_' as that would lead to conflicting macro guards.
     E.g.: "foo/bar.h" and "foo_bar.h" would have macro guard "FOO_BAR_H_".
-* Macros are to be avoided at all costs, or prefixed by 'MBO_'.
-  * Macros for local application must be undefined as close after the last use
+- Macros are to be avoided at all costs, or prefixed by 'MBO\_'.
+  - Macros for local application must be undefined as close after the last use
     as possible.
-  * Where possible macros should be named "{PATH}_{FILE}_{USECASE}". As a minimum they should have the prefix `MBO_`.
-  * Private macro implementation details should be named "MBO_PRIVATE_{PATH}_{FILE}_{USECASE}_". That is, prefix `MBO_PRIVATE_` followed by all caps path/filename with all non alphanumeric chars replaced with `_`, followed by a final `_`.
-* Use `std::size_t` as `size_t` **ONLY** in CC files with `using std::size_t`.
-* Flags in libraries should be prefixed with their path/namespace. E.g. the flag
+  - Where possible macros should be named "{PATH}_{FILE}_{USECASE}". As a minimum they should have the prefix `MBO_`.
+  - Private macro implementation details should be named "MBO*PRIVATE*{PATH}_{FILE}_{USECASE}_". That is, prefix `MBO_PRIVATE_`followed by all caps path/filename with all non alphanumeric chars replaced with`_`, followed by a final `_`.
+- Use `std::size_t` as `size_t` **ONLY** in CC files with `using std::size_t`.
+- Flags in libraries should be prefixed with their path/namespace. E.g. the flag
   `--mbo_log_timing_min_duration` has the prefix `mbo_log` as it is defined in
   `mbo/log/log_timing.cc` (path `mbo/log`) and uses namespace `mbo::log`.
-* All shell files follow https://google.github.io/styleguide/shellguide.html but use shfmt which diverges slightly.
-  * The common shebang line is `#!/usr/bin/env bash` followed by the license.
+- All shell files follow https://google.github.io/styleguide/shellguide.html but use shfmt which diverges slightly.
+  - The common shebang line is `#!/usr/bin/env bash` followed by the license.


### PR DESCRIPTION
## Summary

Three connected housekeeping changes from a `trunk check -a` sweep on the fresh meta-linter setup.

### 1. Node 24 GHA action bumps

GitHub will force JavaScript actions to Node 24 by default on **2026-06-02** and remove Node 20 from runners on **2026-09-16**. Each CI job was emitting a deprecation warning. Bumped:

- `actions/checkout@v4` → `v6`
- `actions/cache/restore@v4` → `v5`
- `actions/cache/save@v4` → `v5`

`bazelbuild/setup-bazelisk@v3` left as-is — no Node 24 release upstream yet.

### 2. Split trunk vs pre-commit lint ownership

After #180 enabled trunk as a meta-linter, four tools ran in **both** pre-commit and trunk. That caused a real conflict (`shfmt`: pre-commit formats to 2-space indent, trunk reverted to tabs because its custom definition omitted `-i=2`) and noisy duplicate diagnostics elsewhere. Trunk is brand new in this repo; pre-commit had been working — bias toward leaving pre-commit alone unless trunk adds clear value.

| Tool | Owner | Why |
|---|---|---|
| `shfmt` | pre-commit | Project pins `-bn -ci -i=2 -w`; trunk's custom def had only `-w` (→ tabs by default) |
| `actionlint` | pre-commit | Pre-commit pins `-shellcheck ""` to suppress nested shellcheck noise |
| `shellcheck` | pre-commit | `.shellcheckrc` moved from `.trunk/configs/` to repo root so pre-commit auto-discovers it; `enable=all` dropped (would have silently raised strictness); `disable=SC2154` kept and documented |
| `buildifier` | trunk | Trunk's custom def splits `--lint=fix` (formatter) from `--lint=warn` (diagnostic) with a JSON parser; newer version (8.5.1 vs 8.2.0) |
| `check-yaml` / `yamllint` | both | `check-yaml` is a cheap parse-only sanity check; `yamllint` adds style |

Trunk-only (no pre-commit equivalent): `checkov`, `clang-tidy`, `git-diff-check`, `markdownlint`, `prettier`, `trivy`, `trufflehog`, `yamllint`.
Pre-commit-only (no trunk equivalent or custom checks): `check-added-large-files`, `check-merge-conflict`, `check-yaml`, `end-of-file-fixer`, `trailing-whitespace`, and the seven local custom hooks (`mope-*`, `*-patch-applies`, `compare-versions`, `no-do-not-merge`, `no-todos-without-context`). **Pre-commit cannot be dropped** — those local hooks have no portable equivalent.

### 3. Clear `trunk check -a` findings (50 → 0 CI-blocking)

A full-repo trunk scan surfaced 50 findings. Resolved as follows.

**Policy edits:**
- `.trunk/trunk.yaml`: override `clang-tidy`'s `run_when` from `[cli, monitor, ci]` to `[cli, monitor]`. clang-tidy is useless without `compile_commands.json`; local devs generate it via `bazel run @hedron_compile_commands//:refresh_all` but CI does not. Even with a compile DB present, trunk's hermetic `clang-tidy@16.0.3` binary cannot resolve C++ stdlib headers (the install ships only `bin/clang-tidy` + clang-builtin headers, no libc++/libstdc++). Gating to local-only avoids ~20 spurious `"<header> file not found"` diagnostics per CI run.
- `.trunk/configs/.yamllint.yaml`: disable `quoted-strings`. The `only-when-needed` setting collides with prettier (which prefers double quotes for many YAML strings); the rule is purely stylistic. yamllint's other useful checks remain.
- `.github/workflows/{cache_cleanup,release,test}.yml`: declare workflow-level `permissions: read-all` to satisfy checkov `CKV2_GHA_1`. `cache_cleanup` uses `secrets.CACHE_ACCESS` (a custom PAT), so the default `GITHUB_TOKEN` does not need write scopes; `release.yml`'s existing job-level `contents: write` override is preserved.

**Auto-fix sweep (one-time, applied now that trunk owns the relevant formatters):**
- `.bcr/metadata.template.json`, `.bcr/presubmit.yml`: prettier reformatted JSON/YAML.
- `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `README.md`, `RULES.md`: markdownlint fixes (MD040 missing language tags, MD026 trailing punctuation, MD041 top-level heading placement, MD045 image alt text). Two affected headings hand-edited to shorter forms with descriptive text moved to body prose.

### 4. Restrict pre-commit `clang-format` to C/C++/CUDA

After the auto-fix sweep, CI surfaced a new fight: `mirrors-clang-format@v19.1.6`'s default `types_or` includes `json` (clang-format 14+ added JSON support), and pre-commit's clang-format reformatted `.bcr/metadata.template.json` back to multi-line — undoing trunk-prettier's compaction. Override `types_or: [c, c++, cuda]` so JSON stays prettier's job.

## Test plan

- [x] `bazel test //mbo/testing:matchers_test` (covered by parallel #181)
- [x] CI green
- [x] `trunk check -a` reports zero CI-visible findings on this branch (the 25 remaining are clang-tidy diagnostics now gated to local-only)
- [x] Node 20 deprecation warning reduced to only `bazelbuild/setup-bazelisk@v3`

## Out of scope

- `clang-tidy` CI integration. The extractor (`hedron_compile_commands`) itself runs clean — no patches needed. The blocker is that trunk's hermetic clang-tidy binary ships no C++ stdlib; resolving that means either (a) wrapping with the Bazel-built clang-tidy, (b) injecting `--extra-arg=-isysroot=...` per platform, or (c) dropping clang-tidy from trunk entirely. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
