### PR TITLE
docs: split C++ style into STYLE_CPP.md (clang configs + gtest conventions)

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -2,61 +2,20 @@
 
 Some rules for the code layout and its development.
 
-- Everything is under Apache 2 license, see fle `LICENSE`.
+> **C++ coding style** (formatting, naming, namespaces, headers, macros, idioms, and
+> the GoogleTest conventions) lives in [`STYLE_CPP.md`](STYLE_CPP.md). This file keeps
+> the project-level rules that are not C++ coding style.
+
+- Everything is under Apache 2 license, see file `LICENSE`.
 - All sources must be unix-text files: https://en.wikipedia.org/wiki/Text_file
   - Lines end in {LF}.
   - The files are either empty or end in {LF}.
 - API changes that are not backwards compatible should not occur in minor version changes.
 - Undocumented and private/internal APIs may be changed in any way at any time.
-- This library uses C++20 and is intended to be compiled with `clang`.
-  - Reasonable effort is performed to ensure compilation with GCC is functional.
-- All (C++) code must be formatted using `clang-format` with '.clang-format'.
-  - This provides consistent formatting.
-  - The choices are meant to enable fast structural reading by humans.
-  - It cares less about writing because there is auto formatting and code is
-    read much more often then written.
-  - Auto formatting also prevents pointless discussions like where '\*' goes.
-  - The guide mostly follows Google style: https://google.github.io/styleguide/
-- All exported library code is in the directory 'mbo'.
-- Directory 'mbo' has no actual library rules, but may have test rules.
-- No namespace may be named 'internal'.
-- Each subdirectory:
-  - has all its code in a namespace: "mbo::{dir}"
-  - there may be functional sub-namespace, e.g.: "mbo::{dir}::{sub}"
-  - internal code goes into special sub-namespace:
-    - Code in these namespace is not allowed to be used outside their library
-    - "mbo::{dir}::{dir}\_internal
-    - "mbo::{dir}::{sub}\_internal
-    - "mbo::{dir}::{sub}::{sub}\_internal
-    - This ensures that "internal" namespace do not conflict.
-    - No namespace component `internal` is otherwise allowed.
-  - Sub namespaces 'detail' are allowed.
-    - Such sub-namespaces imply usable (exported) functionality
-    - "mbo::{dir}::detail
-    - "mbo::{dir}::{sub}::detail
-    - In contrast to internal namespaces the detail namespaces use just "detail"
-      which can result in namespace conflicts. To avoid that they have to be
-      fully qualified.
-- Forward declared symbols must be fully implemented in the same source file.
-  - The exception are 'Impl' classes / structs in a header's class when the
-    actual implementation is in a name-corresponding implementation file. This
-    is useful for visibility and name resolution.
+- All exported library code is in the directory `mbo`.
+  - Directory `mbo` has no actual library rules, but may have test rules.
 - All public / exported code must:
-  - be tested,
-  - have a documentaion.
-- All headers must have macro-guards: "{PATH}_{FILE}_". That is path and filename in all caps, with all non alphanumeric chars replaced with '_' and followed by a final '_'.
-  - A '\_\_' betwen {PATH} and {FILE} would be better, but C++ does not allow it.
-  - Filnames may not start with the basename of any directory in their same
-    directory followed by an '_' as that would lead to conflicting macro guards.
-    E.g.: "foo/bar.h" and "foo_bar.h" would have macro guard "FOO_BAR_H_".
-- Macros are to be avoided at all costs, or prefixed by 'MBO\_'.
-  - Macros for local application must be undefined as close after the last use
-    as possible.
-  - Where possible macros should be named "{PATH}_{FILE}_{USECASE}". As a minimum they should have the prefix `MBO_`.
-  - Private macro implementation details should be named "MBO*PRIVATE*{PATH}_{FILE}_{USECASE}_". That is, prefix `MBO_PRIVATE_`followed by all caps path/filename with all non alphanumeric chars replaced with`_`, followed by a final `_`.
-- Use `std::size_t` as `size_t` **ONLY** in CC files with `using std::size_t`.
-- Flags in libraries should be prefixed with their path/namespace. E.g. the flag
-  `--mbo_log_timing_min_duration` has the prefix `mbo_log` as it is defined in
-  `mbo/log/log_timing.cc` (path `mbo/log`) and uses namespace `mbo::log`.
+  - be tested (see [`STYLE_CPP.md`](STYLE_CPP.md) for the GoogleTest conventions),
+  - have a documentation.
 - All shell files follow https://google.github.io/styleguide/shellguide.html but use shfmt which diverges slightly.
   - The common shebang line is `#!/usr/bin/env bash` followed by the license.

--- a/STYLE_CPP.md
+++ b/STYLE_CPP.md
@@ -1,0 +1,145 @@
+# C++ Style
+
+The C++ coding style for helly25 repositories. It sits on top of two
+machine-enforced config files and adds the human conventions below. When in doubt
+the config files win; this document explains and extends them so a contributor (or
+an AI assistant) can follow them without reverse-engineering the tooling.
+
+## Toolchain (machine-enforced)
+
+- C++20, compiled with `clang`. Compilation with GCC is kept working on a
+  best-effort basis.
+- **`clang-format`** with [`.clang-format`](.clang-format) formats all C++ code. Run
+  it; do not hand-format against it. CI rejects any reformatting diff.
+- **`clang-tidy`** with [`.clang-tidy`](.clang-tidy) lints all C++ code with
+  `WarningsAsErrors: true`, so every finding is a build failure. The enabled set is
+  broad: `abseil-*`, `bugprone-*`, `cppcoreguidelines-*`, `google-*`, `misc-*`,
+  `modernize-*`, `performance-*`, `portability-*`, `readability-*`.
+
+### What `.clang-format` decides (do not fight it)
+
+- Google base style, **column limit 120**.
+- `AlignAfterOpenBracket: AlwaysBreak` + `BinPackParameters: false`: when arguments
+  do not fit, each goes on its own line at one indent (not aligned to the paren).
+- `PointerAlignment: Left` (`int* p`), `QualifierAlignment: Left` (`const int`).
+- `IntegerLiteralSeparator` decimal every 3: write `1'000'000`.
+- `RemoveSemicolon`, `InsertBraces` (always brace bodies), `SeparateDefinitionBlocks`.
+- **`InsertTrailingCommas` is deliberately OFF** (it would force every aggregate to
+  never-bin-pack). That is the lever behind the trailing-comma rule below: a _manual_
+  trailing comma opts a _single_ aggregate into one-element-per-line.
+
+### Naming (enforced by `.clang-tidy readability-identifier-naming`)
+
+- Types / classes / structs / enums / aliases / functions: `CamelCase` (`LimitedMap`).
+- Variables / parameters / data members / namespaces: `lower_case` (`flag_count`).
+- Private data members: `lower_case` with a trailing `_` (`flags_`).
+- constexpr / enum constants / global + static constants: `k` + `CamelCase` (`kMaxDepth`).
+- Macros: `UPPER_CASE`, prefixed `MBO_` (`MBO_...`).
+
+## Code organization
+
+- All exported code lives under the top library directory (in mbo: `mbo/`).
+- Each subdirectory uses namespace `mbo::{dir}` (and `mbo::{dir}::{sub}`).
+  - Internal-only code: `mbo::{dir}::{sub}_internal`. No namespace component is ever
+    just `internal`.
+  - Exported-but-detail code may use a `detail` sub-namespace (fully qualify it, since
+    the bare `detail` name can collide).
+- Header guards: `{PATH}_{FILE}_` (path + filename, uppercased, non-alphanumerics ->
+  `_`, trailing `_`). A file may not start with a sibling directory's basename + `_`:
+  `foo/bar.h` and `foo_bar.h` would both yield `FOO_BAR_H_`.
+- Forward-declared symbols must be fully implemented in the same source file (except
+  the `Impl`-in-header / implementation-in-`.cc` pattern).
+- Macros: avoid them; if unavoidable prefix `MBO_` (private impl `MBO_PRIVATE_...`) and
+  `#undef` a local macro as soon after its last use as possible.
+- `std::size_t`: use the short `size_t` only in `.cc` files, via `using std::size_t`.
+- Library flags are prefixed by their path/namespace (e.g. `--mbo_log_...`).
+
+## Formatting conventions on top of clang-format
+
+clang-format picks a layout per line; these two habits steer it toward the readable one.
+
+1. **No comment at the end of a long line.** Put the comment on its own line _above_
+   the element. A trailing `// ...` that pushes a line past 120 makes clang-format
+   explode the element across several lines.
+
+   ```cpp
+   // -exec run in the matched entry's directory
+   {.name = "-execdir", .kind = Kind::kAction, .arity = -1},
+   ```
+
+2. **Trailing comma on the last field of a complex aggregate** breaks it one field per
+   line. Because `InsertTrailingCommas` is off, the comma is your per-aggregate opt-in.
+   Use it for long/complex initializers; a short one that reads on a single line stays.
+
+   ```cpp
+   const Drop drop{
+       .line = line,
+       .layer = Source::kProject,
+       .safety = Safety::kSecurity,
+   };
+   ```
+
+## Idioms
+
+- **Pass `absl::Status` by value**, not `const&`: it is a tagged pointer, and
+  `.clang-tidy performance-unnecessary-value-param` allowlists it (with `absl::StatusOr`
+  and `std::string_view`). `StatusOr<T>`'s cost depends on `T`.
+- **Prefer container algorithms** from `absl/algorithm/container.h` (`absl::c_contains`,
+  `c_any_of`, `c_find`, `c_sort`, ...) or C++20 `std::ranges` over hand-rolled loops:
+  range-based (no begin/end), well-named, constexpr-friendly.
+- **switch / case**: order case labels alphabetically. Where the cases are a uniform
+  mapping (key -> handler or value), prefer a constexpr `mbo::container::LimitedMap`
+  lookup over a switch.
+- **No em-dashes** anywhere (code, comments, docs, commit messages). Use a spaced
+  hyphen `-`.
+
+## Testing (GoogleTest / GoogleMock)
+
+All exported code must be tested. Tests use GoogleTest + GoogleMock with these conventions.
+
+### Structure
+
+- **Always `TEST_F` with a fixture**, never a bare `TEST`. Even an empty
+  `struct FooTest : ::testing::Test {};` is preferred, so shared setup has a home.
+- One behaviour per test; name the test for the behaviour it asserts.
+
+### Assertions: gmock matchers, not `EXPECT_EQ`
+
+- Assert with **`EXPECT_THAT` / `ASSERT_THAT` + a matcher**, not `EXPECT_EQ` /
+  `ASSERT_EQ`: matchers compose and give far better failure messages.
+- **No redundant `Eq` for POD/strings.** `EXPECT_THAT(x, value)` auto-wraps a bare
+  value in `Eq`, so write `EXPECT_THAT(name, "foo")`, not `EXPECT_THAT(name, Eq("foo"))`.
+- **Floats / doubles**: never `Eq` / `==`; use `FloatEq` / `DoubleEq` (or `Near`).
+- **Optionals**: `EXPECT_THAT(opt, Eq(std::nullopt))` for empty, `Optional(...)` for a
+  value. Nested matchers do **not** auto-wrap: `Optional(Eq("x"))` and `Pointee(Eq("x"))`
+  need the explicit inner `Eq` (a bare value fails to compile there).
+- **Containers**: `ElementsAre(...)` / `UnorderedElementsAre(...)` / `SizeIs(n)` /
+  `IsEmpty()` cover size + order + contents in one matcher, instead of an
+  `ASSERT_EQ(v.size(), n)` followed by indexed `EXPECT_EQ`s. `ElementsAre` auto-wraps
+  each bare element in `Eq`.
+- **Struct elements**: fold per-field checks into the element matcher with the
+  **3-arg, named** `Field("member", &T::member, m)` + `AllOf`, ideally via a small
+  `testing::Matcher<T> FooIs(...)` helper, so a mismatch names the field rather than
+  reporting "whose given field is...".
+
+  ```cpp
+  testing::Matcher<ResolvedFlag> FlagIs(const std::string& flag, Source source) {
+    return AllOf(Field("flag", &ResolvedFlag::flag, flag), Field("source", &ResolvedFlag::source, source));
+  }
+  EXPECT_THAT(Resolve(in), ElementsAre(FlagIs("--color", Source::kUser), FlagIs("--sort", Source::kUser)));
+  ```
+
+### Status matchers (`mbo/testing`)
+
+- `EXPECT_THAT(status_or, mbo::testing::IsOk())`, or
+  `StatusIs(absl::StatusCode::kInvalidArgument)` to match a specific code.
+- `ASSERT_OK_AND_ASSIGN(const auto value, MakeThing())` asserts OK and binds in one step.
+
+### Shell / binary-level tests
+
+- Use **helly25/bashtest** (`bazel_dep(name = "helly25_bashtest")`), not a hand-rolled
+  `sh_test`: `load("@com_helly25_bashtest//bashtest:bashtest.bzl", "bashtest")`, then a
+  script that `source`s `"${helly25_bashtest}"`, defines `test::name()` functions using
+  `expect_eq` / `expect_contains` / `expect_not_contains`, and ends with `test_runner`.
+- It runs under macOS bash 3.2: **no `mapfile` / `readarray`** or other bash-4 features.
+  Read lines with `while IFS= read -r line; do arr+=("$line"); done <<< "$out"`.

--- a/STYLE_CPP.md
+++ b/STYLE_CPP.md
@@ -85,17 +85,134 @@ clang-format picks a layout per line; these two habits steer it toward the reada
   `.clang-tidy performance-unnecessary-value-param` allowlists it (with `absl::StatusOr`
   and `std::string_view`). `StatusOr<T>`'s cost depends on `T`.
 - **Prefer container algorithms** from `absl/algorithm/container.h` (`absl::c_contains`,
-  `c_any_of`, `c_find`, `c_sort`, ...) or C++20 `std::ranges` over hand-rolled loops:
-  range-based (no begin/end), well-named, constexpr-friendly.
+  `c_any_of`, `c_find`, `c_equal`, `c_sort`, ...) or C++20 `std::ranges` over hand-rolled
+  loops: range-based (no begin/end), well-named, constexpr-friendly. A loop that returns
+  on the first match is an `absl::c_any_of` with a lambda; a reserve-then-push copy into a
+  `std::vector` is range construction `std::vector<T>(src.begin(), src.end())`. Keep a raw
+  loop only when it builds a non-trivial structure no algorithm expresses cleanly.
+- **A by-value `std::string_view` is never `const`.** The characters it views are already
+  `const`; making the view itself `const` only disables the view's own API
+  (`remove_prefix`, `remove_suffix`, reassignment) for no benefit. This applies to locals
+  and range-`for` variables. (Not to `std::string_view::size_type`, which is a `size_t`,
+  nor to `absl::Span<const std::string_view>`, where `const` is the element type of an
+  immutable span.)
 - **switch / case**: order case labels alphabetically. Where the cases are a uniform
   mapping (key -> handler or value), prefer a constexpr `mbo::container::LimitedMap`
   lookup over a switch.
 - **No em-dashes** anywhere (code, comments, docs, commit messages). Use a spaced
   hyphen `-`.
 
+## Error handling: `absl::Status` and the MBO status macros
+
+Propagate errors with the macros from `mbo/status/status_macros.h`
+(`@helly25_mbo//mbo/status:status_macros_cc`), not a hand-written
+`if (!x.ok()) return x.status();`.
+
+- **`MBO_RETURN_IF_ERROR(expr)`** evaluates a `Status` or `StatusOr` and returns early if
+  it is not OK. It returns a `mbo::status::StatusBuilder`, which converts to the calling
+  function's `absl::Status` or `absl::StatusOr<T>`, so it works in both.
+- **`MBO_ASSIGN_OR_RETURN(Type var, expr)`** binds the value of a `StatusOr<Type>` to
+  `var` (a new declaration - carry the type - or an existing variable) or returns the
+  status. After it, `var` is the value (not a `StatusOr`); use `var`, not `*var`.
+- **`MBO_MOVE_TO_OR_RETURN(expr, target)`** is the variant whose target may contain commas;
+  the expression comes first so structured bindings work:
+  `MBO_MOVE_TO_OR_RETURN(MakePair(), auto [a, b]);`.
+
+```cpp
+absl::StatusOr<Report> Build(std::string_view path) {
+  MBO_ASSIGN_OR_RETURN(const Config config, LoadConfig(path));  // value, or return status
+  Report report = Analyze(config);
+  MBO_RETURN_IF_ERROR(Persist(report));                         // Status guard
+  return report;
+}
+```
+
+- When you only need the guard but the `StatusOr` value is large and used later through
+  `*expr`, guard on the status to avoid copying the value: `MBO_RETURN_IF_ERROR(big.status());`
+  then use `*big`.
+- **Do not force the macros where they do not fit**: a recovery branch (e.g.
+  `absl::IsNotFound(s)` -> return a default value), a function that returns `bool`/`int`
+  rather than a status, or a CLI path that prints a message and returns an exit code.
+- Pass `absl::Status` by value (see Idioms).
+
+## Output, logging, and `AbslStringify`
+
+- **Never use C strings or `.c_str()`** except to satisfy a C / system API (e.g. building
+  `char* argv[]` for `execvp`); comment why at that one boundary. Keep `std::string` /
+  `std::string_view` end to end - the round-trip out to a `const char*` and back is
+  clutter, not interop.
+- **Never write output through C stdio** (`printf` / `fprintf` / `fputs` to the `stdout` /
+  `stderr` `FILE*`). Use the C++ streams `std::cout` / `std::cerr` (or the logging library).
+  The anti-pattern to delete on sight: `std::fputs(absl::StrCat(...).c_str(), stderr)`.
+- Format with Abseil: `absl::StrCat` for plain concatenation, `absl::StrFormat` for a
+  formatted string, and **`absl::StreamFormat` to write a formatted line straight to a
+  stream with no temporary**: `std::cerr << absl::StreamFormat("wrote %d entries\n", n);`.
+  A plain `<<` is fine for a simple string. Choose per line, but **be consistent within a
+  single function** (do not mix a `StreamFormat` and a `<<` chain in the same function).
+- **Make your types printable with `AbslStringify`, not a hand-rolled `operator<<` /
+  `ToString`.** Abseil's string-conversion extension point is a hidden-friend hook:
+
+  ```cpp
+  struct Point {
+    int x = 0;
+    int y = 0;
+    template<typename Sink>
+    friend void AbslStringify(Sink& sink, const Point& p) {
+      absl::Format(&sink, "(%d, %d)", p.x, p.y);
+    }
+  };
+  ```
+
+  One hook makes the type work with `absl::StrCat`, `absl::StrFormat` / `StreamFormat`
+  `%v`, `absl::StrJoin`, and Abseil logging - and gives GoogleTest readable failure output.
+  `absl::Status` / `StatusOr` already stringify; print them with `%v`.
+
+## Concurrency and thread safety
+
+These are the baseline for any multi-threaded code, not extra credit; threading bugs are
+silent and data-dependent, so the annotations and the sanitizer are the standing guard.
+
+- **Use `absl::Mutex` + `absl::MutexLock`**, not `std::mutex` / `std::lock_guard` or
+  atomics-as-synchronization. Construct the lock from a reference: `absl::MutexLock lock(mu_);`
+  (the pointer constructor is deprecated).
+- **Annotate everything** (`absl/base/thread_annotations.h`): `ABSL_GUARDED_BY(mu_)` on
+  every member the mutex protects, and `ABSL_LOCKS_EXCLUDED` /
+  `ABSL_EXCLUSIVE_LOCKS_REQUIRED` on methods. A comment must state **exactly which members a
+  given mutex guards**, and call out any shared state deliberately left unguarded together
+  with the invariant that keeps it safe (e.g. "each index is handed to exactly one worker,
+  so distinct elements never alias").
+- **If a type has more than one mutex, document their lock-acquisition order** (which is
+  taken before which) so the ordering that prevents deadlock is explicit.
+- **Enforce the annotations**: compile first-party code with clang's `-Wthread-safety`
+  (with `-Werror` an unguarded access becomes a build failure), and add a
+  **ThreadSanitizer CI job** that runs the threaded tests so races are also caught at
+  runtime. Scope the tsan job to the threaded targets; exclude heavy third-party-linked
+  ones so tsan does not rebuild them.
+
+## Protocol Buffers
+
+- **Generated repeated fields and maps are STL-compatible - range-iterate them**, do not
+  index with `field_size()` + `field(i)`. `field_size()` is still fine for `reserve()` and
+  `== 0` emptiness checks; compare two repeated fields with `absl::c_equal`.
+- **Edition 2024**: string accessors default to `string_type = VIEW` and return
+  `std::string_view` (so the by-value-`string_view` rule applies to them); singular fields
+  have **explicit presence** by default, so `set_x(0)` serializes a `0`. To mean "absent",
+  leave the field unset (never call its setter) rather than setting the default.
+- **Build test protos from text, not setters**:
+  `mbo::proto::ParseTextProtoOrDie(R"pb(field: 1 nested { k: "v" })pb")`
+  (`@helly25_proto//mbo/proto:parse_text_proto_cc`). The `R"pb(...)pb"` raw string is what
+  clang-format leaves alone, so the proto stays readable. Do not imperatively `set_` / `add_`
+  your way to a fixture.
+- **Assert on protos structurally** with `mbo::proto::EqualsProto`
+  (`@helly25_proto//mbo/proto:matchers_cc`), which also accepts a text-proto string:
+  `EXPECT_THAT(msg, EqualsProto(R"pb(field: 1)pb"));`. Match a subset with
+  `Partially(EqualsProto(...))`. Never compare serialized strings.
+
 ## Testing (GoogleTest / GoogleMock)
 
-All exported code must be tested. Tests use GoogleTest + GoogleMock with these conventions.
+All exported code must be tested, at every level (unit, integration, and end-to-end where
+it applies). A one-shot manual check or a script you ran once is planning input, never a
+substitute for a committed test. Tests use GoogleTest + GoogleMock with these conventions.
 
 ### Structure
 
@@ -133,7 +250,15 @@ All exported code must be tested. Tests use GoogleTest + GoogleMock with these c
 
 - `EXPECT_THAT(status_or, mbo::testing::IsOk())`, or
   `StatusIs(absl::StatusCode::kInvalidArgument)` to match a specific code.
+- **`IsOkAndHolds(m)`** matches an OK `StatusOr` whose value matches `m` - prefer it over
+  `IsOk()` followed by dereferencing: `EXPECT_THAT(Parse(in), IsOkAndHolds(SizeIs(3)))`.
 - `ASSERT_OK_AND_ASSIGN(const auto value, MakeThing())` asserts OK and binds in one step.
+
+### Protocol-buffer fixtures and matchers
+
+Build proto test data with `mbo::proto::ParseTextProtoOrDie(R"pb(...)pb")` and assert with
+`mbo::proto::EqualsProto` / `Partially(EqualsProto(...))` - never imperative setters or
+serialized-string comparison. See the Protocol Buffers section.
 
 ### Shell / binary-level tests
 


### PR DESCRIPTION
Splits the C++ coding-style rules out of `RULES.md` into a new **`STYLE_CPP.md`** - an AI-workable C++ style guide.

## STYLE_CPP.md
- **Machine-enforced base**: `clang-format` (`.clang-format`: Google, 120 cols, `AlignAfterOpenBracket: AlwaysBreak`, `BinPackParameters: false`, `InsertTrailingCommas` off) + `clang-tidy` (`.clang-tidy`: `WarningsAsErrors`, the broad check set, the naming rules).
- **Code organization** carried over from RULES.md: namespaces (`mbo::{dir}`, `{sub}_internal`, `detail`), header guards, forward decls, macros, `std::size_t`, flag naming.
- **Formatting conventions** that steer clang-format: comment above a long line (not trailing); trailing comma on a complex aggregate to break it one-per-line (works because `InsertTrailingCommas` is off).
- **Idioms**: pass `absl::Status` by value; prefer `absl::c_*` / `std::ranges` over hand-rolled loops; switch/case alphabetical + constexpr `LimitedMap` dispatch; no em-dashes.
- **GoogleTest / GoogleMock**: `TEST_F` + fixture; gmock matchers not `EXPECT_EQ`; no redundant `Eq` (`FloatEq`/`DoubleEq` for floats; nested `Optional`/`Pointee` need an explicit inner `Eq`); `ElementsAre`/`SizeIs`/`IsEmpty`; named 3-arg `Field` via a `FooIs` helper; `mbo::testing` `IsOk`/`StatusIs`/`ASSERT_OK_AND_ASSIGN`; helly25/bashtest for shell tests.

## RULES.md
Slimmed to the project-level rules (license, unix-text, API/versioning, `mbo/` layout, tested+documented, shell) with a pointer to STYLE_CPP.md.

Opened for review rather than auto-merged - this is your canonical style doc, so please tweak any wording or decisions and I can adjust in this PR.