### PR TITLE
ci: let pre-commit own git hooks (disable trunk hook actions)

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -2,7 +2,7 @@ Diagnostics:
     UnusedIncludes: Strict
 
 CompileFlags:
-  Add: -DIS_CLANGD
+  Add: -DIS_CLANGD -std=c++20
 ---
 If:
     PathMatch: .*_test.cc

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,34 @@ jobs:
       - uses: actions/checkout@v6
       - name: Trunk Check
         uses: trunk-io/trunk-action@v1
+      - name: Trunk must not own git hooks
+        run: |
+          # Git hooks belong to pre-commit (see .pre-commit-config.yaml); trunk's
+          # git-hook actions are disabled in .trunk/trunk.yaml so trunk never
+          # clobbers pre-commit's clang-format run. This can only be checked here:
+          # a pre-commit hook can't (if trunk owned core.hooksPath, pre-commit
+          # would never run), and a trunk linter can't (it runs in an isolated
+          # sandbox blind to the real git config).
+          # 1) Config invariant: no trunk git-hook action may be enabled.
+          enabled="$(yq -r '.actions.enabled // [] | .[]' .trunk/trunk.yaml)"
+          for action in trunk-announce trunk-check-pre-commit trunk-check-pre-push \
+            trunk-check-pre-push-always trunk-fmt-pre-commit trufflehog-pre-commit; do
+            if grep -qxF "${action}" <<<"${enabled}"; then
+              echo "::error::trunk git-hook action '${action}' is enabled in .trunk/trunk.yaml; disable it so pre-commit keeps ownership of git hooks"
+              exit 1
+            fi
+          done
+          # 2) Runtime truth (when trunk is available): sync hooks, then require
+          #    core.hooksPath not point back into trunk's cache.
+          if command -v trunk >/dev/null 2>&1; then
+            trunk git-hooks sync 2>&1 || true
+            hooks_path="$(git config --get core.hooksPath || true)"
+            if [[ "${hooks_path}" == *trunk* ]]; then
+              echo "::error::core.hooksPath is trunk-managed (${hooks_path}); trunk grabbed the git hooks"
+              exit 1
+            fi
+          fi
+          echo "OK: pre-commit owns git hooks; trunk is not managing them"
 
   pre-commit:
     runs-on: ubuntu-latest

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -65,17 +65,22 @@ lint:
           max_concurrency: 4
   enabled:
     - buildifier@8.5.1
-    - checkov@3.3.1
+    - checkov@3.3.6
     - clang-tidy@16.0.3
     - git-diff-check
     - markdownlint@0.49.0
-    - prettier@3.8.4
-    - trivy@0.70.0
-    - trufflehog@3.95.3
+    - prettier@3.9.4
+    - trivy@0.72.0
+    - trufflehog@3.95.7
     - yamllint@1.38.0
 actions:
-  enabled:
+  # Git hooks are owned by pre-commit (see .pre-commit-config.yaml). These trunk
+  # actions install git hooks and would take over core.hooksPath, so keep them
+  # disabled so trunk never clobbers pre-commit's clang-format run. Re-enabling
+  # any of them is an obvious diff here and is what a reviewer must reject.
+  disabled:
     - trunk-announce
     - trunk-check-pre-push
     - trunk-fmt-pre-commit
+  enabled:
     - trunk-upgrade-available


### PR DESCRIPTION
## Problem

`clang-format` wasn't auto-formatting new C++ files locally. Root cause: **trunk was the git-hooks manager** — `core.hooksPath` pointed at trunk's cache, so pre-commit's framework hook (which owns `clang-format`) could never install or run on commit, and trunk's own commit hook runs `trunk fmt`, which by design excludes `clang-format`. New files landed with 4-space indent.

## Fix

Disable trunk's three git-hook actions so trunk stops claiming `core.hooksPath`:

- `trunk-announce`, `trunk-check-pre-push`, `trunk-fmt-pre-commit` → `actions.disabled`

With those off, `trunk git-hooks sync` reports *"not managing your git hooks"* and `pre-commit install` can own `.git/hooks/{pre-commit,pre-push}`. Trunk still runs standalone via `trunk check` and the CI `trunk` job. Verified: after the change, real `git commit`s run the pre-commit hooks (both commits in this PR did).

**Per-clone step:** run `pre-commit install` (was blocked before because trunk held `core.hooksPath`).

## Regression guard

A CI step in the `trunk` job asserts trunk never re-seizes the hooks — it rejects any enabled trunk git-hook action in `.trunk/trunk.yaml` and, when trunk is present, syncs hooks and requires `core.hooksPath` not point into trunk's cache. This is the only place the check is reliable: a pre-commit hook can't run if trunk owns the hook path, and a trunk custom linter runs in an isolated sandbox blind to the real git config (both were tried and don't work).

## Also included (staged)

- `.clangd`: add `-std=c++20` to the clangd compile flags.
- `.trunk/trunk.yaml`: routine linter version bumps (checkov, prettier, trivy, trufflehog).