### PR TITLE
Bump version from 0.11.0 to 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 0.11.1
+
 # 0.11.0
 
 - Added `mbo::testing::IsElementOf(container)` — element-on-the-left orientation of gmock's `Contains`. Iterates with raw `operator==` (with a `std::pair` component-wise fallback) so heterogeneous subject types (string literals, `std::string_view`, etc.) compile without caller-side conversion, on both libc++ and libstdc++.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,7 +19,7 @@
 # code depends on it anymore. Slated for removal in a future breaking release.
 module(
     name = "helly25_mbo",
-    version = "0.11.0",
+    version = "0.11.1",
     repo_name = "com_helly25_mbo",
 )
 


### PR DESCRIPTION
Post-release version bump 0.11.0 → 0.11.1.

This is the bump that `trigger_release.sh` normally creates automatically right after tagging, but it didn't for 0.11.0 — the macOS `sed` bug aborted the script after the tag push (fixed in #194). Doing it manually so the next `trigger_release` isn't blocked by "Version tag is already in use".

- `MODULE.bazel`: `version = "0.11.0"` → `"0.11.1"`
- `CHANGELOG.md`: new empty `# 0.11.1` section on top