### PR TITLE
fix(tools): resolve clang-format from the hermetic toolchain first

### DIFF
--- a/tools/clang_format.sh
+++ b/tools/clang_format.sh
@@ -22,12 +22,19 @@ function die() {
   exit 1
 }
 
-# 1) Assume we have the `external` convenience link.
+# Resolve clang-format, preferring the hermetic toolchains_llvm binary so CI and
+# local runs agree on the version, ahead of any system clang-format on PATH.
+
+# The `bazel-<repo>` convenience link points at the execroot; fall back to cwd.
 BAZEL_OUTPUT="bazel-$(basename "${PWD}")"
 [ -d "${BAZEL_OUTPUT}" ] || BAZEL_OUTPUT="."
 
+# The output base holds every fetched repo, including the `--config=clang`
+# dev-dependency LLVM toolchain that the execroot symlink forest may omit.
+OUTPUT_BASE="$(bazel info output_base 2>/dev/null || true)"
+
 declare -a CLANG_FORMAT_LOCS=(
-  # 1) Find it via the `bazel-<repo>` link structure.
+  # 1) Hermetic toolchain via the `bazel-<repo>` execroot link.
   # 1.1) Bazel workspaces
   "${BAZEL_OUTPUT}/external/llvm_toolchain_llvm/bin/clang-format"
   "${BAZEL_OUTPUT}/external/llvm_toolchain/bin/clang-format"
@@ -38,26 +45,37 @@ declare -a CLANG_FORMAT_LOCS=(
   "${BAZEL_OUTPUT}/external/toolchains_llvm++llvm+llvm_toolchain_llvm/bin/clang-format"
   "${BAZEL_OUTPUT}/external/toolchains_llvm++llvm+llvm_toolchain_llvm_llvm/bin/clang-format"
 
-  # 2) Try to find clang-format directly or by its name plus version suffix as is common.
-  "$(which "clang-format-23")"
-  "$(which "clang-format-22")"
-  "$(which "clang-format-21")"
-  "$(which "clang-format-20")"
-  "$(which "clang-format-19")"
-  "$(which "clang-format-18")"
-  "$(which "clang-format-17")"
-  "$(which "clang-format-16")"
-  "$(which "clang-format-15")"
+  # 2) Same hermetic toolchain via the output base (covers the dev-dependency
+  #    case where it is absent from the execroot symlink forest). Still hermetic,
+  #    so this is tried BEFORE any system clang-format below.
+  "${OUTPUT_BASE:+${OUTPUT_BASE}/external/toolchains_llvm++llvm+llvm_toolchain_llvm/bin/clang-format}"
+  "${OUTPUT_BASE:+${OUTPUT_BASE}/external/toolchains_llvm++llvm+llvm_toolchain_llvm_llvm/bin/clang-format}"
 
-  # 3) Prefer clang-format from LLVM_PATH or PATH environment variables if any.
+  # 3) System clang-format by versioned name (its version may differ from the
+  #    hermetic toolchain, so it is a last resort).
+  "$(which "clang-format-23" 2>/dev/null || true)"
+  "$(which "clang-format-22" 2>/dev/null || true)"
+  "$(which "clang-format-21" 2>/dev/null || true)"
+  "$(which "clang-format-20" 2>/dev/null || true)"
+  "$(which "clang-format-19" 2>/dev/null || true)"
+  "$(which "clang-format-18" 2>/dev/null || true)"
+  "$(which "clang-format-17" 2>/dev/null || true)"
+  "$(which "clang-format-16" 2>/dev/null || true)"
+  "$(which "clang-format-15" 2>/dev/null || true)"
+
+  # 4) LLVM_PATH or a plain clang-format on PATH.
   "${LLVM_PATH:-/usr}/bin/clang-format"
-  "$(which clang-format)"
+  "$(which clang-format 2>/dev/null || true)"
 )
 
-for CLANG_FORMAT in "${CLANG_FORMAT_LOCS[@]}"; do
-  [ -x "${CLANG_FORMAT}" ] && break
+CLANG_FORMAT=""
+for LOC in "${CLANG_FORMAT_LOCS[@]}"; do
+  if [ -n "${LOC}" ] && [ -x "${LOC}" ]; then
+    CLANG_FORMAT="${LOC}"
+    break
+  fi
 done
 
-[[ -x ${CLANG_FORMAT} ]] || die "Cannot find clang-format"
+[ -n "${CLANG_FORMAT}" ] || die "Cannot find clang-format (build once with --config=clang so the hermetic toolchain is fetched, or install clang-format)"
 
-"${CLANG_FORMAT}" "${@}"
+exec "${CLANG_FORMAT}" "${@}"


### PR DESCRIPTION
clang_format.sh resolved clang-format only through the bazel-<repo> execroot symlink forest, which omits the --config=clang dev-dependency LLVM toolchain unless the last build used --config=clang. It then fell through to a system clang-format on PATH whose version differs from the pinned toolchain, so formatting diverges between CI and local.

This resolves the hermetic toolchain via `bazel info output_base` (which holds every fetched repo) as well, and orders every hermetic location BEFORE any system clang-format, so the pinned version always wins. Found while wiring the same tooling into helly25/xff.