### PR TITLE
chore: pre-commit is the single git-hook entry point, bump hedron pin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -133,3 +133,18 @@ repos:
     rev: v0.10.0
     hooks:
       - id: shellcheck
+
+  # Trunk delegate. The pre-commit framework is this repo's single git-hook
+  # entry point; `trunk fmt` is invoked here so devs only ever need to run
+  # `pre-commit install` once. trunk's own `trunk-fmt-pre-commit` action is
+  # disabled in .trunk/trunk.yaml to avoid double-installing the git hook.
+  - repo: local
+    hooks:
+      - id: trunk-fmt
+        name: trunk fmt
+        description: Apply trunk-owned formatters (prettier, buildifier, …)
+        language: system
+        entry: trunk fmt --no-progress
+        pass_filenames: true
+        require_serial: true
+        types_or: [text]

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -76,6 +76,13 @@ lint:
 actions:
   enabled:
     - trunk-announce
+    - trunk-upgrade-available
+  # `trunk-fmt-pre-commit` and `trunk-check-pre-push` install their own
+  # `.git/hooks/{pre-commit,pre-push}` scripts, which conflicts with
+  # `pre-commit install` (last installer wins). The pre-commit framework is
+  # this repo's single entry point — it owns the git hook and delegates to
+  # trunk via a `local` hook in .pre-commit-config.yaml. Devs run
+  # `pre-commit install` once; CI runs both jobs independently.
+  disabled:
     - trunk-check-pre-push
     - trunk-fmt-pre-commit
-    - trunk-upgrade-available

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ The project only comes with a Bazel BUILD.bazel file and can be added to other B
 
 The project is formatted with specific clang-format settings which require clang 16+ (in case of MacOs LLVM 16+ can be installed using brew). For simplicity in dev mode the project pulls the appropriate clang tools and can be compiled with those tools using `bazel [build|test] --config=clang ...`.
 
-Lint and format are driven by [Trunk](https://docs.trunk.io/cli). Devs are **required** to install the CLI locally — `curl https://get.trunk.io -fsSL | bash` — then run `trunk check` and `trunk fmt` before pushing. The repo enables `trunk-fmt-pre-commit` and `trunk-check-pre-push` so the hooks run automatically once installed. CI runs `trunk check` only (no auto-fixing on the GitHub side); failing lint must be fixed locally and re-pushed.
+Lint and format are driven by [Trunk](https://docs.trunk.io/cli) plus [pre-commit](https://pre-commit.com). Devs are **required** to install both — `curl https://get.trunk.io -fsSL | bash` and `pip install pre-commit` (or your package manager's equivalent) — then run `pre-commit install` once. The pre-commit framework is this repo's single git-hook entry point and delegates `trunk fmt` to trunk on every commit. CI runs both `pre-commit` and `trunk check` jobs; failing lint must be fixed locally and re-pushed.
 
 ### WORKSPACE
 

--- a/bazelmod/dev.MODULE.bazel
+++ b/bazelmod/dev.MODULE.bazel
@@ -18,7 +18,7 @@
 bazel_dep(name = "hedron_compile_commands", dev_dependency = True)
 git_override(
     module_name = "hedron_compile_commands",
-    commit = "6f0f6e4f8c6722316e2e48ba50c157a6a3c3404b",
+    commit = "abb61a688167623088f8768cc9264798df6a9d10",
     remote = "https://github.com/hedronvision/bazel-compile-commands-extractor.git",
 )
 


### PR DESCRIPTION
## Summary

Two related cleanups from the #182 retrospective.

### 1. Single git-hook entry point

Today both `pre-commit install` and `trunk actions install` write to `.git/hooks/pre-commit` and `.git/hooks/pre-push` — **last installer wins, silently**. Devs running both end up with one tool's hook disabled at random.

Resolution:

- Move trunk's `trunk-fmt-pre-commit` and `trunk-check-pre-push` from `actions.enabled` to `actions.disabled` in `.trunk/trunk.yaml`.
- Add a single `trunk fmt` delegate as a `local` hook in `.pre-commit-config.yaml`.
- pre-commit owns the git hook; devs run `pre-commit install` once and trunk's formatters fire on every commit through the delegate.
- CI's two jobs (`pre-commit` + `trunk`) are unchanged; both still run independently.

README's dev-setup paragraph updated to match.

### 2. Bump `hedron_compile_commands` pin

`bazelmod/dev.MODULE.bazel` was pinned at `6f0f6e4f` (Apr 2024). Bump to `abb61a68` (Aug 2025), which is current upstream `main` HEAD. The two intervening commits are pre-commit autoupdate merges only — no behavior change — but the pin should not drift further.

## Test plan

- [ ] CI green
- [ ] After this lands, run `pre-commit install` once locally; `git commit` triggers `trunk fmt` via the new local hook without any `trunk actions install` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)