### PR TITLE
Bump version from 0.12.0 to 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 0.12.1
+
 # 0.12.0
 
 - Fixed visibility of already-documented APIs whose Bazel `cc_library` targets had defaulted to `//visibility:private` since they were added, so external code could not `deps` them. Now `//visibility:public`: `//mbo/types:optional_ref_cc` (`OptionalRef`), `//mbo/types:optional_data_or_ref_cc` (`OptionalDataOrRef` / `OptionalDataOrConstRef`), and the `//mbo/json:json` / `:json_cc` library - all added in 0.10.0.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,7 +17,7 @@
 
 module(
     name = "helly25_mbo",
-    version = "0.12.0",
+    version = "0.12.1",
 )
 
 # For local development we include LLVM and Hedron-Compile-Commands.


### PR DESCRIPTION
Post-release dev-version bump to **0.12.1** (MODULE.bazel + CHANGELOG header).

`trigger_release.sh` couldn't push this automatically: the runner signs the bump commit with the **release-trigger** key, which isn't registered on a GitHub account, so it's *Unverified* and the **All** branch ruleset (required signatures, no bypass) rejected it. Done here as a **verified** commit instead.

Follow-up (separate) to make the auto-bump work next time: register the release-trigger key on the account, or exclude `chore/bump_version_to_*` from the signed-commit rule.