### PR TITLE
feat(testing): allow StatusIs() to accept a status-code matcher

### DIFF
--- a/mbo/testing/status.h
+++ b/mbo/testing/status.h
@@ -132,24 +132,46 @@ class IsOkAndHoldsMatcher {
   const InnerMatcher inner_matcher_;
 };
 
-// Implements a status matcher interface to verify a status error code, and
-// error message if set, matches an expected value.
+// `StatusCode` is implicitly convertible from `int` and `absl::StatusCode` so
+// that `StatusIs()` accepts either a literal status code or a gMock matcher over
+// status codes (e.g. `StatusIs(AnyOf(kUnknown, kCancelled))`). Adapted from
+// Abseil's `absl::status_internal::StatusCode`.
+class StatusCode {
+ public:
+  StatusCode(int code) : code_(static_cast<absl::StatusCode>(code)) {}  // NOLINT
+
+  StatusCode(absl::StatusCode code) : code_(code) {}  // NOLINT
+
+  explicit operator int() const { return static_cast<int>(code_); }
+
+  friend bool operator==(const StatusCode& lhs, const StatusCode& rhs) { return lhs.code_ == rhs.code_; }
+
+  friend bool operator!=(const StatusCode& lhs, const StatusCode& rhs) { return lhs.code_ != rhs.code_; }
+
+  friend void PrintTo(const StatusCode& code, std::ostream* os) { *os << absl::StatusCodeToString(code.code_); }
+
+ private:
+  absl::StatusCode code_;
+};
+
+// Implements a status matcher interface to verify that a status code (matched
+// against an `absl::StatusCode` or a code matcher) and the error message (if
+// set) match expected values.
 //
 // Sample usage:
-//   EXPECT_THAT(MyCall(), StatusIs(absl::StatusCode::kNotFound,
-//                                  HasSubstr("message")));
-//
-// Sample output on failure:
-//   Value of: MyCall()
-//   Expected: NOT_FOUND and has substring "message"
-//     Actual: UNKNOWN: descriptive error (of type absl::lts_2020_02_25::Status)
+//   EXPECT_THAT(MyCall(), StatusIs(absl::StatusCode::kNotFound, HasSubstr("message")));
+//   EXPECT_THAT(MyCall(), StatusIs(AnyOf(absl::StatusCode::kNotFound, absl::StatusCode::kUnavailable)));
 class StatusIsMatcher {
  public:
-  StatusIsMatcher(const absl::StatusCode& status_code, const ::testing::Matcher<const std::string&>& message_matcher)
-      : status_code_(status_code), message_matcher_(message_matcher) {}
+  template<typename StatusCodeMatcher, typename MessageMatcher>
+  StatusIsMatcher(StatusCodeMatcher&& code_matcher, MessageMatcher&& message_matcher)
+      : code_matcher_(::testing::MatcherCast<StatusCode>(std::forward<StatusCodeMatcher>(code_matcher))),
+        message_matcher_(::testing::MatcherCast<const std::string&>(std::forward<MessageMatcher>(message_matcher))) {}
 
   void DescribeTo(std::ostream* os) const {
-    *os << status_code_ << " and the message ";
+    *os << "has a status code that ";
+    code_matcher_.DescribeTo(os);
+    *os << ", and has an error message that ";
     message_matcher_.DescribeTo(os);
   }
 
@@ -162,36 +184,26 @@ class StatusIsMatcher {
   template<typename StatusType>
   bool MatchAndExplain(const StatusType& actual, ::testing::MatchResultListener* listener) const {
     const absl::Status& actual_status = ::mbo::status::GetStatus(actual);
-    const bool code_match = actual_status.code() == status_code_;
-    if (status_code_ == absl::StatusCode::kOk && code_match) {
-      return true;
+    const bool code_match = code_matcher_.Matches(StatusCode{actual_status.code()});
+    if (actual_status.code() == absl::StatusCode::kOk && code_match) {
+      return true;  // An OK status carries no message; ignore the message matcher.
     }
     ::testing::StringMatchResultListener inner;
     const bool message_match = message_matcher_.MatchAndExplain(std::string{actual_status.message()}, &inner);
     if (code_match && message_match) {
       return true;
     }
-    if (code_match) {
-      *listener << "which has matching status " << actual_status.code();
-    } else {
-      *listener << "which has status " << actual_status.code() << " that isn't " << status_code_;
-    }
+    *listener << "which has status code " << actual_status.code();
     if (actual_status.code() != absl::StatusCode::kOk) {
       *listener << " and ";
       if (message_match) {
-        *listener << "has a matching message";
+        *listener << "a matching message";
+      } else if (actual_status.message().empty()) {
+        *listener << "an empty message";
       } else {
-        *listener << "has message ";
-        if (actual_status.message().empty()) {
-          *listener << " an empty message ";
-        } else {
-          *listener << "'" << actual_status.message() << "' ";
-        }
-        *listener << "which does not match";
-        if (inner.str().empty()) {
-          *listener << " the expected empty message";
-        } else {
-          *listener << " '" << inner.str() << "'";
+        *listener << "the message '" << actual_status.message() << "'";
+        if (!inner.str().empty()) {
+          *listener << " (" << inner.str() << ")";
         }
       }
     }
@@ -199,7 +211,7 @@ class StatusIsMatcher {
   }
 
  private:
-  const absl::StatusCode status_code_;
+  const ::testing::Matcher<StatusCode> code_matcher_;
   const ::testing::Matcher<const std::string&> message_matcher_;
 };
 
@@ -365,18 +377,22 @@ testing_internal::IsOkAndHoldsMatcher<typename std::decay<InnerMatcher>::type> I
       std::forward<InnerMatcher>(inner_matcher));
 }
 
-// Status matcher that checks the StatusCode for an expected value.
-inline ::testing::PolymorphicMatcher<testing_internal::StatusIsMatcher> StatusIs(const absl::StatusCode& code) {
-  return ::testing::MakePolymorphicMatcher(testing_internal::StatusIsMatcher(code, ::testing::_));
+// Status matcher that checks the status code against `code_matcher`, which may be
+// a literal `absl::StatusCode` or a gMock matcher over status codes.
+template<typename StatusCodeMatcher>
+::testing::PolymorphicMatcher<testing_internal::StatusIsMatcher> StatusIs(StatusCodeMatcher&& code_matcher) {
+  return ::testing::MakePolymorphicMatcher(
+      testing_internal::StatusIsMatcher(std::forward<StatusCodeMatcher>(code_matcher), ::testing::_));
 }
 
-// Status matcher that checks the StatusCode and message for expected values.
-template<typename MessageMatcher>
+// Status matcher that checks both the status code (literal or matcher) and the
+// message against the given matchers.
+template<typename StatusCodeMatcher, typename MessageMatcher>
 ::testing::PolymorphicMatcher<testing_internal::StatusIsMatcher> StatusIs(
-    const absl::StatusCode& code,
-    const MessageMatcher& message_matcher) {
-  return ::testing::MakePolymorphicMatcher(
-      testing_internal::StatusIsMatcher(code, ::testing::MatcherCast<const std::string&>(message_matcher)));
+    StatusCodeMatcher&& code_matcher,
+    MessageMatcher&& message_matcher) {
+  return ::testing::MakePolymorphicMatcher(testing_internal::StatusIsMatcher(
+      std::forward<StatusCodeMatcher>(code_matcher), std::forward<MessageMatcher>(message_matcher)));
 }
 
 // Returns a gMock matcher that matches a Status/StatusOr<> whose status is NOT

--- a/mbo/testing/status_test.cc
+++ b/mbo/testing/status_test.cc
@@ -38,11 +38,13 @@ using ::mbo::testing::testing_internal::IsOkAndHoldsMatcher;
 using ::mbo::testing::testing_internal::IsOkMatcher;
 using ::mbo::testing::testing_internal::StatusIsMatcher;
 using ::testing::_;
+using ::testing::AnyOf;
 using ::testing::ElementsAre;
 using ::testing::Ge;
 using ::testing::HasSubstr;
 using ::testing::IsEmpty;
 using ::testing::Key;
+using ::testing::Ne;
 using ::testing::Not;
 using ::testing::Pair;
 using ::testing::SizeIs;
@@ -115,54 +117,75 @@ TEST_F(StatusMatcherTest, StatusIs) {
 
   {
     const StatusIsMatcher matcher(absl::StatusCode::kOk, "x");
-    EXPECT_THAT(Describe(matcher), "OK and the message is equal to \"x\"");
-    EXPECT_THAT(DescribeNegation(matcher), "not (OK and the message is equal to \"x\")");
+    EXPECT_THAT(
+        Describe(matcher), "has a status code that is equal to OK, and has an error message that is equal to \"x\"");
+    EXPECT_THAT(
+        DescribeNegation(matcher),
+        "not (has a status code that is equal to OK, and has an error message that is equal to \"x\")");
     EXPECT_THAT(MatchAndExplain(matcher, absl::OkStatus()), Pair(true, "")) << "Must ignore status message if Ok";
   }
   {
     const StatusIsMatcher matcher(absl::StatusCode::kOk, "");
-    EXPECT_THAT(Describe(matcher), "OK and the message is equal to \"\"");
-    EXPECT_THAT(DescribeNegation(matcher), "not (OK and the message is equal to \"\")");
+    EXPECT_THAT(
+        Describe(matcher), "has a status code that is equal to OK, and has an error message that is equal to \"\"");
+    EXPECT_THAT(
+        DescribeNegation(matcher),
+        "not (has a status code that is equal to OK, and has an error message that is equal to \"\")");
     EXPECT_THAT(
         MatchAndExplain(matcher, absl::UnknownError("")),
-        Pair(
-            false,
-            "which has status UNKNOWN that isn't OK and has a matching "
-            "message"));
+        Pair(false, "which has status code UNKNOWN and a matching message"));
     EXPECT_THAT(
         MatchAndExplain(matcher, absl::UnknownError("Message")),
-        Pair(
-            false,
-            "which has status UNKNOWN that isn't OK and has message 'Message' which does not match the expected empty "
-            "message"));
+        Pair(false, "which has status code UNKNOWN and the message 'Message'"));
   }
   {
     const StatusIsMatcher matcher(absl::StatusCode::kCancelled, "Wanted");
-    EXPECT_THAT(Describe(matcher), "CANCELLED and the message is equal to \"Wanted\"");
-    EXPECT_THAT(DescribeNegation(matcher), "not (CANCELLED and the message is equal to \"Wanted\")");
-    EXPECT_THAT(MatchAndExplain(matcher, absl::OkStatus()), Pair(false, "which has status OK that isn't CANCELLED"));
     EXPECT_THAT(
-        MatchAndExplain(matcher, absl::AbortedError("Wanted")), Pair(
-                                                                    false,
-                                                                    "which has status ABORTED that isn't CANCELLED "
-                                                                    "and has a matching message"));
+        Describe(matcher),
+        "has a status code that is equal to CANCELLED, and has an error message that is equal to \"Wanted\"");
+    EXPECT_THAT(
+        DescribeNegation(matcher),
+        "not (has a status code that is equal to CANCELLED, and has an error message that is equal to \"Wanted\")");
+    EXPECT_THAT(MatchAndExplain(matcher, absl::OkStatus()), Pair(false, "which has status code OK"));
+    EXPECT_THAT(
+        MatchAndExplain(matcher, absl::AbortedError("Wanted")),
+        Pair(false, "which has status code ABORTED and a matching message"));
     EXPECT_THAT(
         MatchAndExplain(matcher, absl::CancelledError("Message")),
-        Pair(
-            false,
-            "which has matching status CANCELLED "
-            "and has message 'Message' which does not match the expected empty message"));
+        Pair(false, "which has status code CANCELLED and the message 'Message'"));
   }
   {
     const StatusIsMatcher matcher(absl::StatusCode::kDataLoss, IsEmpty());
-    EXPECT_THAT(Describe(matcher), "DATA_LOSS and the message is empty");
-    EXPECT_THAT(DescribeNegation(matcher), "not (DATA_LOSS and the message is empty)");
+    EXPECT_THAT(
+        Describe(matcher), "has a status code that is equal to DATA_LOSS, and has an error message that is empty");
+    EXPECT_THAT(
+        DescribeNegation(matcher),
+        "not (has a status code that is equal to DATA_LOSS, and has an error message that is empty)");
     EXPECT_THAT(
         MatchAndExplain(matcher, absl::DataLossError("Message")),
-        Pair(
-            false,
-            "which has matching status DATA_LOSS "
-            "and has message 'Message' which does not match 'whose size is 7'"));
+        Pair(false, "which has status code DATA_LOSS and the message 'Message' (whose size is 7)"));
+  }
+}
+
+TEST_F(StatusMatcherTest, StatusIsWithCodeMatcher) {
+  // The status code argument may be a gMock matcher, not just a literal code.
+  EXPECT_THAT(absl::NotFoundError("nope"), StatusIs(absl::StatusCode::kNotFound));  // literal still works
+  EXPECT_THAT(
+      absl::NotFoundError("nope"), StatusIs(AnyOf(absl::StatusCode::kNotFound, absl::StatusCode::kUnavailable)));
+  EXPECT_THAT(absl::AbortedError("x"), StatusIs(Ne(absl::StatusCode::kOk)));
+  EXPECT_THAT(absl::OkStatus(), Not(StatusIs(Ne(absl::StatusCode::kOk))));
+  EXPECT_THAT(absl::AbortedError("boom"), StatusIs(Ne(absl::StatusCode::kOk), HasSubstr("boom")));
+
+  absl::StatusOr<int> status_or = absl::UnavailableError("down");
+  EXPECT_THAT(status_or, StatusIs(AnyOf(absl::StatusCode::kUnavailable, absl::StatusCode::kDeadlineExceeded)));
+  EXPECT_THAT(status_or, Not(StatusIs(absl::StatusCode::kNotFound)));
+
+  {
+    const StatusIsMatcher matcher(Ne(absl::StatusCode::kOk), _);
+    EXPECT_THAT(
+        Describe(matcher), "has a status code that isn't equal to OK, and has an error message that is anything");
+    EXPECT_THAT(MatchAndExplain(matcher, absl::OkStatus()), Pair(false, "which has status code OK"));
+    EXPECT_THAT(MatchAndExplain(matcher, absl::AbortedError("x")), Pair(true, ""));
   }
 }
 


### PR DESCRIPTION
## What

`mbo::testing::StatusIs()` accepted only a **literal** `absl::StatusCode` for its code argument. This widens it so the code argument may also be a gMock **matcher**:

```cpp
EXPECT_THAT(call(), StatusIs(AnyOf(absl::StatusCode::kNotFound, absl::StatusCode::kUnavailable)));
EXPECT_THAT(call(), StatusIs(Ne(absl::StatusCode::kOk), HasSubstr("boom")));
```

This brings `StatusIs()` to parity with Abseil's `absl_testing::StatusIs` — the one axis on which Abseil's matcher was ahead of mbo's.

## How

- Add a small `StatusCode` bridge in `testing_internal` (implicitly convertible from `int` and `absl::StatusCode`) so `::testing::MatcherCast<StatusCode>` accepts either a literal code or a matcher. Adapted from `absl::status_internal::StatusCode`.
- `StatusIsMatcher` now stores a `::testing::Matcher<StatusCode>`; its constructor and both `StatusIs()` factories are templated and `MatcherCast` the code argument.
- `MatchAndExplain` stays templated on the status type, so `StatusIs()` keeps matching **any type convertible to `absl::Status`** via `mbo::status::GetStatus` — the generality a plain forward to Abseil's matchers would have dropped.

## Compatibility

- A literal `absl::StatusCode` still works (casts to `Eq(...)`).
- The "ignore the message when the status is OK" behavior is preserved.
- Matcher `DescribeTo` / explanation output now reads "has a status code that <code matcher>, and has an error message that <message matcher>"; golden-string assertions in `status_test.cc` are updated to match, and a new `StatusIsWithCodeMatcher` test is added.

## Test plan

- `bazel test //mbo/testing:status_test` — green.
- `bazel build //mbo/...` — all 175 targets compile.
- `bazel test //mbo/testing/... //mbo/status/...` — green.