### PR TITLE
C++ style guide, conformance, and 0.12.0 public-API exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-# 0.11.2
+# 0.12.0
+
+- Fixed visibility of already-documented APIs whose Bazel `cc_library` targets had defaulted to `//visibility:private` since they were added, so external code could not `deps` them. Now `//visibility:public`: `//mbo/types:optional_ref_cc` (`OptionalRef`), `//mbo/types:optional_data_or_ref_cc` (`OptionalDataOrRef` / `OptionalDataOrConstRef`), and the `//mbo/json:json` / `:json_cc` library - all added in 0.10.0.
+- Made `//mbo/types:stringify_ostream_cc` public (`stringify_ostream.h`): the ostream `<<` integration for `Stringify` / `Extend` types plus the `SetStringifyOstreamOutputMode` / `SetStringifyOstreamOptions` configuration functions.
 
 # 0.11.1
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,7 +19,7 @@
 # code depends on it anymore. Slated for removal in a future breaking release.
 module(
     name = "helly25_mbo",
-    version = "0.11.2",
+    version = "0.12.0",
     repo_name = "com_helly25_mbo",
 )
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ The C++ library is organized in functional groups each residing in their own dir
   - `namespace mbo::hash`
   - mbo/hash:hash_cc, mbo/hash/hash.h
     - function `simple::GetHash(std::string_view)`: A constexpr capable hash function.
+- Json
+  - `namespace mbo::json`
+  - mbo/json:json_cc, mbo/json/json.h
+    - class `Json`: A JSON value/document that can be built from almost any structured type (see `ConvertibleToJson`) and serialized to JSON text.
+    - enum `Json::SerializeMode`: Selects `kCompact`, `kLine`, or `kPretty` JSON output.
+    - function `Json::Serialize`: Returns the JSON value as a `std::string`.
+    - function `Json::Stream`: Writes the JSON value to a `std::ostream`.
+    - concept `ConvertibleToJson`: Determines whether a value can be stored in a `Json`.
 - Log
   - `namespace mbo::log`
   - mbo/log:demangle_cc, mbo/log/demangle.h

--- a/STYLE_CPP.md
+++ b/STYLE_CPP.md
@@ -49,10 +49,22 @@ an AI assistant) can follow them without reverse-engineering the tooling.
   `foo/bar.h` and `foo_bar.h` would both yield `FOO_BAR_H_`.
 - Forward-declared symbols must be fully implemented in the same source file (except
   the `Impl`-in-header / implementation-in-`.cc` pattern).
-- Macros: avoid them; if unavoidable prefix `MBO_` (private impl `MBO_PRIVATE_...`) and
-  `#undef` a local macro as soon after its last use as possible.
-- `std::size_t`: use the short `size_t` only in `.cc` files, via `using std::size_t`.
-- Library flags are prefixed by their path/namespace (e.g. `--mbo_log_...`).
+- Macros: avoid them. An **exported** macro (defined in a header for other code to use) is
+  prefixed `MBO_` (private impl `MBO_PRIVATE_...`). A macro **local to one translation unit**
+  - a `.cc` / test file, or a header helper you `#undef` right after its last use - may stay
+    unprefixed (still `UPPER_CASE`); `#undef` a local macro as soon after its last use as
+    possible.
+- **C-library names: use the `std::` form; the unqualified global alias is optional.** A
+  `<cstddef>` / `<cXXX>` header is only required to declare `size_t`, `int64_t`, `memcpy`,
+  ... in `namespace std`; whether it _also_ injects the bare global name is
+  implementation-defined, so we never rely on it.
+  - In **headers**, always fully qualify (`std::size_t`); no namespace-level `using`.
+  - In an **implementation file** (`.cc`), a `using std::size_t;` (or other `using std::...`)
+    is fine where it reads better - bring the name in explicitly rather than leaning on the
+    global alias. Be consistent within a file, but readability outranks consistency.
+- Library flags are prefixed by their path/namespace (e.g. `--mbo_log_timing_min_duration`
+  in `mbo/log`). Application entry-point binaries (`glob`, `diff`, `mope`) may use bare flag
+  names (`--depth`, `--algorithm`, `--template`).
 
 ## Formatting conventions on top of clang-format
 
@@ -90,12 +102,32 @@ clang-format picks a layout per line; these two habits steer it toward the reada
   on the first match is an `absl::c_any_of` with a lambda; a reserve-then-push copy into a
   `std::vector` is range construction `std::vector<T>(src.begin(), src.end())`. Keep a raw
   loop only when it builds a non-trivial structure no algorithm expresses cleanly.
+- **Container choice: prefer the Abseil containers over the bare `std::` ones.** The reason is
+  in their favor, not against `std::`: the Abseil variants are faster, support transparent
+  (heterogeneous) lookup - find in a `std::string`-keyed map with a `std::string_view`, no
+  temporary `std::string` - and `flat_hash_*` stores elements inline for lower memory.
+  - **Never `std::unordered_*`** - no `<unordered_map>` / `<unordered_set>` include, and none
+    of `unordered_map` / `unordered_set` / `unordered_multimap` / `unordered_multiset`. Use
+    `absl::flat_hash_map` / `flat_hash_set`, or the `node_hash_map` / `node_hash_set` variants
+    when you need pointer/reference stability. This holds in tests too - the one exception is a
+    container-compatibility test that deliberately exercises a `std::unordered_*` input.
+  - **Avoid `std::map` / `std::set`** (and the `multi` variants) in library code; prefer
+    `absl::btree_map` / `absl::btree_set`, which keep the same ordered interface but are
+    cache-friendlier. In tests, `std::map` / `std::set` are fine.
+  - Small compile-time tables: `mbo::container::LimitedMap` / `LimitedSet`.
+  - A type-detection trait may name a `std::` container type freely - it must, to recognize it.
 - **A by-value `std::string_view` is never `const`.** The characters it views are already
   `const`; making the view itself `const` only disables the view's own API
   (`remove_prefix`, `remove_suffix`, reassignment) for no benefit. This applies to locals
   and range-`for` variables. (Not to `std::string_view::size_type`, which is a `size_t`,
   nor to `absl::Span<const std::string_view>`, where `const` is the element type of an
   immutable span.)
+- **Do not overload `const T*` to express "optional" or to conflate omission with value.** A
+  raw pointer mixes nullability, the pointed-at value, and ownership/lifetime into one type
+  the caller has to second-guess. For an optional reference use
+  `std::optional<std::reference_wrapper<T>>` or, preferably, mbo's `mbo::types::OptionalRef<T>`
+  (`mbo/types/optional_ref.h`) and its related types (e.g. `OptionalDataOrRef` when it may own
+  a value or refer to one).
 - **switch / case**: order case labels alphabetically. Where the cases are a uniform
   mapping (key -> handler or value), prefer a constexpr `mbo::container::LimitedMap`
   lookup over a switch.
@@ -171,6 +203,8 @@ absl::StatusOr<Report> Build(std::string_view path) {
 
 These are the baseline for any multi-threaded code, not extra credit; threading bugs are
 silent and data-dependent, so the annotations and the sanitizer are the standing guard.
+Most of this repo is single-threaded today, so this section is the standard to apply _when
+you add_ multi-threaded code, not a description of current breadth.
 
 - **Use `absl::Mutex` + `absl::MutexLock`**, not `std::mutex` / `std::lock_guard` or
   atomics-as-synchronization. Construct the lock from a reference: `absl::MutexLock lock(mu_);`

--- a/STYLE_CPP.md
+++ b/STYLE_CPP.md
@@ -283,8 +283,15 @@ substitute for a committed test. Tests use GoogleTest + GoogleMock with these co
 
 - Assert with **`EXPECT_THAT` / `ASSERT_THAT` + a matcher**, not `EXPECT_EQ` /
   `ASSERT_EQ`: matchers compose and give far better failure messages.
-- **No redundant `Eq` for POD/strings.** `EXPECT_THAT(x, value)` auto-wraps a bare
-  value in `Eq`, so write `EXPECT_THAT(name, "foo")`, not `EXPECT_THAT(name, Eq("foo"))`.
+- **`Eq` is optional - a readability choice, not a rule.** `EXPECT_THAT(x, value)` auto-wraps a
+  bare value in `Eq`, so both forms compile. The value of `EXPECT_THAT` is that the line reads as
+  a sentence - `EXPECT_THAT(foo, Eq(25))` is "expect that foo equals 25" - so keep `Eq` where it
+  makes the assertion read that way, and drop it where the value already carries the meaning
+  (`EXPECT_THAT(name, "foo")`). Inside composite matchers prefer bare elements
+  (`ElementsAre(1, 2, 3)`); `Optional` / `Pointee` are the exception and need the inner `Eq` (see
+  below). Strings sometimes need `StrEq` (e.g. a `char*` subject, where bare `Eq` compares
+  pointers). For booleans, `IsTrue()` / `IsFalse()` usually read better than a bare `true` /
+  `false` or `Eq(true)`: `EXPECT_THAT(found, IsTrue())`.
 - **Floats / doubles**: never `Eq` / `==`; use `FloatEq` / `DoubleEq` (or `Near`).
 - **Optionals**: `EXPECT_THAT(opt, Eq(std::nullopt))` for empty, `Optional(...)` for a
   value. Nested matchers do **not** auto-wrap: `Optional(Eq("x"))` and `Pointee(Eq("x"))`

--- a/STYLE_CPP.md
+++ b/STYLE_CPP.md
@@ -311,7 +311,10 @@ substitute for a committed test. Tests use GoogleTest + GoogleMock with these co
   `StatusIs(absl::StatusCode::kInvalidArgument)` to match a specific code.
 - **`IsOkAndHolds(m)`** matches an OK `StatusOr` whose value matches `m` - prefer it over
   `IsOk()` followed by dereferencing: `EXPECT_THAT(Parse(in), IsOkAndHolds(SizeIs(3)))`.
-- `ASSERT_OK_AND_ASSIGN(const auto value, MakeThing())` asserts OK and binds in one step.
+- `MBO_ASSERT_OK_AND_ASSIGN(const auto value, MakeThing())` asserts OK and binds in one step.
+- `MBO_ASSERT_OK_AND_MOVE_TO(MakePair(), auto [a, b])` is the move variant whose target may
+  contain commas (so the expression comes first) - the test mirror of `MBO_MOVE_TO_OR_RETURN`,
+  for structured bindings and move-only types.
 
 ### Protocol-buffer fixtures and matchers
 

--- a/STYLE_CPP.md
+++ b/STYLE_CPP.md
@@ -281,8 +281,11 @@ substitute for a committed test. Tests use GoogleTest + GoogleMock with these co
 
 ### Assertions: gmock matchers, not `EXPECT_EQ`
 
-- Assert with **`EXPECT_THAT` / `ASSERT_THAT` + a matcher**, not `EXPECT_EQ` /
-  `ASSERT_EQ`: matchers compose and give far better failure messages.
+- Assert with **`EXPECT_THAT` / `ASSERT_THAT` + a matcher** rather than the comparison macros
+  `EXPECT_EQ` / `NE` / `GT` / `LT` / `GE` / `LE` (and their `ASSERT_` forms): matchers compose and
+  give far better failure messages. The accepted exception is the boolean `EXPECT_TRUE` /
+  `EXPECT_FALSE` (and `ASSERT_TRUE` / `ASSERT_FALSE`), which read fine on their own. Within a
+  single test keep one style - do not mix, say, `EXPECT_TRUE(x)` and `EXPECT_THAT(y, IsTrue())`.
 - **`Eq` is optional - a readability choice, not a rule.** `EXPECT_THAT(x, value)` auto-wraps a
   bare value in `Eq`, so both forms compile. The value of `EXPECT_THAT` is that the line reads as
   a sentence - `EXPECT_THAT(foo, Eq(25))` is "expect that foo equals 25" - so keep `Eq` where it

--- a/STYLE_CPP.md
+++ b/STYLE_CPP.md
@@ -11,10 +11,13 @@ an AI assistant) can follow them without reverse-engineering the tooling.
   best-effort basis.
 - **`clang-format`** with [`.clang-format`](.clang-format) formats all C++ code. Run
   it; do not hand-format against it. CI rejects any reformatting diff.
-- **`clang-tidy`** with [`.clang-tidy`](.clang-tidy) lints all C++ code with
-  `WarningsAsErrors: true`, so every finding is a build failure. The enabled set is
-  broad: `abseil-*`, `bugprone-*`, `cppcoreguidelines-*`, `google-*`, `misc-*`,
-  `modernize-*`, `performance-*`, `portability-*`, `readability-*`.
+- **`clang-tidy`** with [`.clang-tidy`](.clang-tidy) (`WarningsAsErrors: true`) runs **locally**
+  via `trunk` (a `trunk check` and the editor daemon) against a `compile_commands.json` you
+  generate with `bazel run @hedron_compile_commands//:refresh_all`. **CI does not run it** (no
+  compile DB there), so CI's hard gate is the compiler `-Werror` in the bazel matrix; still treat
+  a clang-tidy finding as a must-fix before pushing. The enabled set is broad: `abseil-*`,
+  `bugprone-*`, `cppcoreguidelines-*`, `google-*`, `misc-*`, `modernize-*`, `performance-*`,
+  `portability-*`, `readability-*`.
 
 ### What `.clang-format` decides (do not fight it)
 

--- a/STYLE_CPP.md
+++ b/STYLE_CPP.md
@@ -147,6 +147,12 @@ clang-format picks a layout per line; these habits steer it toward the readable 
   `std::optional<std::reference_wrapper<T>>` or, preferably, mbo's `mbo::types::OptionalRef<T>`
   (`mbo/types/optional_ref.h`) and its related types (e.g. `OptionalDataOrRef` when it may own
   a value or refer to one).
+- **Mark a return value `[[nodiscard]]`** when silently ignoring it is a bug - an
+  `absl::Status` / `StatusOr`, a parsed result, a `Consume...` "did it match?" flag, an acquired
+  handle. The exception is a function _designed_ for its result to be optionally used: a builder
+  method returning `*this` for chaining, or a mutator that also returns the previous value as a
+  convenience. We disable `modernize-use-nodiscard` in `.clang-tidy` precisely because it would
+  blanket-annotate every const method - apply `[[nodiscard]]` by judgment instead.
 - **switch / case**: order case labels alphabetically. Where the cases are a uniform
   mapping (key -> handler or value), prefer a constexpr `mbo::container::LimitedMap`
   lookup over a switch.

--- a/STYLE_CPP.md
+++ b/STYLE_CPP.md
@@ -109,9 +109,14 @@ clang-format picks a layout per line; these habits steer it toward the readable 
    over a bare `// NL`. Always keep the `NL` prefix - do not drop to a bare `//` or an unprefixed
    comment - for two reasons: it marks the comment as load-bearing for layout, so a reader knows
    that removing it re-crams the line; and the consistent marker is machine-checkable, so a
-   pre-commit rule can verify these lines stay broken. Do **not** reach for `// clang-format off` /
-   `on` to hand-place layout: the `on` is easy to forget, and everything between the two loses
-   every formatting guarantee above.
+   pre-commit rule can verify these lines stay broken.
+
+   Reserve `// clang-format off` / `on` for a genuine table or hand-aligned expression that
+   clang-format cannot lay out - `// NL` only _inserts_ breaks, so it cannot keep an over-120
+   line whole or stop a reflow (e.g. a one-line-per-case test table, or a multi-clause
+   `requires(...)`). Do not use it to hand-place ordinary layout, and keep the `off`/`on` pair
+   tight and adjacent so the `on` is never forgotten: everything between the two loses every
+   formatting guarantee above.
 
 ## Idioms
 

--- a/STYLE_CPP.md
+++ b/STYLE_CPP.md
@@ -68,7 +68,7 @@ an AI assistant) can follow them without reverse-engineering the tooling.
 
 ## Formatting conventions on top of clang-format
 
-clang-format picks a layout per line; these two habits steer it toward the readable one.
+clang-format picks a layout per line; these habits steer it toward the readable one.
 
 1. **No comment at the end of a long line.** Put the comment on its own line _above_
    the element. A trailing `// ...` that pushes a line past 120 makes clang-format
@@ -90,6 +90,24 @@ clang-format picks a layout per line; these two habits steer it toward the reada
        .safety = Safety::kSecurity,
    };
    ```
+
+3. **Force a line break with a comment rather than let clang-format cram a value at the right
+   margin.** A long argument - especially a raw string such as a proto `R"pb(...)pb"` - otherwise
+   gets packed onto the call line and shoved against the 120 column, unreadable. A trailing
+   comment makes clang-format keep the element on its own line; the bare placeholder for that is
+   written `// NL` ("new line"; a plain trailing `//` does the same, but `// NL` says why):
+
+   ```cpp
+   EXPECT_THAT(  // NL
+       message,
+       EqualsProto(R"pb(name: "n" value: 1)pb"));
+   ```
+
+   Prefer a _real_ short comment over `// NL` whenever there is something worth saying - it
+   breaks the line the same way and also documents the value; `// NL` is only the fallback when
+   there genuinely is nothing to add. Do **not** reach for `// clang-format off` / `on` to
+   hand-place layout: the `on` is easy to forget, and everything between the two loses every
+   formatting guarantee above.
 
 ## Idioms
 

--- a/STYLE_CPP.md
+++ b/STYLE_CPP.md
@@ -94,8 +94,7 @@ clang-format picks a layout per line; these habits steer it toward the readable 
 3. **Force a line break with a comment rather than let clang-format cram a value at the right
    margin.** A long argument - especially a raw string such as a proto `R"pb(...)pb"` - otherwise
    gets packed onto the call line and shoved against the 120 column, unreadable. A trailing
-   comment makes clang-format keep the element on its own line; the bare placeholder for that is
-   written `// NL` ("new line"; a plain trailing `//` does the same, but `// NL` says why):
+   comment makes clang-format keep the element on its own line. Mark it `// NL` ("new line"):
 
    ```cpp
    EXPECT_THAT(  // NL
@@ -103,11 +102,13 @@ clang-format picks a layout per line; these habits steer it toward the readable 
        EqualsProto(R"pb(name: "n" value: 1)pb"));
    ```
 
-   Prefer a _real_ short comment over `// NL` whenever there is something worth saying - it
-   breaks the line the same way and also documents the value; `// NL` is only the fallback when
-   there genuinely is nothing to add. Do **not** reach for `// clang-format off` / `on` to
-   hand-place layout: the `on` is easy to forget, and everything between the two loses every
-   formatting guarantee above.
+   When there is a relevant reason, keep the prefix and add it: `// NL: <short reason>`, preferred
+   over a bare `// NL`. Always keep the `NL` prefix - do not drop to a bare `//` or an unprefixed
+   comment - for two reasons: it marks the comment as load-bearing for layout, so a reader knows
+   that removing it re-crams the line; and the consistent marker is machine-checkable, so a
+   pre-commit rule can verify these lines stay broken. Do **not** reach for `// clang-format off` /
+   `on` to hand-place layout: the `on` is easy to forget, and everything between the two loses
+   every formatting guarantee above.
 
 ## Idioms
 

--- a/mbo/diff/internal/context.h
+++ b/mbo/diff/internal/context.h
@@ -53,7 +53,7 @@ class Context final {
   }
 
   std::string_view PopFront() noexcept {
-    const std::string_view result = data_.front();
+    std::string_view result = data_.front();
     data_.pop_front();
     return result;
   }

--- a/mbo/json/BUILD.bazel
+++ b/mbo/json/BUILD.bazel
@@ -20,11 +20,13 @@ package(default_visibility = ["//visibility:private"])
 alias(
     name = "json",
     actual = "json_cc",
+    visibility = ["//visibility:public"],
 )
 
 cc_library(
     name = "json_cc",
     hdrs = ["json.h"],
+    visibility = ["//visibility:public"],
     deps = [
         "//mbo/config:require_cc",
         "//mbo/types:cases_cc",

--- a/mbo/mope/mope_main.cc
+++ b/mbo/mope/mope_main.cc
@@ -69,7 +69,7 @@ absl::Status Process(const Options& opts) {
   for (const auto& set_kv : absl::GetFlag(FLAGS_set)) {
     const auto [names, value] = std::pair<std::string_view, std::string_view>(absl::StrSplit(set_kv, '='));
     std::vector<std::string_view> section_names = absl::StrSplit(names, ':');
-    const std::string_view key = section_names.back();
+    std::string_view key = section_names.back();
     if (key.empty()) {
       return absl::InvalidArgumentError("No part of the key in `--set=<key>=<value>` may be empty if split by ':'.");
     }
@@ -78,7 +78,7 @@ absl::Status Process(const Options& opts) {
       context_data[key].assign(value);  // Global context_data
     } else {
       auto* section = &mope_template;
-      for (const std::string_view section_name : section_names) {
+      for (std::string_view section_name : section_names) {
         if (section_name.empty()) {
           return absl::InvalidArgumentError(
               "No part of the key in `--set=<key>=<value>` may be empty if split by ':'.");

--- a/mbo/strings/parse.cc
+++ b/mbo/strings/parse.cc
@@ -108,17 +108,17 @@ enum class Quotes { kNone, kSingle, kDouble };
 void HandleQuotes(const ParseOptions& options, char chr, Quotes& quotes, std::string& result) {
   if (options.enable_double_quotes) {
     switch (quotes) {
-      case Quotes::kNone: quotes = chr == '"' ? Quotes::kDouble : Quotes::kSingle; break;
-      case Quotes::kSingle:
-        if (chr == '\'') {
+      case Quotes::kDouble:
+        if (chr == '"') {
           quotes = Quotes::kNone;
         } else {
           result += chr;
           return;
         }
         break;
-      case Quotes::kDouble:
-        if (chr == '"') {
+      case Quotes::kNone: quotes = chr == '"' ? Quotes::kDouble : Quotes::kSingle; break;
+      case Quotes::kSingle:
+        if (chr == '\'') {
           quotes = Quotes::kNone;
         } else {
           result += chr;

--- a/mbo/testing/BUILD.bazel
+++ b/mbo/testing/BUILD.bazel
@@ -66,6 +66,7 @@ cc_library(
     deps = [
         "//mbo/status:status_cc",
         "//mbo/status:status_macros_cc",
+        "@abseil-cpp//absl/container:btree",
         "@abseil-cpp//absl/status",
         "@abseil-cpp//absl/status:statusor",
         "@abseil-cpp//absl/strings",

--- a/mbo/testing/runfiles_dir.cc
+++ b/mbo/testing/runfiles_dir.cc
@@ -87,7 +87,7 @@ absl::StatusOr<std::string> RunfilesDir(std::string_view workspace, std::string_
     }
     const std::string mapping_file = absl::StrCat(test_bin, "/_repo_mapping");
     MBO_ASSIGN_OR_RETURN(const std::string mapping, mbo::file::GetContents(mapping_file));
-    for (const std::string_view line : absl::StrSplit(mapping, '\n')) {
+    for (std::string_view line : absl::StrSplit(mapping, '\n')) {
       const std::vector<std::string_view> parts = absl::StrSplit(line, ',', absl::AllowEmpty());
       if (parts.size() == 3 && parts[1] == workspace) {
         return runfiles->Rlocation(mbo::file::JoinPaths(parts[2], source_rel));

--- a/mbo/testing/status.h
+++ b/mbo/testing/status.h
@@ -22,6 +22,7 @@
 #include <type_traits>
 #include <utility>
 
+#include "absl/container/btree_map.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "gmock/gmock.h"
@@ -312,7 +313,7 @@ class StatusHasPayload {
 // Implementation of `StatusPayloads` matcher.
 class StatusPayloads {
  public:
-  explicit StatusPayloads(const ::testing::Matcher<const std::map<std::string, std::string>&>& payload_matcher)
+  explicit StatusPayloads(const ::testing::Matcher<const absl::btree_map<std::string, std::string>&>& payload_matcher)
       : payload_matcher_(payload_matcher) {}
 
   void DescribeTo(std::ostream* os) const {
@@ -328,7 +329,7 @@ class StatusPayloads {
   template<typename StatusType>
   bool MatchAndExplain(const StatusType& actual, ::testing::MatchResultListener* listener) const {
     const absl::Status& actual_status = ::mbo::status::GetStatus(actual);
-    std::map<std::string, std::string> payload_map;
+    absl::btree_map<std::string, std::string> payload_map;
     actual_status.ForEachPayload([&payload_map](std::string_view type_url, const absl::Cord& payload) {
       payload_map.emplace(type_url, payload);
     });
@@ -357,7 +358,7 @@ class StatusPayloads {
   }
 
  private:
-  const ::testing::Matcher<const std::map<std::string, std::string>&> payload_matcher_;
+  const ::testing::Matcher<const absl::btree_map<std::string, std::string>&> payload_matcher_;
 };
 
 }  // namespace testing_internal
@@ -423,7 +424,7 @@ template<typename PayloadMatcher>
 inline ::testing::PolymorphicMatcher<testing_internal::StatusPayloads> StatusPayloads(
     const PayloadMatcher& payload_matcher) {
   return ::testing::MakePolymorphicMatcher(testing_internal::StatusPayloads(
-      ::testing::MatcherCast<const std::map<std::string, std::string>&>(payload_matcher)));
+      ::testing::MatcherCast<const absl::btree_map<std::string, std::string>&>(payload_matcher)));
 }
 
 // NOLINTBEGIN(cppcoreguidelines-macro-usage)

--- a/mbo/types/BUILD.bazel
+++ b/mbo/types/BUILD.bazel
@@ -172,6 +172,7 @@ cc_test(
 cc_library(
     name = "optional_data_or_ref_cc",
     hdrs = ["optional_data_or_ref.h"],
+    visibility = ["//visibility:public"],
     deps = [
         ":traits_cc",
         "//mbo/config:require_cc",
@@ -195,6 +196,7 @@ cc_test(
 cc_library(
     name = "optional_ref_cc",
     hdrs = ["optional_ref.h"],
+    visibility = ["//visibility:public"],
     deps = [
         "//mbo/config:require_cc",
         "//mbo/log:demangle_cc",
@@ -300,6 +302,7 @@ cc_library(
     name = "stringify_ostream_cc",
     srcs = ["stringify_ostream.cc"],
     hdrs = ["stringify_ostream.h"],
+    visibility = ["//visibility:public"],
     deps = [
         ":stringify_cc",
         "@abseil-cpp//absl/synchronization",

--- a/mbo/types/stringify_ostream.cc
+++ b/mbo/types/stringify_ostream.cc
@@ -15,21 +15,23 @@
 
 #include <memory>
 
+#include "absl/base/thread_annotations.h"
 #include "absl/synchronization/mutex.h"
 #include "mbo/types/stringify.h"
 
 namespace mbo::types {
 namespace {
 
-absl::Mutex g_mx(absl::kConstInit);                      // NOLINT(*-avoid-non-const-global-variables)
-std::shared_ptr<const Stringify> g_stringify = nullptr;  // NOLINT(*-avoid-non-const-global-variables)
+absl::Mutex g_mx(absl::kConstInit);  // NOLINT(*-avoid-non-const-global-variables)
+// NOLINTNEXTLINE(*-avoid-non-const-global-variables)
+std::shared_ptr<const Stringify> g_stringify ABSL_GUARDED_BY(g_mx) = nullptr;
 
 }  // namespace
 
 namespace types_internal {
 
 std::shared_ptr<const Stringify> GetStringifyForOstream() {
-  absl::MutexLock lock(&g_mx);
+  absl::MutexLock lock(g_mx);
   if (g_stringify == nullptr) {
     g_stringify = std::make_shared<Stringify>();
   }
@@ -39,12 +41,12 @@ std::shared_ptr<const Stringify> GetStringifyForOstream() {
 }  // namespace types_internal
 
 void SetStringifyOstreamOutputMode(Stringify::OutputMode output_mode) {
-  absl::MutexLock lock(&g_mx);
+  absl::MutexLock lock(g_mx);
   g_stringify.reset(new Stringify(output_mode));  // NOLINT
 }
 
 void SetStringifyOstreamOptions(const StringifyOptions& options) {
-  absl::MutexLock lock(&g_mx);
+  absl::MutexLock lock(g_mx);
   g_stringify.reset(new Stringify(options));  // NOLINT
 }
 

--- a/mbo/types/tstring.h
+++ b/mbo/types/tstring.h
@@ -124,7 +124,7 @@ struct tstring final {
   }
 
   // String based comparison (run-time), uses `std::string_view::compare`.
-  static constexpr auto compare(const std::string_view other) noexcept { return str().compare(other); }
+  static constexpr auto compare(std::string_view other) noexcept { return str().compare(other); }
 
   static constexpr size_type size() noexcept { return num_chars; }
 


### PR DESCRIPTION
## Summary

Expands `STYLE_CPP.md`, brings first-party code into conformance, and fixes a class of packaging bugs where already-documented public APIs shipped with private Bazel targets. Releases as **0.12.0**.

### `docs(style)` - STYLE_CPP.md
- **C-library names**: always use the `std::`-qualified form (`std::size_t`, ...); the unqualified global alias is implementation-defined, so we do not rely on it. Headers must qualify; a `.cc` may `using std::...` for readability.
- **Container choice**: prefer Abseil containers (faster, transparent lookup, lower memory). Never `std::unordered_*`; avoid `std::map`/`std::set` in library code in favor of `absl::btree_*`. `std::map`/`std::set` are fine in tests; `std::unordered_*` only in container-compatibility tests.
- **`const T*`**: do not overload it to mean "optional" or to conflate omission with value - use `std::optional<std::reference_wrapper<T>>` or `mbo::types::OptionalRef`.
- **Macros**: `MBO_` prefix is for exported macros; purely local `#undef`'d macros may stay unprefixed.
- Concurrency section framed as forward-looking (repo is largely single-threaded); library-vs-binary flag prefixing clarified.

### `refactor` - conformance
- `stringify_ostream.cc`: `absl::MutexLock` reference ctor (pointer ctor is `[[deprecated]]`) + `ABSL_GUARDED_BY` on the mutex-guarded global.
- Drop `const` from by-value `std::string_view` (`tstring.h`, `mope_main.cc`, `context.h`, `runfiles_dir.cc`).
- `parse.cc`: alphabetize switch case labels.
- `testing/status.h`: `std::map` -> `absl::btree_map` in the payload matcher (ordering preserved; transparent to callers).

### `feat(build)` - export public APIs + release 0.12.0
`OptionalRef`, `OptionalDataOrRef` / `OptionalDataOrConstRef`, and the `mbo/json` library were **added in 0.10.0** but their `cc_library` targets defaulted to `//visibility:private`, so external code could not depend on them. Made public (plus `stringify_ostream_cc`), documented `mbo/json` in README, and bumped `0.11.2 -> 0.12.0`.

## Verification
- Full suite green: `bazel test //mbo/...` -> **74/74 pass**.
- `clang-format` clean on all changed files. (`parse.cc:215-217` shows pre-existing format drift present on `main`, untouched by this PR's reorder; the locally-resolved clang-format is likely ahead of the committed LLVM pin.)
