### PR TITLE
ci: grant release dispatcher pull-requests: write

### DIFF
--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -1,10 +1,10 @@
 # One-click release. Actions tab -> "Trigger Release" -> "Run workflow" (on main).
 #
 # Delegates to the shared reusable workflow in helly25/bzl, which checks out this
-# repo's main, verifies the version in MODULE.bazel and CHANGELOG.md is identical
-# and neither tagged nor released, then runs tools/trigger_release.sh (push the
-# signed tag -> release.yml -> GitHub release + BCR, and open the bump PR). The
-# released version is whatever MODULE.bazel currently holds.
+# repo's main, verifies the version in MODULE.bazel and CHANGELOG.md match and are
+# neither tagged nor released, then cuts the release: pushes the signed tag
+# (-> release.yml -> GitHub release + BCR) and opens, approves, and auto-merges
+# the next-version bump PR. The released version is whatever MODULE.bazel holds.
 #
 # Requires the repo secrets RELEASE_TOKEN, RELEASE_GPG_PRIVATE_KEY and
 # RELEASE_GPG_PASSPHRASE (passed through via `secrets: inherit`).
@@ -24,5 +24,6 @@ jobs:
   trigger-release:
     permissions:
       contents: read
+      pull-requests: write
     uses: helly25/bzl/.github/workflows/trigger_release.yaml@main
     secrets: inherit


### PR DESCRIPTION
Pairs with helly25/bzl#40. The reworked reusable workflow approves the bump PR as `github-actions[bot]`, which requires `pull-requests: write` on this repo's `GITHUB_TOKEN`; grant it on the dispatcher job (writes still go through the PAT). Comment refreshed: the reusable workflow now cuts the release directly.