### PR TITLE
chore(release): 0.11.1 changelog note + trunk linter bump

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -65,11 +65,11 @@ lint:
           max_concurrency: 4
   enabled:
     - buildifier@8.5.1
-    - checkov@3.2.533
+    - checkov@3.3.1
     - clang-tidy@16.0.3
     - git-diff-check
-    - markdownlint@0.48.0
-    - prettier@3.8.3
+    - markdownlint@0.49.0
+    - prettier@3.8.4
     - trivy@0.70.0
     - trufflehog@3.95.3
     - yamllint@1.38.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 0.11.1
 
+- Release/packaging fixes (no API changes): self-contained release archives; hardened `trigger_release.sh`.
+
 # 0.11.0
 
 - Added `mbo::testing::IsElementOf(container)` — element-on-the-left orientation of gmock's `Contains`. Iterates with raw `operator==` (with a `std::pair` component-wise fallback) so heterogeneous subject types (string literals, `std::string_view`, etc.) compile without caller-side conversion, on both libc++ and libstdc++.


### PR DESCRIPTION
Pre-release tidy before cutting 0.11.1:
- Fill the empty `# 0.11.1` CHANGELOG section (so the release notes aren't blank).
- Bump trunk linters (checkov 3.3.1, markdownlint 0.49.0, prettier 3.8.4) — also clears the lingering working-tree WIP so the release runs from a clean tree.

No source changes.