### PR TITLE
ci: one-click Trigger Release (dispatcher)

### DIFF
--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -11,7 +11,7 @@
 name: Trigger Release
 
 on:
-  workflow_dispatch:
+  workflow_dispatch: {}
 
 permissions:
   contents: read

--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -3,19 +3,15 @@
 # Delegates to the shared reusable workflow in helly25/bzl, which checks out this
 # repo's main, verifies the version in MODULE.bazel and CHANGELOG.md is identical
 # and neither tagged nor released, then runs tools/trigger_release.sh (push the
-# signed tag -> release.yml -> GitHub release + BCR, and open the bump PR).
+# signed tag -> release.yml -> GitHub release + BCR, and open the bump PR). The
+# released version is whatever MODULE.bazel currently holds.
 #
-# Requires the org-level secrets RELEASE_TOKEN, RELEASE_GPG_PRIVATE_KEY and
+# Requires the repo secrets RELEASE_TOKEN, RELEASE_GPG_PRIVATE_KEY and
 # RELEASE_GPG_PASSPHRASE (passed through via `secrets: inherit`).
 name: Trigger Release
 
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: "Release version x.y.z (blank = use MODULE.bazel)."
-        required: false
-        type: string
 
 permissions:
   contents: read
@@ -30,5 +26,3 @@ jobs:
       contents: read
     uses: helly25/bzl/.github/workflows/trigger_release.yaml@main
     secrets: inherit
-    with:
-      version: ${{ inputs.version }}

--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -1,0 +1,34 @@
+# One-click release. Actions tab -> "Trigger Release" -> "Run workflow" (on main).
+#
+# Delegates to the shared reusable workflow in helly25/bzl, which checks out this
+# repo's main, verifies the version in MODULE.bazel and CHANGELOG.md is identical
+# and neither tagged nor released, then runs tools/trigger_release.sh (push the
+# signed tag -> release.yml -> GitHub release + BCR, and open the bump PR).
+#
+# Requires the org-level secrets RELEASE_TOKEN, RELEASE_GPG_PRIVATE_KEY and
+# RELEASE_GPG_PASSPHRASE (passed through via `secrets: inherit`).
+name: Trigger Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version x.y.z (blank = use MODULE.bazel)."
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: trigger-release
+  cancel-in-progress: false
+
+jobs:
+  trigger-release:
+    permissions:
+      contents: read
+    uses: helly25/bzl/.github/workflows/trigger_release.yaml@main
+    secrets: inherit
+    with:
+      version: ${{ inputs.version }}


### PR DESCRIPTION
Adds `.github/workflows/trigger_release.yml` -- a `workflow_dispatch` you run from the repo's **Actions** tab ("Trigger Release" -> "Run workflow").

It delegates to the shared reusable workflow **helly25/bzl#39** (`secrets: inherit`), which checks out mbo's `main`, verifies the `MODULE.bazel`/`CHANGELOG.md` version is identical and **neither tagged nor released**, then runs `tools/trigger_release.sh` (signed tag -> release.yml -> GitHub release + BCR, plus the bump PR).

**Depends on:** helly25/bzl#39 (merge first) and org secrets `RELEASE_TOKEN`, `RELEASE_GPG_PRIVATE_KEY`, `RELEASE_GPG_PASSPHRASE`.
Leave the `version` input blank to release the version currently in `MODULE.bazel`.