### PR TITLE
Verify macOS clang+asan via toolchains_llvm #767 (@loader_path rpath fix)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,10 +93,12 @@ jobs:
         llvm_version: [20.1.8, 21.1.8, 22.1.7]
         bazel_config: [asan, cpp23, fastbuild, opt]
         exclude:
-          # macOS + clang + asan is deferred to a follow-up: the asan runtime
-          # needs LLVM >= 22.1.7 (20.1.8's compiler-rt hangs in
-          # FindDynamicShadowStart on macOS 26) plus absolute toolchain paths.
+          # macOS asan works via toolchains_llvm's @loader_path rpath fix for the
+          # sanitizer runtime dylib (helly25 fork; upstream PR #767), on LLVM
+          # 22.1.7. 20.1.8 still hangs in compiler-rt FindDynamicShadowStart on
+          # macOS 26, so exclude only that combo; macOS asan rides the 22.1.7 rung.
           - os: macos-26
+            llvm_version: 20.1.8
             bazel_config: asan
           # 20.1.8 is the default pin -> full config coverage
           # 21.1.8 less coverage, just check opt

--- a/bazelmod/llvm.MODULE.bazel
+++ b/bazelmod/llvm.MODULE.bazel
@@ -17,15 +17,14 @@
 
 bazel_dep(name = "toolchains_llvm", version = "1.7.0")
 
-# Pin to the helly25 fork carrying the macOS sanitizer-runtime rpath fix
-# (upstream PR bazel-contrib/toolchains_llvm#767): asan's
-# `@rpath/libclang_rt...dylib` becomes loadable at test runtime via an
-# `@loader_path` rpath, so macOS asan works without `absolute_paths`. Drop once
-# #767 lands in a release. (Also pulls the post-1.7.0 changes up to #765.)
+# Pin to the upstream commit where PR bazel-contrib/toolchains_llvm#769 merged
+# (macOS sanitizer runtime via `dynamic_runtime_lib` + `@loader_path` rpath;
+# fixes #192): asan's `@rpath/libclang_rt...dylib` loads at test runtime without
+# `absolute_paths`. Drop once a toolchains_llvm release includes it.
 git_override(
     module_name = "toolchains_llvm",
-    commit = "8f690ce3c1c062cc2464678a75db3e6305bee14e",
-    remote = "https://github.com/helly25/toolchains_llvm.git",
+    commit = "ef8f9fd48593407f8ba76082a73913c0356ff595",
+    remote = "https://github.com/bazel-contrib/toolchains_llvm.git",
 )
 
 llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm", dev_dependency = True)

--- a/bazelmod/llvm.MODULE.bazel
+++ b/bazelmod/llvm.MODULE.bazel
@@ -17,6 +17,17 @@
 
 bazel_dep(name = "toolchains_llvm", version = "1.7.0")
 
+# Pin to the helly25 fork carrying the macOS sanitizer-runtime rpath fix
+# (upstream PR bazel-contrib/toolchains_llvm#767): asan's
+# `@rpath/libclang_rt...dylib` becomes loadable at test runtime via an
+# `@loader_path` rpath, so macOS asan works without `absolute_paths`. Drop once
+# #767 lands in a release. (Also pulls the post-1.7.0 changes up to #765.)
+git_override(
+    module_name = "toolchains_llvm",
+    commit = "8f690ce3c1c062cc2464678a75db3e6305bee14e",
+    remote = "https://github.com/helly25/toolchains_llvm.git",
+)
+
 llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm", dev_dependency = True)
 llvm.toolchain(
     name = "llvm_toolchain_llvm",

--- a/bazelmod/llvm.MODULE.bazel
+++ b/bazelmod/llvm.MODULE.bazel
@@ -15,17 +15,7 @@
 
 """LLVM toolchain."""
 
-bazel_dep(name = "toolchains_llvm", version = "1.7.0")
-
-# Pin to the upstream commit where PR bazel-contrib/toolchains_llvm#769 merged
-# (macOS sanitizer runtime via `dynamic_runtime_lib` + `@loader_path` rpath;
-# fixes #192): asan's `@rpath/libclang_rt...dylib` loads at test runtime without
-# `absolute_paths`. Drop once a toolchains_llvm release includes it.
-git_override(
-    module_name = "toolchains_llvm",
-    commit = "ef8f9fd48593407f8ba76082a73913c0356ff595",
-    remote = "https://github.com/bazel-contrib/toolchains_llvm.git",
-)
+bazel_dep(name = "toolchains_llvm", version = "1.8.0")
 
 llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm", dev_dependency = True)
 llvm.toolchain(


### PR DESCRIPTION
Verifies in CI that macOS `clang` + `asan` works on Apple Silicon, using the sanitizer-runtime rpath fix from upstream PR [bazel-contrib/toolchains_llvm#769](https://github.com/bazel-contrib/toolchains_llvm/pull/769) — now shipped in **toolchains_llvm 1.8.0**.

## Changes
- **`bazelmod/llvm.MODULE.bazel`**: bump `toolchains_llvm` to **1.8.0** (BCR). It carries #769, which gives the sanitizer runtime dylib an `@loader_path`-relative `LC_RPATH` (via `dynamic_runtime_lib`), so `@rpath/libclang_rt.asan_osx_dynamic.dylib` resolves at test runtime — fixing the macOS asan "Library not loaded" dyld error without `absolute_paths` (which broke sandboxed builds) or data deps. No `git_override` needed.
- **`.github/workflows/main.yml`**: re-enable macOS asan in `test-clang` on the **22.1.7** rung; exclude only `macos-26 + 20.1.8 + asan` (20.1.8's compiler-rt hangs in `FindDynamicShadowStart` on macOS 26 — a separate LLVM-20 bug, fixed in 22.1.7).

Default LLVM pin stays **20.1.8** (the supported floor); `absolute_paths` is not used, so the earlier broad clang-CI breakage does not recur.

## Local verification (macOS 26 / Apple Silicon)
- Full `//mbo/...` AddressSanitizer suite **74/74 pass** on 22.1.7 with the fix.
- Re-confirmed against the released **1.8.0** (no override): macOS clang+asan green on the 22.1.7 rung.
- Confirmed **21.1.8 does not** fix the hang (still times out at 300s), so 22.1.7 stays the asan rung and 20.1.8 stays the floor.

Includes a merge of latest `main` (#189).