### PR TITLE
Drop the com_helly25_mbo repo alias (0.13.0)

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -59,7 +59,7 @@ fi
 } >BUILD.bazel
 
 # Apply patches
-for patch in "${PATCHES[@]}"; do
+for patch in ${PATCHES[@]+"${PATCHES[@]}"}; do
   patch -s -p 1 <"${patch}"
 done
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.13.0
+
+- Renamed the module repo to `helly25_mbo` and dropped the `com_helly25_mbo` alias (`repo_name`). The last internal user (the `ini_file` golden test) now resolves its runfiles via the repo-relative `//mbo/file/ini:tests/test.ini`, so nothing depends on the old name. Consumers referencing `@com_helly25_mbo//...` must switch to `@helly25_mbo//...`.
+
 # 0.12.0
 
 - Fixed visibility of already-documented APIs whose Bazel `cc_library` targets had defaulted to `//visibility:private` since they were added, so external code could not `deps` them. Now `//visibility:public`: `//mbo/types:optional_ref_cc` (`OptionalRef`), `//mbo/types:optional_data_or_ref_cc` (`OptionalDataOrRef` / `OptionalDataOrConstRef`), and the `//mbo/json:json` / `:json_cc` library - all added in 0.10.0.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,12 +15,9 @@
 
 """Module helly25_mbo"""
 
-# repo_name keeps the old WORKSPACE-era name as a downstream alias; no internal
-# code depends on it anymore. Slated for removal in a future breaking release.
 module(
     name = "helly25_mbo",
-    version = "0.12.0",
-    repo_name = "com_helly25_mbo",
+    version = "0.13.0",
 )
 
 # For local development we include LLVM and Hedron-Compile-Commands.

--- a/mbo/config/internal/config.h.in
+++ b/mbo/config/internal/config.h.in
@@ -32,8 +32,8 @@ namespace mbo::config {
 // For complex code inlining + unrolling might become problematic for larger values.
 //
 // This is controlled by the custom Bazel flag `--//mbo/config:limited_ordered_max_unroll_capacity`.
-// When the library is built as a dependency (e.g. as `com_helly25_mbo`), then the flag becomes
-// `--@com_helly25_mbo//mbo/config:limited_ordered_max_unroll_capacity`.
+// When the library is built as a dependency (e.g. as `helly25_mbo`), then the flag becomes
+// `--@helly25_mbo//mbo/config:limited_ordered_max_unroll_capacity`.
 static constexpr std::size_t kUnrollMaxCapacityDefault = 16;
 
 // Configuration that controls whether container requirement violations result in throwing a
@@ -42,8 +42,8 @@ static constexpr std::size_t kUnrollMaxCapacityDefault = 16;
 // When exceptions are used then the affected functions cannot be declared `noexcept`.
 //
 // This is controlled by custom Bazel `--//mbo/config:require_throws`.
-// When the library is built as a dependency (e.g. as `com_helly25_mbo`), then the flag becomes
-// `--@com_helly25_mbo//mbo/config:require_throws` (defaults to `False` / `0`).
+// When the library is built as a dependency (e.g. as `helly25_mbo`), then the flag becomes
+// `--@helly25_mbo//mbo/config:require_throws` (defaults to `False` / `0`).
 #if __cpp_exceptions
 static constexpr bool kRequireThrows = false;
 #else

--- a/mbo/file/ini/ini_file_test.cc
+++ b/mbo/file/ini/ini_file_test.cc
@@ -79,7 +79,7 @@ struct IniFileTest : ::testing::Test {
 
 TEST_F(IniFileTest, TestGolden) {
   MBO_ASSERT_OK_AND_MOVE_TO(
-      GatherTests(mbo::testing::RunfilesDirOrDie("@com_helly25_mbo//mbo/file/ini:tests/test.ini")),
+      GatherTests(mbo::testing::RunfilesDirOrDie("//mbo/file/ini:tests/test.ini")),
       const std::map<std::string, std::pair<std::string, std::string>> tests);
   std::size_t file_count = 0;
   for (const auto& [base, files] : tests) {


### PR DESCRIPTION
## Summary

Drops the legacy `com_helly25_mbo` Bazel repo alias so the module is referenced only by its real name `helly25_mbo`, and releases as **0.13.0**.

### `chore(module)!` — drop the alias
- Remove `repo_name = "com_helly25_mbo"` from `MODULE.bazel`.
- The last internal user, the `ini_file` golden test, now resolves its runfiles via the repo-relative `//mbo/file/ini:tests/test.ini` instead of `@com_helly25_mbo//...`.
- `mbo/config/internal/config.h.in` doc comments use the new name in the flag examples.
- Bump version `0.12.0 -> 0.13.0`.

**BREAKING CHANGE:** consumers referencing `@com_helly25_mbo//...` must switch to `@helly25_mbo//...`.

### `fix(release)` — release script robustness
- `release_prep.sh`: expand `PATCHES` with `${PATCHES[@]+"${PATCHES[@]}"}` so an empty array does not trip `unbound variable` under `set -u` (also bash 3.2 safe).

## Verification
- No `com_helly25_mbo` references remain anywhere in the tree (outside the CHANGELOG history note).
- Full suite green: `bazel test //mbo/...` -> **74/74 pass** (incl. the `ini_file` golden test that exercised the renamed runfiles path).
