### PR TITLE
ci: harden the release path

### DIFF
--- a/.bcr/patches/bazelmod.patch
+++ b/.bcr/patches/bazelmod.patch
@@ -1,15 +1,10 @@
 diff --git a/MODULE.bazel b/MODULE.bazel
-index c298a32..658794e 100644
 --- a/MODULE.bazel
 +++ b/MODULE.bazel
-@@ -24,8 +24,8 @@ module(name = "helly25_mbo"...)
- 
- # For local development we include LLVM and Hedron-Compile-Commands.
+@@ -27,4 +27,4 @@
  # For bazelmod usage these have to be provided by the main module - if necessary.
 -include("//bazelmod:dev.MODULE.bazel")
 -include("//bazelmod:llvm.MODULE.bazel")
 +# include("//bazelmod:dev.MODULE.bazel")
 +# include("//bazelmod:llvm.MODULE.bazel")
  
- bazel_dep(name = "bazel_skylib", version = "1.8.2")
- bazel_dep(name = "platforms", version = "1.0.0")

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,10 @@
 name: Test
-on: [push]
+# Branches only — release tags are handled by release.yml. Running this on tag
+# pushes fired the full matrix needlessly and broke `trunk check`, which diffs
+# against `github.event.before` (the prior tag object, gone after a tag move).
+on:
+  push:
+    branches: ["**"]
 
 permissions: read-all
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,9 @@ name: Release
 on:
   push:
     tags:
-      - "*.*.*"
+      # Numeric semver only (e.g. 0.11.0); releases are <num>.<num>.<num>. This
+      # is stricter than "*.*.*", which also matches things like "v1.2.x".
+      - "[0-9]+.[0-9]+.[0-9]+"
 
 permissions: read-all
 

--- a/tools/trigger_release.sh
+++ b/tools/trigger_release.sh
@@ -26,6 +26,17 @@ function die() {
 
 git fetch origin main # Make sure the below is relevant
 
+# Must actually be on `main` at exactly origin/main. The tree-diff checks below
+# pass for any branch whose tree matches main (e.g. a just-squash-merged feature
+# branch), so on their own they would let a release be cut off the wrong commit.
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [[ "${BRANCH}" != "main" ]]; then
+  die "Must be run from the 'main' branch (currently on '${BRANCH}')."
+fi
+if [[ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]]; then
+  die "HEAD ($(git rev-parse --short HEAD)) is not at origin/main ($(git rev-parse --short origin/main)); pull first."
+fi
+
 if [[ -n "$(git status --porcelain)" ]]; then
   # Non empty output means non clean branch.
   die "Must be run from clean 'main' branch."
@@ -38,6 +49,11 @@ if [[ -n "$(git diff origin/main --cached --numstat)" ]]; then
 fi
 
 VERSION="${1}"
+
+# Releases are strictly numeric <major>.<minor>.<patch>.
+if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  die "Version must be numeric <major>.<minor>.<patch> (got '${VERSION}')."
+fi
 
 BAZELMOD_VERSION="$(sed -rne 's,.*version = "([0-9]+([.][0-9]+)+.*)".*,\1,p' <MODULE.bazel | head -n1)"
 CHANGELOG_VERSION="$(sed -rne 's,^# ([0-9]+([.][0-9]+)+.*)$,\1,p' <CHANGELOG.md | head -n1)"
@@ -57,6 +73,16 @@ fi
 
 grep "${VERSION}" < <(git tag -l) && die "Version tag is already in use."
 
+# Pre-flight: the post-release publish-to-bcr step applies every .bcr/patches/*
+# patch to the released MODULE.bazel. If one no longer applies (e.g. context
+# drift after a dependency bump) it fails at "Create final entry" AFTER the
+# release is already public. Catch it here, before we tag anything.
+for bcr_patch in .bcr/patches/*.patch; do
+  [[ -e "${bcr_patch}" ]] || continue
+  git apply --check "${bcr_patch}" 2>/dev/null ||
+    die "BCR patch '${bcr_patch}' no longer applies to MODULE.bazel; regenerate it before releasing."
+done
+
 git tag -s -a "${VERSION}" \
   -m "New release tag version: '${VERSION}'." \
   -m "$(awk '/^#/{if(NR>1)exit}/^[^#]/{print}' <CHANGELOG.md)"
@@ -64,10 +90,15 @@ git push origin --tags
 
 echo "Next version: ${NEXT_VERSION}"
 
-sed -i "0,/version = \"${VERSION}\"/s/version = \"${VERSION}\"/version = \"${NEXT_VERSION}\"/" MODULE.bazel
+# Bump the module version (the first `version = "X"` line). Portable across BSD
+# (macOS) and GNU sed: BSD `sed -i` needs a backup-suffix arg and `0,/re/` is a
+# GNU-only address, so write to a temp file and use the portable `1,/re/` range.
+sed "1,/version = \"${VERSION}\"/ s/version = \"${VERSION}\"/version = \"${NEXT_VERSION}\"/" MODULE.bazel >MODULE.bazel.tmp
+mv MODULE.bazel.tmp MODULE.bazel
 
-sed -i "1i\
-    # ${NEXT_VERSION}\n" CHANGELOG.md
+# Prepend a new top section for the next version (portable; no `sed -i`).
+{ printf '# %s\n\n' "${NEXT_VERSION}"; cat CHANGELOG.md; } >CHANGELOG.md.tmp
+mv CHANGELOG.md.tmp CHANGELOG.md
 
 NEXT_BRANCH="chore/bump_version_to_${NEXT_VERSION}"
 

--- a/tools/trigger_release.sh
+++ b/tools/trigger_release.sh
@@ -79,8 +79,8 @@ grep "${VERSION}" < <(git tag -l) && die "Version tag is already in use."
 # release is already public. Catch it here, before we tag anything.
 for bcr_patch in .bcr/patches/*.patch; do
   [[ -e "${bcr_patch}" ]] || continue
-  git apply --check "${bcr_patch}" 2>/dev/null ||
-    die "BCR patch '${bcr_patch}' no longer applies to MODULE.bazel; regenerate it before releasing."
+  git apply --check "${bcr_patch}" 2>/dev/null \
+    || die "BCR patch '${bcr_patch}' no longer applies to MODULE.bazel; regenerate it before releasing."
 done
 
 git tag -s -a "${VERSION}" \
@@ -97,7 +97,10 @@ sed "1,/version = \"${VERSION}\"/ s/version = \"${VERSION}\"/version = \"${NEXT_
 mv MODULE.bazel.tmp MODULE.bazel
 
 # Prepend a new top section for the next version (portable; no `sed -i`).
-{ printf '# %s\n\n' "${NEXT_VERSION}"; cat CHANGELOG.md; } >CHANGELOG.md.tmp
+{
+  printf '# %s\n\n' "${NEXT_VERSION}"
+  cat CHANGELOG.md
+} >CHANGELOG.md.tmp
 mv CHANGELOG.md.tmp CHANGELOG.md
 
 NEXT_BRANCH="chore/bump_version_to_${NEXT_VERSION}"


### PR DESCRIPTION
Fallout-fixes from the 0.11.0 release mishap.

## What broke
- `trigger_release.sh` was run from a squash-merged feature branch. Its guards only check `git diff origin/main` (tree), which was empty because the branch tree == main — so it tagged the **wrong commit**. (Tag since moved onto main.)
- On macOS the script then died at `sed` — BSD `sed -i` needs a backup-suffix arg and `0,/re/` is GNU-only, so it parsed `MODULE.bazel` as the script (`invalid command code M`). The version bump never ran.
- The full **Test** matrix fires on tag pushes (`on: [push]`), and `trunk check` broke diffing against the now-gone prior tag object after the tag move.
- 0.11.0's **BCR publish** died at *Create final entry*: `.bcr/patches/bazelmod.patch` no longer applied (its context said `skylib 1.8.2`/`platforms 1.0.0`; the tarball has `1.9.0`/`1.1.0`).

## Fixes
- **`trigger_release.sh`**: must be on `main` at exactly `origin/main`; numeric `X.Y.Z` arg check; **pre-flight** that every `.bcr/patches/*` still applies (fails *before* tagging); portable `sed` (BSD + GNU).
- **`main.yml`**: branch pushes only (`branches: ['**']`).
- **`release.yml`**: numeric semver tag filter (`[0-9]+.[0-9]+.[0-9]+`).
- **`.bcr/patches/bazelmod.patch`**: regenerated with 1-line context — verified to apply to both the repo and the published 0.11.0 tarball, and won't re-break on dependency bumps.