### PR TITLE
ci: harden `done` job into a real aggregating gate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,9 +112,59 @@ jobs:
       llvm_version: ${{ matrix.llvm_version }}
       bazel_config: ${{ matrix.bazel_config }}
 
+  # Single aggregating gate for branch protection. It depends on every job that
+  # must pass, so "done" is the only status check that needs to be marked
+  # "required" on the main branch -- adding or renaming a job above no longer
+  # means editing branch protection, only this job's `needs` list. When any
+  # dependency fails or is cancelled, this job fails and names the offending
+  # jobs in its log and in the run summary.
   done:
     needs: [trunk, pre-commit, test-gcc, test-clang, test-bcr]
+    if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Done
-        run: echo "Done"
+      - uses: actions/checkout@v6
+      - name: Ensure every job is wired into this gate
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          # Parse the workflow with a real YAML reader (yq) and fail if any
+          # declared job (other than this gate) is absent from `needs` above, so
+          # a newly added job cannot silently escape the required gate.
+          declared="$(yq '.jobs | keys | .[]' .github/workflows/main.yml |
+            grep -vx done | sort)"
+          wired="$(jq -r 'keys[]' <<<"${NEEDS_JSON}" | sort)"
+          missing="$(comm -23 <(printf '%s\n' "${declared}") <(printf '%s\n' "${wired}"))"
+          if [[ -n "${missing}" ]]; then
+            echo "Jobs declared in the workflow but missing from done.needs:"
+            while read -r job; do
+              echo "  - ${job}"
+              echo "::error title=Gate is missing a job::${job} not in done.needs"
+            done <<<"${missing}"
+            exit 1
+          fi
+          echo "done covers all $(grep -c . <<<"${declared}") workflow jobs."
+      - name: Verify required jobs succeeded
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          {
+            echo "| Required job | Result |"
+            echo "| --- | --- |"
+            jq -r 'to_entries[] | "| \(.key) | \(.value.result) |"' <<<"${NEEDS_JSON}"
+          } >>"${GITHUB_STEP_SUMMARY}"
+
+          failed="$(jq -r 'to_entries[]
+            | select(.value.result != "success" and .value.result != "skipped")
+            | .key' <<<"${NEEDS_JSON}")"
+
+          if [[ -n "${failed}" ]]; then
+            echo "The following required jobs did not succeed:"
+            while read -r job; do
+              echo "  - ${job}"
+              echo "::error title=Required job failed::${job} did not succeed"
+            done <<<"${failed}"
+            exit 1
+          fi
+
+          echo "All required jobs succeeded."


### PR DESCRIPTION
## Summary

The `done` job was a no-op `echo "Done"`. Without `if: always()`, GitHub *skips* it whenever a dependency fails — so branch protection requiring only `done` would pass on a job that never actually ran.

Apply the principle from [bazel-contrib/toolchains_llvm#757](https://github.com/bazel-contrib/toolchains_llvm/pull/757): keep one required status check, but make it actually gate things.

## Behaviour

- `if: always()` so the gate runs on every outcome (success, failure, cancelled).
- Reads `toJSON(needs)` via an env var (not script interpolation — avoids injection), writes a Job → Result table to the run summary, treats `success`/`skipped` as passing, and fails with `::error::` annotations naming each non-passing dep.
- A first step uses `yq` to verify every job declared in `.github/workflows/main.yml` (other than `done` itself) is wired into `needs:`, so a newly added job cannot silently escape the gate.

Branch protection on `main` already targets `done`, so no settings change is required after merge.

## Test plan

- [x] CI passes on this PR (`done` reports green).
- [x] Locally verified `yq '.jobs | keys | .[]'` returns exactly the 5 jobs currently in `needs`.
- [ ] (Manual, if desired) temporarily add a no-op job without wiring it into `needs` and confirm `done` fails with a "Gate is missing a job" annotation.