### PR TITLE
ci: auto-publish releases to the BCR via reusable workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,6 +15,11 @@ on:
         required: true
   workflow_dispatch: {}
 
+# Deny all by default at the workflow level (checkov CKV2_GHA_1); the publish
+# job opts into contents:write. Empty (not read-all) so this reusable workflow
+# doesn't force the caller to grant every read scope.
+permissions: {}
+
 jobs:
   publish:
     permissions:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,35 @@
+# Publish a new release to the Bazel Central Registry (BCR).
+#
+# Called by release.yml after a release is cut. Can also be run manually from
+# the Actions UI ("Run workflow") against a release tag to retry a failed run.
+name: Publish to BCR
+
+on:
+  workflow_call:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+    secrets:
+      BCR_PUBLISH_TOKEN:
+        required: true
+  workflow_dispatch: {}
+
+jobs:
+  publish:
+    permissions:
+      contents: write
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.4.1
+    with:
+      tag_name: ${{ inputs.tag_name || github.ref_name }}
+      registry_fork: helly25/bazel-central-registry
+      # Personal-account PAT: open a draft PR so the author can click "Ready for
+      # review" to approve it (GitHub forbids reviewing your own PR).
+      draft: true
+      # Our release flow emits no SLSA attestations and uploads no workflow
+      # artifact, so compute integrity by downloading the tarball from the URL
+      # in .bcr/source.template.json instead.
+      attest: false
+      download_default_release_artifacts: false
+    secrets:
+      publish_token: ${{ secrets.BCR_PUBLISH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,3 +14,17 @@ jobs:
     with:
       release_files: mbo-*.tar.gz
       prerelease: true
+
+  # Mirror the release to the Bazel Central Registry (replaces the retired
+  # publish-to-bcr GitHub App). See .github/workflows/publish.yaml.
+  publish:
+    needs: release
+    # Grant what publish.yaml's job requests; overrides the workflow-level
+    # read-all, and a called workflow cannot exceed the caller's permissions.
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish.yaml
+    with:
+      tag_name: ${{ github.ref_name }}
+    secrets:
+      BCR_PUBLISH_TOKEN: ${{ secrets.BCR_PUBLISH_TOKEN }}


### PR DESCRIPTION
Rolls out the BCR auto-publish workflow to mbo (proven end-to-end on bashtest → BCR PR #9275 and bzl → BCR PR #9276).

- **publish.yaml**: `bazel-contrib/publish-to-bcr@v1.4.1`, `registry_fork: helly25/bazel-central-registry`, draft PR, URL-based integrity (mbo's release emits no attestations → `attest: false`).
- **release.yml**: `publish` job `needs: release`, `permissions: contents: write` (overrides the workflow-level `read-all`).

Corrected permission pattern (grant `contents: write`; no `read-all` in the wrapper). `BCR_PUBLISH_TOKEN` is set on mbo. After merge, the next tagged release (0.11.0) opens a draft BCR PR for `helly25_mbo`.