### PR TITLE
ci(bcr): test on macos_arm64 and add Bazel 9.x

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -2,9 +2,10 @@ matrix:
   bazel:
     - 7.x
     - 8.x
+    - 9.x
   platform:
     - ubuntu2404
-    - macos
+    - macos_arm64
 tasks:
   verify_targets:
     name: Verify build targets


### PR DESCRIPTION
The BCR `macos` platform runs on Intel x86_64, which we no longer test. This switches the presubmit matrix to `macos_arm64` (Apple Silicon) and adds Bazel `9.x` to the version matrix.

- platform: `macos` → `macos_arm64`
- bazel: `7.x, 8.x` → `7.x, 8.x, 9.x`