### PR TITLE
ci: add self-check to `done` gate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,14 +118,32 @@ jobs:
       llvm_version: ${{ matrix.llvm_version }}
       bazel_config: ${{ matrix.bazel_config }}
 
-  # Single aggregating gate for branch protection: mark only "done" as required.
-  # `if: always()` runs it even when a dependency fails/cancels; it then fails if
-  # any dependency did not succeed. Keep `needs` in sync with the jobs above.
   done:
-    if: always()
     needs: [trunk, pre-commit, test-gcc, test-clang, test-bcr]
+    if: always()
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+      - name: Ensure every job is wired into this gate
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          # Parse the workflow with a real YAML reader (yq) and fail if any
+          # declared job (other than this gate) is absent from `needs` above, so
+          # a newly added job cannot silently escape the required gate.
+          declared="$(yq '.jobs | keys | .[]' .github/workflows/main.yml |
+            grep -vx done | sort)"
+          wired="$(jq -r 'keys[]' <<<"${NEEDS_JSON}" | sort)"
+          missing="$(comm -23 <(printf '%s\n' "${declared}") <(printf '%s\n' "${wired}"))"
+          if [[ -n "${missing}" ]]; then
+            echo "Jobs declared in the workflow but missing from done.needs:"
+            while read -r job; do
+              echo "  - ${job}"
+              echo "::error title=Gate is missing a job::${job} not in done.needs"
+            done <<<"${missing}"
+            exit 1
+          fi
+          echo "done covers all $(grep -c . <<<"${declared}") workflow jobs."
       - name: Fail if any dependency did not succeed
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: exit 1


### PR DESCRIPTION
The current \`done\` job aggregates failures via \`contains(needs.*.result, 'failure')\` but has one gap: a newly added job that someone forgets to add to \`needs:\` silently escapes the gate. The required-check setting on branch protection still passes because \`done\` only sees the jobs it lists.

Adds a yq-based self-check copied from [helly25/bzl](https://github.com/helly25/bzl/blob/main/.github/workflows/main.yml): parses the workflow, enumerates every declared job, fails if any (other than \`done\` itself) is absent from \`done.needs\`.

Failure aggregation stays as the existing 1-line \`contains()\` guard — GitHub's Actions UI already shows the per-job results, so the elaborate result-table version originally in bzl wasn't carrying its weight.

\`needs:\` list unchanged: trunk, pre-commit, test-gcc, test-clang, test-bcr.

Part of a batch syncing the gate across helly25 repos. coderef gets a parallel simplification PR; bashtest / proto / vscode-iwyu / mbo-tools get the same treatment.