### PR TITLE
feat(hash): faster constexpr hash (mbo::hash::mh) + hardening & tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 0.12.1
+# 0.13.0
+
+- Added `mbo::hash::GetHash64(std::string_view)` / `GetHash128(std::string_view)` and the `mbo::hash::Hash128` result type - a new constexpr-safe, non-cryptographic hash (namespace `mbo::hash::mh`), now the default behind `mbo::hash::GetHash*`.
+- Deprecated `mbo::hash::simple::GetHash(std::string_view)`; use `mbo::hash::GetHash64()` instead. The previous implementation remains available as `mbo::hash::simple::GetHash64`.
+- Hash values are not guaranteed stable across library versions and are not intended for persistence or cryptographic use.
 
 # 0.12.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Added `mbo::hash::GetHash64(std::string_view)` / `GetHash128(std::string_view)` and the `mbo::hash::Hash128` result type - a new constexpr-safe, non-cryptographic hash (namespace `mbo::hash::mh`), now the default behind `mbo::hash::GetHash*`.
 - Deprecated `mbo::hash::simple::GetHash(std::string_view)`; use `mbo::hash::GetHash64()` instead. The previous implementation remains available as `mbo::hash::simple::GetHash64`.
+- `mbo::hash::GetHash` is now a template over the hash implementation and seed (`GetHash<&Fn, Seed>(data)`), defaulting to the current default.
+- Added the `MBO_HASH_MANGLE` build flag (default `1`); define it to `0` for fully reproducible `GetHash` values (`GetHash == GetHash64`).
 - Hash values are not guaranteed stable across library versions and are not intended for persistence or cryptographic use.
 
 # 0.12.0

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,7 +17,7 @@
 
 module(
     name = "helly25_mbo",
-    version = "0.12.1",
+    version = "0.13.0",
 )
 
 # For local development we include LLVM and Hedron-Compile-Commands.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This C++20 library provides some general useful building blocks and integrates
 with [Google's Abseil library](https://abseil.io/).
 
-The library is tested with Clang (16+) and GCC (12+) on Ubuntu and MacOS (arm) using continuous integration: [![Test](https://github.com/helly25/mbo/actions/workflows/main.yml/badge.svg)](https://github.com/helly25/mbo/actions/workflows/main.yml).
+The library is tested with Clang (20+) and GCC (13+) on Ubuntu and MacOS (arm) using continuous integration: [![Test](https://github.com/helly25/mbo/actions/workflows/main.yml/badge.svg)](https://github.com/helly25/mbo/actions/workflows/main.yml).
 
 ## Library organization
 
@@ -72,7 +72,9 @@ The C++ library is organized in functional groups each residing in their own dir
 - Hash
   - `namespace mbo::hash`
   - mbo/hash:hash_cc, mbo/hash/hash.h
-    - function `simple::GetHash(std::string_view)`: A constexpr capable hash function.
+    - function `GetHash64(std::string_view)` / `GetHash128(std::string_view)`: A constexpr-safe, non-cryptographic hash (result type `Hash128`). Values are not stable across versions and not for persistence.
+    - function `GetHash(std::string_view)`: as `GetHash64` but folded through a per-build (`__DATE__`/`__TIME__`) seed, so values may differ between builds.
+    - function `simple::GetHash64(std::string_view)`: the previous hash implementation (`simple::GetHash` is deprecated).
 - Json
   - `namespace mbo::json`
   - mbo/json:json_cc, mbo/json/json.h
@@ -297,7 +299,7 @@ The [Bazel-Central-Registry](https://registry.bazel.build/modules/helly25_mbo) i
 
 Presented at [C++ On Sea 2024](https://cpponsea.uk/2024/session/practical-production-proven-constexpr-api-elements), this presentation covers the theory behind:
 
-- `mbo::hash::simple::GetHash`,
+- `mbo::hash::simple::GetHash64` (formerly `mbo::hash::simple::GetHash`),
 - `mbo::container::LimitedVector`,
 - `mbo::container::LimitedMap`, and
 - `mbo::container::LimitedSet`.

--- a/mbo/hash/BUILD.bazel
+++ b/mbo/hash/BUILD.bazel
@@ -50,6 +50,17 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "hash_no_mangle_test",
+    srcs = ["hash_no_mangle_test.cc"],
+    local_defines = ["MBO_HASH_MANGLE=0"],
+    deps = [
+        ":hash_cc",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+    ],
+)
+
 cc_binary(
     name = "hash_benchmark",
     testonly = True,

--- a/mbo/hash/BUILD.bazel
+++ b/mbo/hash/BUILD.bazel
@@ -13,15 +13,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 
 package(default_visibility = ["//visibility:private"])
 
 cc_library(
     name = "hash_cc",
-    srcs = ["hash_simple.h"],
+    srcs = [
+        "hash_internal_util.h",
+        "hash_mangle.h",
+        "hash_mh.h",
+        "hash_simple.h",
+        "hash_types.h",
+    ],
     hdrs = ["hash.h"],
     visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "hash_test_util",
+    testonly = True,
+    hdrs = ["hash_test_util.h"],
+    deps = [":hash_cc"],
 )
 
 cc_test(
@@ -29,7 +42,21 @@ cc_test(
     srcs = ["hash_test.cc"],
     deps = [
         ":hash_cc",
+        ":hash_test_util",
+        "@abseil-cpp//absl/container:flat_hash_set",
+        "@abseil-cpp//absl/strings",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
+    ],
+)
+
+cc_binary(
+    name = "hash_benchmark",
+    testonly = True,
+    srcs = ["hash_benchmark.cc"],
+    tags = ["manual"],
+    deps = [
+        ":hash_test_util",
+        "@com_github_google_benchmark//:benchmark",
     ],
 )

--- a/mbo/hash/hash.h
+++ b/mbo/hash/hash.h
@@ -16,6 +16,39 @@
 #ifndef MBO_HASH_HASH_H_
 #define MBO_HASH_HASH_H_
 
-#include "mbo/hash/hash_simple.h"  // IWYU pragma: export
+#include <cstdint>
+#include <string_view>
+
+#include "mbo/hash/hash_internal_util.h"  // IWYU pragma: export
+#include "mbo/hash/hash_mangle.h"         // IWYU pragma: export
+#include "mbo/hash/hash_mh.h"             // IWYU pragma: export
+#include "mbo/hash/hash_simple.h"         // IWYU pragma: export
+#include "mbo/hash/hash_types.h"          // IWYU pragma: export
+
+namespace mbo::hash {
+
+// Selected current default implementations (see `hash_mh.h`).
+using ::mbo::hash::mh::GetHash128;
+using ::mbo::hash::mh::GetHash64;
+
+// A fast, constexpr-safe, non-cryptographic hash with a per-build seed.
+//
+// `GetHash` folds `GetHash64` through a `HashMangle` step whose seed is derived
+// from the compiler `__DATE__`/`__TIME__` macros. Its value therefore **may**
+// change from build to build -- though a hermetic build environment (e.g. Bazel)
+// may pin those macros, in which case it stays constant. Use `GetHash` when you
+// want values that are deliberately not comparable across independent builds.
+//
+// For a fully deterministic, reproducible value (identical at compile time and
+// run time, and across builds) call `GetHash64` / `GetHash128` directly.
+//
+// Stability: none of these values are guaranteed stable across library versions,
+// none are portable as a persisted/on-the-wire format, and none are suitable for
+// cryptographic use.
+inline constexpr uint64_t GetHash(std::string_view data) {
+  return HashMangle(GetHash64(data));
+}
+
+}  // namespace mbo::hash
 
 #endif  // MBO_HASH_HASH_H_

--- a/mbo/hash/hash.h
+++ b/mbo/hash/hash.h
@@ -46,8 +46,8 @@ using Hash64Fn = uint64_t (*)(std::string_view, uint64_t) noexcept;
 // independent builds.
 //
 // The implementation defaults to the current default (`mbo::hash::mh`), but any
-// hash matching `Hash64Fn` can be plugged in as a template argument, e.g.
-// `GetHash<&mbo::hash::mh::GetHash64>(data)`.
+// hash matching `Hash64Fn` can be plugged in as a template argument, and the
+// seed likewise, e.g. `GetHash<&mbo::hash::mh::GetHash64, 0x1234>(data)`.
 //
 // For a fully deterministic, reproducible value (identical at compile time and
 // run time, and across builds) call `GetHash64` / `GetHash128` directly.
@@ -55,9 +55,9 @@ using Hash64Fn = uint64_t (*)(std::string_view, uint64_t) noexcept;
 // Stability: none of these values are guaranteed stable across library versions,
 // none are portable as a persisted/on-the-wire format, and none are suitable for
 // cryptographic use.
-template<Hash64Fn GetHashFn = &::mbo::hash::mh::GetHash64>
-inline constexpr uint64_t GetHash(std::string_view data, uint64_t seed = mh::kDefaultSeed) {
-  return HashMangle(GetHashFn(data, seed));
+template<Hash64Fn GetHashFn = &::mbo::hash::mh::GetHash64, uint64_t Seed = mh::kDefaultSeed>
+inline constexpr uint64_t GetHash(std::string_view data) {
+  return HashMangle(GetHashFn(data, Seed));
 }
 
 }  // namespace mbo::hash

--- a/mbo/hash/hash.h
+++ b/mbo/hash/hash.h
@@ -31,14 +31,23 @@ namespace mbo::hash {
 using ::mbo::hash::mh::GetHash128;
 using ::mbo::hash::mh::GetHash64;
 
+// The signature every pluggable 64-bit hash implementation provides:
+// `(data, seed) -> hash`, constexpr-safe and non-throwing.
+using Hash64Fn = uint64_t (*)(std::string_view, uint64_t) noexcept;
+
 // A fast, constexpr-safe, non-cryptographic hash with a per-build seed.
 //
-// `GetHash` folds `GetHash64` through a `HashMangle` step that mixes in one of a
-// small, fixed set of build-derived seeds (bucketed from `__DATE__`/`__TIME__`,
-// see `kMangleSeedCount`). Its value therefore **may** change from build to
-// build -- bounded to that seed set so it stays cache-friendly, and pinned to a
-// single seed in a hermetic build (e.g. Bazel). Use `GetHash` when you want
-// values that are deliberately not comparable across independent builds.
+// `GetHash` folds a 64-bit hash implementation through a `HashMangle` step that
+// mixes in one of a small, fixed set of build-derived seeds (bucketed from
+// `__DATE__`/`__TIME__`, see `kMangleSeedCount`). Its value therefore **may**
+// change from build to build -- bounded to that seed set so it stays
+// cache-friendly, and pinned to a single seed in a hermetic build (e.g. Bazel).
+// Use `GetHash` when you want values that are deliberately not comparable across
+// independent builds.
+//
+// The implementation defaults to the current default (`mbo::hash::mh`), but any
+// hash matching `Hash64Fn` can be plugged in as a template argument, e.g.
+// `GetHash<&mbo::hash::mh::GetHash64>(data)`.
 //
 // For a fully deterministic, reproducible value (identical at compile time and
 // run time, and across builds) call `GetHash64` / `GetHash128` directly.
@@ -46,8 +55,9 @@ using ::mbo::hash::mh::GetHash64;
 // Stability: none of these values are guaranteed stable across library versions,
 // none are portable as a persisted/on-the-wire format, and none are suitable for
 // cryptographic use.
-inline constexpr uint64_t GetHash(std::string_view data) {
-  return HashMangle(GetHash64(data));
+template<Hash64Fn GetHashFn = &::mbo::hash::mh::GetHash64>
+inline constexpr uint64_t GetHash(std::string_view data, uint64_t seed = mh::kDefaultSeed) {
+  return HashMangle(GetHashFn(data, seed));
 }
 
 }  // namespace mbo::hash

--- a/mbo/hash/hash.h
+++ b/mbo/hash/hash.h
@@ -33,11 +33,12 @@ using ::mbo::hash::mh::GetHash64;
 
 // A fast, constexpr-safe, non-cryptographic hash with a per-build seed.
 //
-// `GetHash` folds `GetHash64` through a `HashMangle` step whose seed is derived
-// from the compiler `__DATE__`/`__TIME__` macros. Its value therefore **may**
-// change from build to build -- though a hermetic build environment (e.g. Bazel)
-// may pin those macros, in which case it stays constant. Use `GetHash` when you
-// want values that are deliberately not comparable across independent builds.
+// `GetHash` folds `GetHash64` through a `HashMangle` step that mixes in one of a
+// small, fixed set of build-derived seeds (bucketed from `__DATE__`/`__TIME__`,
+// see `kMangleSeedCount`). Its value therefore **may** change from build to
+// build -- bounded to that seed set so it stays cache-friendly, and pinned to a
+// single seed in a hermetic build (e.g. Bazel). Use `GetHash` when you want
+// values that are deliberately not comparable across independent builds.
 //
 // For a fully deterministic, reproducible value (identical at compile time and
 // run time, and across builds) call `GetHash64` / `GetHash128` directly.

--- a/mbo/hash/hash_benchmark.cc
+++ b/mbo/hash/hash_benchmark.cc
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Length-bucketed throughput benchmark comparing the hash algorithms (see
+// hash_test_util.h). Run with: bazel run -c opt //mbo/hash:hash_benchmark
+
+#include <cstdint>
+#include <random>
+#include <string>
+
+#include "benchmark/benchmark.h"
+#include "mbo/hash/hash_test_util.h"
+
+namespace mbo::hash {
+namespace {
+
+// NOLINTBEGIN(*-magic-numbers)
+
+constexpr uint64_t kSeed = 5'381;
+constexpr int kMinLen = 1;
+constexpr int kMaxLen = 4'096;
+constexpr int kRangeMultiplier = 4;
+
+template<typename Algo>
+void BmHash64(benchmark::State& state) {
+  const auto length = static_cast<std::size_t>(state.range(0));
+  std::mt19937_64 rng(0x1234);  // NOLINT(cert-msc51-cpp,cert-msc32-c): fixed data per length
+  const std::string data = algo::RandomString(rng, length);
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(Algo::Get64(data, kSeed));
+  }
+  state.SetBytesProcessed(state.iterations() * static_cast<int64_t>(length));
+  state.SetLabel(std::string(Algo::Name()));
+}
+
+template<typename Algo>
+requires algo::HasHash128<Algo>
+void BmHash128(benchmark::State& state) {
+  const auto length = static_cast<std::size_t>(state.range(0));
+  std::mt19937_64 rng(0x1234);  // NOLINT(cert-msc51-cpp,cert-msc32-c): fixed data per length
+  const std::string data = algo::RandomString(rng, length);
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(Algo::Get128(data, kSeed));
+  }
+  state.SetBytesProcessed(state.iterations() * static_cast<int64_t>(length));
+  state.SetLabel(std::string(Algo::Name()));
+}
+
+// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables,cppcoreguidelines-owning-memory)
+BENCHMARK_TEMPLATE(BmHash64, algo::SimpleHash)->RangeMultiplier(kRangeMultiplier)->Range(kMinLen, kMaxLen);
+BENCHMARK_TEMPLATE(BmHash64, algo::DefaultHash)->RangeMultiplier(kRangeMultiplier)->Range(kMinLen, kMaxLen);
+BENCHMARK_TEMPLATE(BmHash128, algo::DefaultHash)->RangeMultiplier(kRangeMultiplier)->Range(kMinLen, kMaxLen);
+// NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables,cppcoreguidelines-owning-memory)
+
+// NOLINTEND(*-magic-numbers)
+
+}  // namespace
+}  // namespace mbo::hash
+
+BENCHMARK_MAIN();  // NOLINT

--- a/mbo/hash/hash_internal_util.h
+++ b/mbo/hash/hash_internal_util.h
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MBO_HASH_HASH_INTERNAL_UTIL_H_
+#define MBO_HASH_HASH_INTERNAL_UTIL_H_
+
+// IWYU pragma: private, include "mbo/hash/hash.h"
+
+#include <cstddef>
+#include <cstdint>
+
+#include "mbo/hash/hash_types.h"
+
+namespace mbo::hash::hash_internal {
+
+// NOLINTBEGIN(*-magic-numbers,*-pointer-arithmetic)
+
+// Final mixer (MurmurHash3 `fmix64`) that spreads entropy across all 64 bits.
+constexpr uint64_t Fmix64(uint64_t val) noexcept {
+  val ^= val >> 33U;
+  val *= 0xff51afd7ed558ccdULL;
+  val ^= val >> 33U;
+  val *= 0xc4ceb9fe1a85ec53ULL;
+  val ^= val >> 33U;
+  return val;
+}
+
+// Loads 8 bytes as a **little-endian** `uint64_t`. Assembling the word from bytes
+// (rather than `std::bit_cast`) makes the result endian-independent, so hashes
+// match across platforms; it is constexpr-safe and compilers fold it to a single
+// load on little-endian targets (a load + byte-swap on big-endian).
+constexpr uint64_t Load64(const char* ptr) noexcept {
+  uint64_t result = 0;
+  for (std::size_t i = 0; i < 8; ++i) {
+    result |= static_cast<uint64_t>(static_cast<uint8_t>(ptr[i])) << (i * 8U);
+  }
+  return result;
+}
+
+// Loads the 1..7 remaining tail bytes as a little-endian `uint64_t` without any
+// out-of-bounds reads.
+constexpr uint64_t LoadTail(const char* ptr, std::size_t remaining) noexcept {
+  uint64_t result = 0;
+  for (std::size_t i = 0; i < remaining; ++i) {
+    result |= static_cast<uint64_t>(static_cast<uint8_t>(ptr[i])) << (i * 8U);
+  }
+  return result;
+}
+
+// Folds the two 64-bit lanes into one (offsetting `h2` so equal lanes do not
+// cancel) and finalizes the result.
+constexpr uint64_t Hash128To64(Hash128 hash) noexcept {
+  const uint64_t combined = hash.h1 ^ (hash.h2 + 0x9e3779b97f4a7c15ULL);
+  return Fmix64(combined);
+}
+
+// NOLINTEND(*-magic-numbers,*-pointer-arithmetic)
+
+}  // namespace mbo::hash::hash_internal
+
+#endif  // MBO_HASH_HASH_INTERNAL_UTIL_H_

--- a/mbo/hash/hash_mangle.h
+++ b/mbo/hash/hash_mangle.h
@@ -35,17 +35,30 @@ namespace mbo::hash {
 #endif
 // NOLINTEND(*-macro-usage)
 
-// A simple constexpr safe hash function.
+// Number of distinct per-build mangle seeds.
 //
-// This function uses an optimized implementation at run-time and a constexpr safe implementation
-// that yields the exact same values for compile-time usage. It uses compiler provided macros as a
-// seed generator. This means that the seed **may** vary from run to run, but there is no guarantee
-// as a dev environment (e.g. Bazel) may set these macros always to the same value.
+// The mangle mixes a build-derived seed into a hash so precomputed inputs cannot
+// be relied on across builds. Deriving the seed directly from `__DATE__` /
+// `__TIME__` yields a *full 64-bit*, effectively unbounded seed that changes
+// every compile -- which bakes a different constant into every build and so
+// defeats reproducible builds and build caches. Bounding the seed to a small,
+// fixed set of buckets keeps a little per-build variation while capping the
+// number of possible outputs (so caches converge). Use a power of two in
+// {4, 8, 16}; set to 1 to disable variation entirely.
+inline constexpr uint64_t kMangleSeedCount = 16;
+
+// Mixes `data` with one of `kMangleSeedCount` build-derived seeds (constexpr safe).
+//
+// The `__DATE__` / `__TIME__` hash only *selects* a bucket via `% kMangleSeedCount`;
+// the bucket is then expanded into a full-width constant so the whole hash is
+// mangled, not just its low bits. A hermetic build (e.g. Bazel pinning these
+// macros) collapses to a single, stable bucket.
 inline constexpr uint64_t HashMangle(uint64_t data) {
-  // In theory this should be a random number or at least an arbitray number that
-  // changes on every program start. Howeverm this number must be constexpr.
-  constexpr uint64_t kNotSoRandom =  //
-      5'008'709'998'333'326'415ULL
+  constexpr uint64_t kBase = 5'008'709'998'333'326'415ULL;
+  constexpr uint64_t kSpread = 0x9E3779B97F4A7C15ULL;  // full-width odd: spreads a bucket across all bits
+
+  constexpr uint64_t kDateTime =  //
+      0ULL
 #if defined(__DATE__)
       ^ (MBO_CONSTANT_P(__DATE__, 1) == 0 ? 0 : simple::GetHash64(std::string_view(__DATE__)))
 #endif
@@ -55,7 +68,9 @@ inline constexpr uint64_t HashMangle(uint64_t data) {
       ^ (MBO_CONSTANT_P(__TIMESTAMP__, 1) == 0 ? 0 : simple::GetHash64(std::string_view(__TIMESTAMP__)))
 #endif
       ;
-  return data ^ kNotSoRandom;
+  constexpr uint64_t kBucket = kDateTime % kMangleSeedCount;  // 0 .. kMangleSeedCount-1
+  constexpr uint64_t kSeed = kBase ^ (kBucket * kSpread);
+  return data ^ kSeed;
 }
 
 #undef MBO_CONSTANT_P  // Be gone.

--- a/mbo/hash/hash_mangle.h
+++ b/mbo/hash/hash_mangle.h
@@ -35,6 +35,18 @@ namespace mbo::hash {
 #endif
 // NOLINTEND(*-macro-usage)
 
+// MBO_HASH_MANGLE enables (1, default) or disables (0) the per-build seed mangle.
+// Disable it for fully reproducible `mbo::hash::GetHash` values -- identical
+// across builds, so `GetHash == GetHash64` -- e.g. for reproducible builds or
+// golden tests. Set it consistently for ALL translation units / build configs of
+// a program: `HashMangle` is `inline constexpr`, so mixing values across TUs is
+// an ODR violation, and tying it to the -O level or NDEBUG would make debug and
+// release builds disagree (a worse footgun than the mangle it removes). Hence it
+// is one explicit, build-wide switch, not automatic.
+#if !defined(MBO_HASH_MANGLE)
+# define MBO_HASH_MANGLE 1  // NOLINT(*-macro-usage)
+#endif
+
 // Number of distinct per-build mangle seeds.
 //
 // The mangle mixes a build-derived seed into a hash so precomputed inputs cannot
@@ -52,25 +64,30 @@ inline constexpr uint64_t kMangleSeedCount = 16;
 // The `__DATE__` / `__TIME__` hash only *selects* a bucket via `% kMangleSeedCount`;
 // the bucket is then expanded into a full-width constant so the whole hash is
 // mangled, not just its low bits. A hermetic build (e.g. Bazel pinning these
-// macros) collapses to a single, stable bucket.
+// macros) collapses to a single, stable bucket. With MBO_HASH_MANGLE=0 this is
+// the identity.
 inline constexpr uint64_t HashMangle(uint64_t data) {
+#if MBO_HASH_MANGLE
   constexpr uint64_t kBase = 5'008'709'998'333'326'415ULL;
   constexpr uint64_t kSpread = 0x9E3779B97F4A7C15ULL;  // full-width odd: spreads a bucket across all bits
 
   constexpr uint64_t kDateTime =  //
       0ULL
-#if defined(__DATE__)
+# if defined(__DATE__)
       ^ (MBO_CONSTANT_P(__DATE__, 1) == 0 ? 0 : simple::GetHash64(std::string_view(__DATE__)))
-#endif
-#if defined(__TIME__)
+# endif
+# if defined(__TIME__)
       ^ (MBO_CONSTANT_P(__TIME__, 1) == 0 ? 0 : simple::GetHash64(std::string_view(__TIME__)))
-#elif defined(__TIMESTAMP__)
+# elif defined(__TIMESTAMP__)
       ^ (MBO_CONSTANT_P(__TIMESTAMP__, 1) == 0 ? 0 : simple::GetHash64(std::string_view(__TIMESTAMP__)))
-#endif
+# endif
       ;
   constexpr uint64_t kBucket = kDateTime % kMangleSeedCount;  // 0 .. kMangleSeedCount-1
   constexpr uint64_t kSeed = kBase ^ (kBucket * kSpread);
   return data ^ kSeed;
+#else   // MBO_HASH_MANGLE
+  return data;
+#endif  // MBO_HASH_MANGLE
 }
 
 #undef MBO_CONSTANT_P  // Be gone.

--- a/mbo/hash/hash_mangle.h
+++ b/mbo/hash/hash_mangle.h
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MBO_HASH_HASH_MANGLE_H_
+#define MBO_HASH_HASH_MANGLE_H_
+
+// IWYU pragma: private, include "mbo/hash/hash.h"
+
+#include <cstdint>
+#include <string_view>
+
+#include "mbo/hash/hash_simple.h"
+
+namespace mbo::hash {
+
+// NOLINTBEGIN(*-macro-usage)
+#define MBO_CONSTANT_P(expression, fallback) (fallback)
+#ifdef __has_builtin
+# if __has_builtin(__builtin_constant_p)
+#  undef MBO_CONSTANT_P
+#  define MBO_CONSTANT_P(expression, fallback) __builtin_constant_p(expression)
+# endif
+#endif
+// NOLINTEND(*-macro-usage)
+
+// A simple constexpr safe hash function.
+//
+// This function uses an optimized implementation at run-time and a constexpr safe implementation
+// that yields the exact same values for compile-time usage. It uses compiler provided macros as a
+// seed generator. This means that the seed **may** vary from run to run, but there is no guarantee
+// as a dev environment (e.g. Bazel) may set these macros always to the same value.
+inline constexpr uint64_t HashMangle(uint64_t data) {
+  // In theory this should be a random number or at least an arbitray number that
+  // changes on every program start. Howeverm this number must be constexpr.
+  constexpr uint64_t kNotSoRandom =  //
+      5'008'709'998'333'326'415ULL
+#if defined(__DATE__)
+      ^ (MBO_CONSTANT_P(__DATE__, 1) == 0 ? 0 : simple::GetHash64(std::string_view(__DATE__)))
+#endif
+#if defined(__TIME__)
+      ^ (MBO_CONSTANT_P(__TIME__, 1) == 0 ? 0 : simple::GetHash64(std::string_view(__TIME__)))
+#elif defined(__TIMESTAMP__)
+      ^ (MBO_CONSTANT_P(__TIMESTAMP__, 1) == 0 ? 0 : simple::GetHash64(std::string_view(__TIMESTAMP__)))
+#endif
+      ;
+  return data ^ kNotSoRandom;
+}
+
+#undef MBO_CONSTANT_P  // Be gone.
+
+}  // namespace mbo::hash
+
+#endif  // MBO_HASH_HASH_MANGLE_H_

--- a/mbo/hash/hash_mh.h
+++ b/mbo/hash/hash_mh.h
@@ -42,6 +42,10 @@ inline constexpr uint64_t kMul2 = 0xC2B2AE3D27D4EB4FULL;
 // (see below). Tuned via //mbo/hash:hash_benchmark.
 inline constexpr std::size_t kSmallInputCutoff = 32;
 
+// Default seed (djb2's initial value). Shared so `mbo::hash::GetHash` folds the
+// same value the bare `GetHash*` functions use by default.
+inline constexpr uint64_t kDefaultSeed = 5'381;
+
 // 128-bit variant: dual-lane rotate-multiply state.
 //
 // Each 8-byte block is folded into both lanes, then the lane is rotated *before*
@@ -49,7 +53,7 @@ inline constexpr std::size_t kSmallInputCutoff = 32;
 // (a plain multiply-then-xor with a small multiplier diffuses far too slowly).
 // The two lanes combine the block differently (xor vs add) and use distinct
 // multipliers so they stay decorrelated.
-constexpr Hash128 GetHash128(std::string_view str, uint64_t seed = 5'381) noexcept {
+constexpr Hash128 GetHash128(std::string_view str, uint64_t seed = kDefaultSeed) noexcept {
   Hash128 hash = {.h1 = seed, .h2 = seed ^ 0xAA55AA55AA55AA55ULL};
 
   const char* ptr = str.data();
@@ -87,7 +91,7 @@ constexpr Hash128 GetHash128(std::string_view str, uint64_t seed = 5'381) noexce
 // state, which wins on throughput once the block loop dominates. (The two paths
 // deliberately produce different values -- GetHash64 is not required to equal a
 // fold of GetHash128.)
-constexpr uint64_t GetHash64(std::string_view str, uint64_t seed = 5'381) noexcept {
+constexpr uint64_t GetHash64(std::string_view str, uint64_t seed = kDefaultSeed) noexcept {
   const std::size_t len = str.size();
   if (len > kSmallInputCutoff) {
     return hash_internal::Hash128To64(GetHash128(str, seed));

--- a/mbo/hash/hash_mh.h
+++ b/mbo/hash/hash_mh.h
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MBO_HASH_HASH_MH_H_
+#define MBO_HASH_HASH_MH_H_
+
+// IWYU pragma: private, include "mbo/hash/hash.h"
+
+#include <bit>
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+
+#include "mbo/hash/hash_internal_util.h"
+#include "mbo/hash/hash_types.h"
+
+// The `mbo::hash::mh` ("mbo hash") implementation -- the current default behind
+// `mbo::hash::GetHash*`.
+namespace mbo::hash::mh {
+
+// NOLINTBEGIN(*-magic-numbers,*-pointer-arithmetic)
+
+// Full-width odd multipliers (golden-ratio / mix constants); distinct per lane so
+// the two 128-bit lanes stay decorrelated. Odd => invertible mod 2^64 (no bit
+// loss); full width => fast diffusion into the high bits.
+inline constexpr uint64_t kMul1 = 0x9E3779B97F4A7C15ULL;
+inline constexpr uint64_t kMul2 = 0xC2B2AE3D27D4EB4FULL;
+
+// Inputs of at most this many bytes use the cheaper single-lane GetHash64 path
+// (see below). Tuned via //mbo/hash:hash_benchmark.
+inline constexpr std::size_t kSmallInputCutoff = 32;
+
+// 128-bit variant: dual-lane rotate-multiply state.
+//
+// Each 8-byte block is folded into both lanes, then the lane is rotated *before*
+// the multiply so the block's low bits reach the high bits within a single round
+// (a plain multiply-then-xor with a small multiplier diffuses far too slowly).
+// The two lanes combine the block differently (xor vs add) and use distinct
+// multipliers so they stay decorrelated.
+constexpr Hash128 GetHash128(std::string_view str, uint64_t seed = 5'381) noexcept {
+  Hash128 hash = {.h1 = seed, .h2 = seed ^ 0xAA55AA55AA55AA55ULL};
+
+  const char* ptr = str.data();
+  const std::size_t len = str.size();
+  const std::size_t blocks = len / 8;
+
+  for (std::size_t i = 0; i < blocks; ++i) {
+    const uint64_t block = hash_internal::Load64(ptr);
+    hash.h1 = std::rotl(hash.h1 ^ block, 31) * kMul1;
+    hash.h2 = std::rotl(hash.h2 + block, 27) * kMul2;
+    ptr += 8;
+  }
+
+  const std::size_t remaining = len % 8;
+  if (remaining > 0) {
+    const uint64_t tail = hash_internal::LoadTail(ptr, remaining);
+    hash.h1 = std::rotl(hash.h1 ^ tail, 31) * kMul1;
+    hash.h2 = std::rotl(hash.h2 + tail, 27) * kMul2;
+  }
+
+  hash.h1 ^= len;
+  hash.h2 += len;
+
+  return {
+      .h1 = hash_internal::Fmix64(hash.h1),
+      .h2 = hash_internal::Fmix64(hash.h2),
+  };
+}
+
+// 64-bit variant.
+//
+// Small inputs (<= kSmallInputCutoff bytes) take a cheaper single-lane path with
+// a single finalize: the 128-bit dual-lane state plus its 128->64 fold add fixed
+// overhead that dominates for short keys. Larger inputs fold the full 128-bit
+// state, which wins on throughput once the block loop dominates. (The two paths
+// deliberately produce different values -- GetHash64 is not required to equal a
+// fold of GetHash128.)
+constexpr uint64_t GetHash64(std::string_view str, uint64_t seed = 5'381) noexcept {
+  const std::size_t len = str.size();
+  if (len > kSmallInputCutoff) {
+    return hash_internal::Hash128To64(GetHash128(str, seed));
+  }
+
+  const char* ptr = str.data();
+  uint64_t hash = seed ^ (static_cast<uint64_t>(len) * kMul2);
+  std::size_t pos = 0;
+  for (; pos + 8 <= len; pos += 8) {
+    hash ^= hash_internal::Load64(ptr + pos);
+    hash = std::rotl(hash, 31) * kMul1;
+  }
+  if (pos < len) {
+    hash ^= hash_internal::LoadTail(ptr + pos, len - pos);
+    hash = std::rotl(hash, 27) * kMul2;
+  }
+  return hash_internal::Fmix64(hash);
+}
+
+// NOLINTEND(*-magic-numbers,*-pointer-arithmetic)
+
+}  // namespace mbo::hash::mh
+
+#endif  // MBO_HASH_HASH_MH_H_

--- a/mbo/hash/hash_no_mangle_test.cc
+++ b/mbo/hash/hash_no_mangle_test.cc
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This target is built with -DMBO_HASH_MANGLE=0 (see BUILD.bazel) to cover the
+// disabled-mangle path: `GetHash` must then equal `GetHash64` and `HashMangle`
+// must be the identity.
+
+#include "gtest/gtest.h"
+#include "mbo/hash/hash.h"
+
+namespace mbo::hash {
+namespace {
+
+static_assert(MBO_HASH_MANGLE == 0, "this target must be built with -DMBO_HASH_MANGLE=0");
+
+// NOLINTBEGIN(*-magic-numbers)
+
+TEST(HashNoMangleTest, MangleIsIdentity) {
+  EXPECT_EQ(HashMangle(0), 0ULL);
+  EXPECT_EQ(HashMangle(0x0123456789ABCDEFULL), 0x0123456789ABCDEFULL);
+}
+
+TEST(HashNoMangleTest, GetHashEqualsGetHash64) {
+  EXPECT_EQ(GetHash("reproducible"), GetHash64("reproducible"));
+  EXPECT_EQ(GetHash(""), GetHash64(""));
+  EXPECT_EQ(GetHash("another value"), GetHash64("another value"));
+}
+
+// NOLINTEND(*-magic-numbers)
+
+}  // namespace
+}  // namespace mbo::hash

--- a/mbo/hash/hash_simple.h
+++ b/mbo/hash/hash_simple.h
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef MBO_HASH_SIMPLE_HASH_H_
-#define MBO_HASH_SIMPLE_HASH_H_
+#ifndef MBO_HASH_HASH_SIMPLE_H_
+#define MBO_HASH_HASH_SIMPLE_H_
 
 // IWYU pragma: private, include "mbo/hash/hash.h"
 
@@ -23,11 +23,14 @@
 #include <string_view>
 #include <type_traits>
 
+namespace mbo::hash::simple {
+
+// NOLINTBEGIN(*-identifier-naming,*-magic-numbers,*-constant-array-index,*-pointer-arithmetic,*-signed-bitwise)
+
 // Namespace `mbo::hash::simple` offers a `GetHash` a constexpr safe simple hash function.
-namespace mbo::hash::hash_internal {
+namespace hash_internal {
 
 inline constexpr uint64_t GetSimpleHash(std::string_view data) {
-  // NOLINTBEGIN(*-magic-numbers)
   constexpr uint64_t kArbitrary = 5'008'709'998'333'326'415ULL;
   constexpr uint64_t kPrimeNum10k = 104'729ULL;
   if (data.empty()) {
@@ -52,14 +55,14 @@ inline constexpr uint64_t GetSimpleHash(std::string_view data) {
       add += data[pos++] << 8U;
       add += data[pos++] << 16U;
       add += data[pos++] << 24U;
-      result = result * 6'571 ^ ((17 * add + (add >> 16U)) ^ (result >> 32U));
+      result = (result * 6'571) ^ ((17 * add + (add >> 16U)) ^ (result >> 32U));
       len -= 4;
     }
     uint64_t add = 0;
     switch (len) {
       case 3: add += data[pos + 2] << 16U;
       case 2: add += data[pos + 1] << 8U;
-      case 1: add += data[pos]; return result * 193 + kPrimeNum10k * add;
+      case 1: add += data[pos]; return (result * 193) + (kPrimeNum10k * add);
       default: break;
     }
     return result;
@@ -70,70 +73,41 @@ inline constexpr uint64_t GetSimpleHash(std::string_view data) {
     uint64_t add = 0;
     while (str < end) {
       std::memcpy(&add, str, 4);
-      result = result * 6'571 ^ ((17 * add + (add >> 16U)) ^ (result >> 32U));
-      str += 4;  // NOLINT(*-pointer-arithmetic)
+      result = (result * 6'571) ^ ((17 * add + (add >> 16U)) ^ (result >> 32U));
+      str += 4;
     }
     switch (data.length() % 4) {  // NOLINT(*-default-case)
       case 3:
         add = 0;
         std::memcpy(&add, str, 3);
-        return result * 193 + kPrimeNum10k * add;
+        return (result * 193) + (kPrimeNum10k * add);
       case 2:
         add = 0;
         std::memcpy(&add, str, 2);
-        return result * 193 + kPrimeNum10k * add;
+        return (result * 193) + (kPrimeNum10k * add);
       case 1:
         add = 0;
         std::memcpy(&add, str, 1);
-        return result * 193 + kPrimeNum10k * add;
+        return (result * 193) + (kPrimeNum10k * add);
       case 0: return result;
     }
     return result;
   }
-  // NOLINTEND(*-magic-numbers)
 }
 
-}  // namespace mbo::hash::hash_internal
+}  // namespace hash_internal
 
-namespace mbo::hash::simple {
-
-// NOLINTBEGIN(*-macro-usage)
-#define MBO_CONSTANT_P(expression, fallback) (fallback)
-#ifdef __has_builtin
-# if __has_builtin(__builtin_constant_p)
-#  undef MBO_CONSTANT_P
-#  define MBO_CONSTANT_P(expression, fallback) __builtin_constant_p(expression)
-# endif
-#endif
-// NOLINTEND(*-macro-usage)
-
-// A simple constexpr safe hash function.
-//
-// This function uses an optimized implementation at run-time and a constexpr safe implementation
-// that yields the exact same values for compile-time usage. It uses compiler provided macros as a
-// seed generator. This means that the seed **may** vary from run to run, but there is no guarantee
-// as a dev environment (e.g. Bazel) may set these macros always to the same value.
-inline constexpr uint64_t GetHash(std::string_view data) {
-  using mbo::hash::hash_internal::GetSimpleHash;
-  // In theory this should be a random number or at least an arbitray number that
-  // changes on every program start. Howeverm this number must be constexpr.
-  constexpr uint64_t kNotSoRandom =  //
-      5'008'709'998'333'326'415ULL
-#if defined(__DATE__)
-      ^ (MBO_CONSTANT_P(__DATE__, 1) == 0 ? 0 : GetSimpleHash(std::string_view(__DATE__)))
-#endif
-#if defined(__TIME__)
-      ^ (MBO_CONSTANT_P(__TIME__, 1) == 0 ? 0 : GetSimpleHash(std::string_view(__TIME__)))
-#endif
-#if defined(__TIMESTAMP__)
-      ^ (MBO_CONSTANT_P(__TIMESTAMP__, 1) == 0 ? 0 : GetSimpleHash(std::string_view(__TIMESTAMP__)))
-#endif
-      ;
-  return GetSimpleHash(data) ^ kNotSoRandom;
+inline constexpr uint64_t GetHash64(std::string_view data) {
+  return hash_internal::GetSimpleHash(data);
 }
 
-#undef MBO_CONSTANT_P  // Be gone.
+// Deprecated in version 0.13.0
+[[deprecated("Use ::mbo::hash::GetHash64() instead.")]] inline constexpr uint64_t GetHash(std::string_view data) {
+  return hash_internal::GetSimpleHash(data);
+}
+
+// NOLINTEND(*-identifier-naming,*-magic-numbers,*-constant-array-index,*-pointer-arithmetic,*-signed-bitwise)
 
 }  // namespace mbo::hash::simple
 
-#endif  // MBO_HASH_SIMPLE_HASH_H_
+#endif  // MBO_HASH_HASH_SIMPLE_H_

--- a/mbo/hash/hash_test.cc
+++ b/mbo/hash/hash_test.cc
@@ -187,6 +187,21 @@ TEST(HashMangleTest, GetHashAppliesMangle) {
   EXPECT_EQ(GetHash("hash-mangle-check"), HashMangle(GetHash64("hash-mangle-check")));
 }
 
+// A stand-in alternative implementation matching `Hash64Fn`, used to exercise
+// GetHash's pluggability.
+constexpr uint64_t AltHash64(std::string_view data, uint64_t seed) noexcept {
+  return mh::GetHash64(data, seed) ^ 0xABCDEFULL;
+}
+
+TEST(HashMangleTest, GetHashIsPluggable) {
+  // The default template argument matches the bare default call.
+  EXPECT_EQ(GetHash("plug"), GetHash<&mh::GetHash64>("plug"));
+  // Any Hash64Fn flows through the same mangle...
+  EXPECT_EQ(GetHash<&AltHash64>("plug"), HashMangle(AltHash64("plug", mh::kDefaultSeed)));
+  // ...and a different implementation yields a different mangled value.
+  EXPECT_NE(GetHash("plug"), GetHash<&AltHash64>("plug"));
+}
+
 // NOLINTEND(*-magic-numbers)
 
 }  // namespace

--- a/mbo/hash/hash_test.cc
+++ b/mbo/hash/hash_test.cc
@@ -194,12 +194,15 @@ constexpr uint64_t AltHash64(std::string_view data, uint64_t seed) noexcept {
 }
 
 TEST(HashMangleTest, GetHashIsPluggable) {
-  // The default template argument matches the bare default call.
+  // The default template arguments match the bare default call.
   EXPECT_EQ(GetHash("plug"), GetHash<&mh::GetHash64>("plug"));
   // Any Hash64Fn flows through the same mangle...
   EXPECT_EQ(GetHash<&AltHash64>("plug"), HashMangle(AltHash64("plug", mh::kDefaultSeed)));
   // ...and a different implementation yields a different mangled value.
   EXPECT_NE(GetHash("plug"), GetHash<&AltHash64>("plug"));
+  // The seed is a template constant too (parens guard the macro comma).
+  EXPECT_EQ((GetHash<&mh::GetHash64, 999>("plug")), HashMangle(mh::GetHash64("plug", 999)));
+  EXPECT_NE(GetHash("plug"), (GetHash<&mh::GetHash64, 999>("plug")));
 }
 
 // NOLINTEND(*-magic-numbers)

--- a/mbo/hash/hash_test.cc
+++ b/mbo/hash/hash_test.cc
@@ -173,6 +173,20 @@ TEST(Hash128Test, Ordering) {
   EXPECT_LT((Hash128{.h1 = 1, .h2 = 9}), (Hash128{.h1 = 2, .h2 = 0}));
 }
 
+// ---------------------------------------------------------------------------
+// HashMangle: a single per-build seed XORed in (see hash_mangle.h). The seed
+// value is build-dependent, so tests only assert seed-independent properties.
+// ---------------------------------------------------------------------------
+TEST(HashMangleTest, IsConstantXorMask) {
+  // HashMangle(x) == x ^ seed, so XORing two mangled values cancels the seed.
+  EXPECT_EQ(HashMangle(0) ^ HashMangle(1), 0ULL ^ 1ULL);
+  EXPECT_EQ(HashMangle(0x1111) ^ HashMangle(0x2222), 0x1111ULL ^ 0x2222ULL);
+}
+
+TEST(HashMangleTest, GetHashAppliesMangle) {
+  EXPECT_EQ(GetHash("hash-mangle-check"), HashMangle(GetHash64("hash-mangle-check")));
+}
+
 // NOLINTEND(*-magic-numbers)
 
 }  // namespace

--- a/mbo/hash/hash_test.cc
+++ b/mbo/hash/hash_test.cc
@@ -16,6 +16,7 @@
 #include "mbo/hash/hash.h"
 
 #include <array>
+#include <bit>
 #include <cstddef>
 #include <cstdint>
 #include <random>
@@ -23,115 +24,156 @@
 #include <string>
 #include <string_view>
 
-#include "gmock/gmock.h"
+#include "absl/container/flat_hash_set.h"
+#include "absl/strings/str_cat.h"
 #include "gtest/gtest.h"
+#include "mbo/hash/hash_test_util.h"
 
-// NOLINTBEGIN(cppcoreguidelines-pro-bounds-constant-array-index)
+// Shrink the heavy collision test under sanitizers (kept from the original test).
+#undef MBO_HASH_TEST_SANITIZER
+#if defined(__has_feature)
+# if __has_feature(address_sanitizer) || __has_feature(memory_sanitizer)
+#  define MBO_HASH_TEST_SANITIZER
+# endif
+#elif defined(__SANITIZE_ADDRESS__)
+# define MBO_HASH_TEST_SANITIZER
+#endif
 
-namespace mbo::hash::simple {
+namespace mbo::hash {
 namespace {
 
-using ::testing::Le;
-using ::testing::Ne;
+// NOLINTBEGIN(*-magic-numbers)
 
-struct HashTest : ::testing::Test {};
+constexpr uint64_t kSeed = 5'381;
 
-TEST_F(HashTest, TestEmty) {
-  constexpr std::size_t kHashEmpty = GetHash("");
-  constexpr std::size_t kHashNull = GetHash(std::string_view());
-  EXPECT_THAT(kHashEmpty, kHashNull);
-  // Force using non constexpr `GetHash` by providing a non const string_view variable.
-  const std::string_view sv_empty{""};  // NOLINT(*-redundant-string-init)
-  const std::string_view sv_null{};
-  const std::size_t hash_empty = GetHash(sv_empty);
-  const std::size_t hash_null = GetHash(sv_null);
-  EXPECT_THAT(kHashEmpty, hash_empty);
-  EXPECT_THAT(kHashEmpty, hash_null);
+// ---------------------------------------------------------------------------
+// Templated framework: every test below runs once per hash-algorithm descriptor
+// (see hash_test_util.h). Add an algorithm to `HashAlgorithms` to test it.
+// ---------------------------------------------------------------------------
+template<typename Algo>
+class HashTest : public ::testing::Test {};
+
+using HashAlgorithms = ::testing::Types<algo::SimpleHash, algo::DefaultHash>;
+TYPED_TEST_SUITE(HashTest, HashAlgorithms);
+
+// The framework detects 64- vs 128-bit algorithms from the descriptor.
+TYPED_TEST(HashTest, BitWidthDetection) {
+  EXPECT_EQ((algo::kHashBits<TypeParam>), algo::HasHash128<TypeParam> ? 128 : 64);
 }
 
-TEST_F(HashTest, Test) {
+// Compile-time and run-time evaluation must agree (single code path).
+TYPED_TEST(HashTest, ConstexprMatchesRuntime) {
+  constexpr uint64_t kCompile = TypeParam::Get64("constexpr-vs-runtime", kSeed);
+  std::string_view runtime = "constexpr-vs-runtime";  // non-const forces the runtime path
+  EXPECT_EQ(kCompile, TypeParam::Get64(runtime, kSeed));
+  if constexpr (algo::HasHash128<TypeParam>) {
+    constexpr Hash128 kCompile128 = TypeParam::Get128("constexpr-vs-runtime", kSeed);
+    EXPECT_EQ(kCompile128, TypeParam::Get128(runtime, kSeed));
+  }
+}
+
+TYPED_TEST(HashTest, EmptyEqualsNullAndIsNontrivial) {
+  const uint64_t empty = TypeParam::Get64(std::string_view(""), kSeed);
+  const uint64_t null_view = TypeParam::Get64(std::string_view(), kSeed);
+  EXPECT_EQ(empty, null_view);
+  EXPECT_NE(empty, uint64_t{0});
+  EXPECT_NE(empty, ~uint64_t{0});
+}
+
+TYPED_TEST(HashTest, DistinctForDistinctShortInputs) {
   constexpr std::array<std::string_view, 10> kData{
       "1", "12", "123", "1234", "12345", "123456", "1234567", "12345678", "123456789", "1234567890",
   };
-  // Generate the constexpr hashes.
-  constexpr std::array<uint64_t, kData.size()> kHashes{
-      GetHash(kData[0]), GetHash(kData[1]), GetHash(kData[2]), GetHash(kData[3]), GetHash(kData[4]),
-      GetHash(kData[5]), GetHash(kData[6]), GetHash(kData[7]), GetHash(kData[8]), GetHash(kData[9]),
-  };
-  std::string_view sv;
-  for (std::size_t n = 0; n < kData.size(); ++n) {
-    // Force using non constexpr `GetHash` by providing a non const string_view variable.
-    sv = kData[n];
-    EXPECT_THAT(GetHash(sv), kHashes[n]) << "Using the non const `string_view sv` to compute a hash should result in "
-                                            "the same value as the compile-time computed hash.";
-    EXPECT_THAT(GetHash(sv), Ne(0));
-    EXPECT_THAT(GetHash(sv), Ne(-1));
-    EXPECT_THAT(GetHash(sv), Ne(~0ULL));
-  }
-}
-
-class RandomStringGenerator {
- public:
-  static inline constexpr std::size_t kDefaultMaxLen = 80;
-
-  explicit RandomStringGenerator(int seed) : mt_(seed), char_dist_(0, kMaxChar) {}
-
-  std::string GetRandomString(std::size_t max_len = kDefaultMaxLen) const {
-    std::uniform_int_distribution<> str_len_dist(0, static_cast<int>(max_len));
-
-    std::size_t length{0};
-    while ((length = str_len_dist(mt_)) > max_len) {};
-    std::string str;
-    str.resize(length);
-    for (std::size_t n = 0; n < length; ++n) {
-      str[n] = static_cast<char>(char_dist_(mt_));
-    }
-    return str;
-  }
-
-  // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-  std::set<std::string> GetRandomStringSet(std::size_t num_strings, std::size_t max_len = kDefaultMaxLen) const {
-    std::set<std::string> result;
-    while (result.size() < num_strings) {
-      result.insert(GetRandomString(max_len));
-    }
-    return result;
-  }
-
- private:
-  static inline constexpr int kMaxChar = 255;  // Could exclude 255 (invalid UTF-8).
-  mutable std::mt19937 mt_;
-  mutable std::uniform_int_distribution<int> char_dist_;
-};
-
-#undef SANITIZER
-// Clang
-#if defined(__has_feature)
-# if __has_feature(address_sanitizer) || __has_feature(memory_sanitizer)
-#  define SANITIZER
-# endif
-// GCC
-#elif defined(__SANITIZE_ADDRESS__)
-# define SANITIZER
-#endif
-
-TEST_F(HashTest, Collision) {
-  const RandomStringGenerator rsg(::testing::UnitTest::GetInstance()->random_seed());
-#ifdef SANITIZER
-  constexpr std::size_t kNumStrings = 200'000;
-#else   // SANITIZER
-  constexpr std::size_t kNumStrings = 2'000'000;
-#endif  // SANITIZER
-  const std::set<std::string> strings = rsg.GetRandomStringSet(kNumStrings, 30);
   std::set<uint64_t> hashes;
-  for (const auto& str : strings) {
-    hashes.insert(GetHash(str));
+  for (const std::string_view data : kData) {
+    hashes.insert(TypeParam::Get64(data, kSeed));
   }
-  constexpr int kNumMaxCollisions = kNumStrings / 2'000'000;
-  EXPECT_THAT(strings.size() - hashes.size(), Le(kNumMaxCollisions));
+  EXPECT_EQ(hashes.size(), kData.size());
 }
+
+TYPED_TEST(HashTest, LowCollisionRate) {
+  std::mt19937_64 rng(::testing::UnitTest::GetInstance()->random_seed());
+#ifdef MBO_HASH_TEST_SANITIZER
+  constexpr std::size_t kNumStrings = 200'000;
+#else   // MBO_HASH_TEST_SANITIZER
+  constexpr std::size_t kNumStrings = 2'000'000;
+#endif  // MBO_HASH_TEST_SANITIZER
+  std::set<std::string> inputs;
+  while (inputs.size() < kNumStrings) {
+    inputs.insert(algo::RandomString(rng, 30));
+  }
+  std::set<uint64_t> hashes;
+  for (const std::string& input : inputs) {
+    hashes.insert(TypeParam::Get64(input, kSeed));
+  }
+  EXPECT_LE(inputs.size() - hashes.size(), kNumStrings / 2'000'000);
+}
+
+// Avalanche: flipping a single input bit should flip ~half the output bits.
+// Two lengths so both the small-input path and the block path get exercised.
+TYPED_TEST(HashTest, Avalanche) {
+  std::mt19937_64 rng(0xA5A5A5A5U);  // NOLINT(cert-msc51-cpp,cert-msc32-c): fixed seed keeps this reproducible
+  constexpr int kTrials = 8'000;
+  for (const std::size_t length : std::array<std::size_t, 2>{12, 100}) {
+    std::size_t flipped = 0;
+    for (int trial = 0; trial < kTrials; ++trial) {
+      const std::string base = algo::RandomString(rng, length);
+      const uint64_t hash0 = TypeParam::Get64(base, kSeed);
+      const std::size_t bit = rng() % (base.size() * 8);
+      std::string mutated = base;
+      const unsigned mask = 1U << (bit % 8U);
+      mutated[bit / 8] = static_cast<char>(static_cast<unsigned>(static_cast<unsigned char>(mutated[bit / 8])) ^ mask);
+      const uint64_t hash1 = TypeParam::Get64(mutated, kSeed);
+      flipped += static_cast<std::size_t>(std::popcount(hash0 ^ hash1));
+    }
+    const double ratio = static_cast<double>(flipped) / (static_cast<double>(kTrials) * 64.0);
+    if constexpr (TypeParam::kStrongAvalanche) {
+      EXPECT_GT(ratio, 0.45) << "len=" << length << " weak avalanche: " << ratio;
+      EXPECT_LT(ratio, 0.55) << "len=" << length << " biased avalanche: " << ratio;
+    } else {
+      EXPECT_GT(ratio, 0.10) << "len=" << length << " barely reacts: " << ratio;
+    }
+  }
+}
+
+// 128-bit-only checks; skipped for 64-bit-based algorithms via the detection trait.
+TYPED_TEST(HashTest, Hash128) {
+  if constexpr (algo::HasHash128<TypeParam>) {
+    EXPECT_EQ(TypeParam::Get128("abc", kSeed), TypeParam::Get128("abc", kSeed));  // deterministic
+    EXPECT_NE(TypeParam::Get128("abc", kSeed), TypeParam::Get128("abd", kSeed));  // distinct
+    constexpr std::string_view kLong = "this input is longer than the small-input cutoff.";
+    const Hash128 hash = TypeParam::Get128(kLong, kSeed);
+    EXPECT_NE(hash.h1, hash.h2);
+    // Above the small-input cutoff, the 64-bit variant folds the 128-bit state.
+    EXPECT_EQ(TypeParam::Get64(kLong, kSeed), hash_internal::Hash128To64(TypeParam::Get128(kLong, kSeed)));
+  } else {
+    GTEST_SKIP() << TypeParam::Name() << " is 64-bit only";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hash128 value-type behaviour (not per-algorithm).
+// ---------------------------------------------------------------------------
+TEST(Hash128Test, AbslStringifyRendersHex) {
+  const Hash128 hash{.h1 = 0x0123456789abcdefULL, .h2 = 0xfedcba9876543210ULL};
+  EXPECT_EQ(absl::StrCat(hash), "0x0123456789abcdeffedcba9876543210");
+}
+
+TEST(Hash128Test, AbslHashValueUsableAsKey) {
+  absl::flat_hash_set<Hash128> seen;
+  seen.insert(Hash128{.h1 = 1, .h2 = 2});
+  seen.insert(Hash128{.h1 = 1, .h2 = 2});
+  seen.insert(Hash128{.h1 = 3, .h2 = 4});
+  EXPECT_EQ(seen.size(), 2U);
+}
+
+TEST(Hash128Test, Ordering) {
+  EXPECT_EQ((Hash128{.h1 = 1, .h2 = 2}), (Hash128{.h1 = 1, .h2 = 2}));
+  EXPECT_LT((Hash128{.h1 = 1, .h2 = 2}), (Hash128{.h1 = 1, .h2 = 3}));
+  EXPECT_LT((Hash128{.h1 = 1, .h2 = 9}), (Hash128{.h1 = 2, .h2 = 0}));
+}
+
+// NOLINTEND(*-magic-numbers)
 
 }  // namespace
-}  // namespace mbo::hash::simple
-
-// NOLINTEND(cppcoreguidelines-pro-bounds-constant-array-index)
+}  // namespace mbo::hash

--- a/mbo/hash/hash_test_util.h
+++ b/mbo/hash/hash_test_util.h
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MBO_HASH_HASH_TEST_UTIL_H_
+#define MBO_HASH_HASH_TEST_UTIL_H_
+
+// Test/benchmark support -- NOT part of the public API.
+//
+// Provides a set of hash-algorithm *descriptors* and the traits that let a
+// single templated test/benchmark drive many algorithms, and detect whether an
+// algorithm is 64- or 128-bit based. Shared by hash_test.cc and hash_benchmark.cc.
+//
+// A descriptor exposes:
+//   static constexpr std::string_view Name();
+//   static constexpr uint64_t Get64(std::string_view data, uint64_t seed);   // required
+//   static constexpr Hash128  Get128(std::string_view data, uint64_t seed);  // optional
+//   static constexpr bool     kStrongAvalanche;   // whether it targets ~50% avalanche
+// Exposing Get128 makes the algorithm "128-bit based" (see HasHash128 / kHashBits).
+
+#include <concepts>
+#include <cstddef>
+#include <cstdint>
+#include <random>
+#include <string>
+#include <string_view>
+
+#include "mbo/hash/hash.h"
+
+namespace mbo::hash::algo {
+
+// The current default hash (namespace `mbo::hash::mh`, exposed via `GetHash*`).
+struct DefaultHash {
+  static constexpr bool kStrongAvalanche = true;
+
+  static constexpr std::string_view Name() { return "mh"; }
+
+  static constexpr uint64_t Get64(std::string_view data, uint64_t seed) {
+    return ::mbo::hash::mh::GetHash64(data, seed);
+  }
+
+  static constexpr ::mbo::hash::Hash128 Get128(std::string_view data, uint64_t seed) {
+    return ::mbo::hash::mh::GetHash128(data, seed);
+  }
+};
+
+// The previous "simple" implementation (64-bit only; ignores the seed).
+struct SimpleHash {
+  static constexpr bool kStrongAvalanche = false;
+
+  static constexpr std::string_view Name() { return "simple"; }
+
+  static constexpr uint64_t Get64(std::string_view data, uint64_t /*seed*/) {
+    return ::mbo::hash::simple::GetHash64(data);
+  }
+};
+
+// Detects whether an algorithm provides a 128-bit variant (is "128-bit based").
+template<typename Algo>
+concept HasHash128 = requires(std::string_view data, uint64_t seed) {
+  { Algo::Get128(data, seed) } -> std::same_as<::mbo::hash::Hash128>;
+};
+
+// The bit width the algorithm is based on: 128 if it exposes a 128-bit variant.
+template<typename Algo>
+inline constexpr int kHashBits = HasHash128<Algo> ? 128 : 64;
+
+// Pseudo-random byte string of `length` bytes (shared by tests and benchmarks).
+inline std::string RandomString(std::mt19937_64& rng, std::size_t length) {
+  static constexpr int kMaxByte = 255;
+  std::string result(length, '\0');
+  std::uniform_int_distribution<int> dist(0, kMaxByte);
+  for (std::size_t i = 0; i < length; ++i) {
+    result[i] = static_cast<char>(dist(rng));
+  }
+  return result;
+}
+
+}  // namespace mbo::hash::algo
+
+#endif  // MBO_HASH_HASH_TEST_UTIL_H_

--- a/mbo/hash/hash_types.h
+++ b/mbo/hash/hash_types.h
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MBO_HASH_HASH_TYPES_H_
+#define MBO_HASH_HASH_TYPES_H_
+
+// IWYU pragma: private, include "mbo/hash/hash.h"
+
+#include <array>
+#include <compare>  // IWYU pragma: keep  // std::strong_ordering for the defaulted operator<=>
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+#include <utility>
+
+namespace mbo::hash {
+
+// The structured 128-bit hash state produced by `mbo::hash::GetHash128`.
+struct Hash128 {
+  uint64_t h1;
+  uint64_t h2;
+
+  constexpr auto operator<=>(const Hash128& other) const noexcept = default;
+
+  // Abseil hashing support. Dependency-free: the caller-supplied `H` provides
+  // `combine`, so this needs no abseil header and keeps `hash_cc` free of that
+  // dependency while still letting `Hash128` be used as a key in Abseil maps.
+  template<typename H>
+  friend H AbslHashValue(H state, const Hash128& value) {
+    return H::combine(std::move(state), value.h1, value.h2);
+  }
+
+  // Abseil stringification: renders as `0x` followed by 32 lowercase hex digits
+  // (`h1` high half, `h2` low half). Dependency-free -- writes to the sink
+  // directly instead of via `absl::Format`.
+  template<typename Sink>
+  friend void AbslStringify(Sink& sink, const Hash128& value) {
+    // NOLINTBEGIN(*-magic-numbers,*-constant-array-index)
+    static constexpr std::string_view kHex = "0123456789abcdef";
+    std::array<char, 34> buffer = {'0', 'x'};
+    const std::array<uint64_t, 2> lanes = {value.h1, value.h2};
+    std::size_t pos = 2;
+    for (const uint64_t lane : lanes) {
+      for (int shift = 60; shift >= 0; shift -= 4) {
+        buffer[pos++] = kHex[(lane >> static_cast<unsigned>(shift)) & 0xFU];
+      }
+    }
+    sink.Append(std::string_view(buffer.data(), pos));
+    // NOLINTEND(*-magic-numbers,*-constant-array-index)
+  }
+};
+
+}  // namespace mbo::hash
+
+#endif  // MBO_HASH_HASH_TYPES_H_

--- a/mbo/types/tstring.h
+++ b/mbo/types/tstring.h
@@ -386,7 +386,7 @@ struct tstring final {
   }
 
   // Returns the value of `GetHash(str())` - so as if this was a `std::string` or `std::string`.
-  static constexpr uint64_t StringHash() { return ::mbo::hash::simple::GetHash(str()); }
+  static constexpr uint64_t StringHash() { return ::mbo::hash::GetHash64(str()); }
 
   // Returns the typed hash, so different from `StringHash` above.
   static constexpr uint64_t Hash() {

--- a/mbo/types/tstring_test.cc
+++ b/mbo/types/tstring_test.cc
@@ -662,28 +662,28 @@ TEST_F(TStringTest, FindFirstLast) {
 }
 
 TEST_F(TStringTest, StdHash) {
-  using ::mbo::hash::simple::GetHash;
+  using ::mbo::hash::GetHash64;
   // "bar"_ts
   constexpr tstring<'b', 'a', 'r'> kTsBar;
   using TsBar = decltype(kTsBar);
   const std::size_t k_bar_hash_ts = std::hash<TsBar>{}(kTsBar);
   EXPECT_THAT(std::hash<TsBar>{}(), k_bar_hash_ts);
-  constexpr auto kBarDirectHashTs = GetHash("bar");
+  constexpr auto kBarDirectHashTs = GetHash64("bar");
   EXPECT_THAT(kBarDirectHashTs, Ne(k_bar_hash_ts));
   EXPECT_THAT(kBarDirectHashTs, decltype(kTsBar)::StringHash());
   const std::string_view vs_bar{"bar"};
-  const auto k_bar_volatile_hash_ts = GetHash(vs_bar);
+  const auto k_bar_volatile_hash_ts = GetHash64(vs_bar);
   EXPECT_THAT(k_bar_volatile_hash_ts, kBarDirectHashTs);
   // "foo"_ts
   constexpr tstring<'f', 'o', 'o'> kTsFoo;
   using TsFoo = decltype(kTsFoo);
   const std::size_t k_foo_hash_ts = std::hash<TsFoo>{}(kTsFoo);
   EXPECT_THAT(std::hash<TsFoo>{}(), k_foo_hash_ts);
-  constexpr auto kFooDirectHashTs = GetHash("foo");
+  constexpr auto kFooDirectHashTs = GetHash64("foo");
   EXPECT_THAT(kFooDirectHashTs, Ne(k_foo_hash_ts));
   EXPECT_THAT(kFooDirectHashTs, decltype(kTsFoo)::StringHash());
   const std::string_view vs_foo{"foo"};
-  const auto k_foo_volatile_hash_ts = GetHash(vs_foo);
+  const auto k_foo_volatile_hash_ts = GetHash64(vs_foo);
   EXPECT_THAT(k_foo_volatile_hash_ts, kFooDirectHashTs);
   // hash("bar"_ts) != hash("foo"_ts)
   EXPECT_THAT(k_bar_hash_ts, Ne(k_foo_hash_ts));


### PR DESCRIPTION
Hardens and tests the new hash work, and makes it the default.

## What
- New `mbo::hash::GetHash64` / `GetHash128` + `Hash128` type (namespace `mbo::hash::mh`), now the default behind `mbo::hash::GetHash*`. `mbo::hash::simple::GetHash` is deprecated (kept as `simple::GetHash64`).
- Module bumped to **0.13.0** (matches the CHANGELOG entry).

## Implementation
- **Dual-lane rotate-multiply** core with full-width odd multipliers + MurmurHash3 `fmix64` finalize. Strong avalanche (verified ~0.50), ~2× `simple`'s throughput on ≥1 KB.
- **Endian-independent** little-endian byte loads (portable values across platforms; replaces `bit_cast`).
- **Small-input (≤32 B) fast path** for `GetHash64`: single lane + one finalize so short keys don't pay the 128-bit fold overhead (16 B: 9.8 GiB/s vs simple 6.8; 1 B improved 2.9→1.7 ns).
- `Hash128` gets dependency-free `AbslHashValue` / `AbslStringify` (no abseil dep added to `hash_cc`).

## Testing
- **Templated framework** (`hash_test_util.h`): algorithm descriptors + a `HasHash128`/`kHashBits` trait that **detects 64- vs 128-bit** algorithms. `hash_test.cc` runs `TYPED_TEST`s over `{simple, mh}` — constexpr==runtime, empty/null, distinctness, collisions, and **avalanche on both code paths**. The 128-bit test auto-skips for the 64-bit-only `simple`.
- **`hash_benchmark`** (`google_benchmark`, `tags=["manual"]`): length-bucketed throughput to substantiate the perf claims.

## Fixes rolled in (from the review)
Missing `<bit>`/`<cstddef>`/`<string_view>` includes, malformed NOLINT, IWYU private pragmas on impl headers, accurate `GetHash` doc + **stability note** (values are not stable across versions and not for persistence/crypto), and CHANGELOG/README reconciliation ("deprecated", not "removed").

## Perf note (reviewer FYI)
For 1–4 byte keys `simple` is still marginally faster (inherent `fmix64` finalize cost); `mh` wins or ties at typical key sizes (≥16 B) and is ~2× faster on large inputs. Hash values are intentionally not stable across versions.