### PR TITLE
feat(hash): add canonical FNV-1a, XXH64, and MurmurHash3 implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Deprecated `mbo::hash::simple::GetHash(std::string_view)`; use `mbo::hash::GetHash64()` instead. The previous implementation remains available as `mbo::hash::simple::GetHash64`.
 - `mbo::hash::GetHash` is now a template over the hash implementation and seed (`GetHash<&Fn, Seed>(data)`), defaulting to the current default.
 - Added constexpr-safe, canonical implementations of further hash algorithms, all usable with `GetHash<&Fn>`: `mbo::hash::fnv1a::GetHash64` (FNV-1a 64), `mbo::hash::xxh64::GetHash64` (XXH64), and `mbo::hash::murmur3::GetHash64/GetHash128` (MurmurHash3 x64 128). All produce the published reference values on every platform (little-endian defined).
+- Exposed `mbo::hash::Hash128To64(Hash128)`: folds a 128-bit hash into a well-mixed 64-bit one, e.g. to derive a fold-mixed 64-bit value from `murmur3::GetHash128` (whose `GetHash64` is the canonical `h1` truncation instead).
 - Added the `MBO_HASH_MANGLE` build flag (default `1`); define it to `0` for fully reproducible `GetHash` values (`GetHash == GetHash64`).
 - Hash values are not guaranteed stable across library versions and are not intended for persistence or cryptographic use.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Added `mbo::hash::GetHash64(std::string_view)` / `GetHash128(std::string_view)` and the `mbo::hash::Hash128` result type - a new constexpr-safe, non-cryptographic hash (namespace `mbo::hash::mh`), now the default behind `mbo::hash::GetHash*`.
 - Deprecated `mbo::hash::simple::GetHash(std::string_view)`; use `mbo::hash::GetHash64()` instead. The previous implementation remains available as `mbo::hash::simple::GetHash64`.
 - `mbo::hash::GetHash` is now a template over the hash implementation and seed (`GetHash<&Fn, Seed>(data)`), defaulting to the current default.
+- Added constexpr-safe, canonical implementations of further hash algorithms, all usable with `GetHash<&Fn>`: `mbo::hash::fnv1a::GetHash64` (FNV-1a 64), `mbo::hash::xxh64::GetHash64` (XXH64), and `mbo::hash::murmur3::GetHash64/GetHash128` (MurmurHash3 x64 128). All produce the published reference values on every platform (little-endian defined).
 - Added the `MBO_HASH_MANGLE` build flag (default `1`); define it to `0` for fully reproducible `GetHash` values (`GetHash == GetHash64`).
 - Hash values are not guaranteed stable across library versions and are not intended for persistence or cryptographic use.
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,11 @@ The C++ library is organized in functional groups each residing in their own dir
   - `namespace mbo::hash`
   - mbo/hash:hash_cc, mbo/hash/hash.h
     - function `GetHash64(std::string_view)` / `GetHash128(std::string_view)`: A constexpr-safe, non-cryptographic hash (result type `Hash128`). Values are not stable across versions and not for persistence.
-    - function `GetHash(std::string_view)`: as `GetHash64` but folded through a per-build (`__DATE__`/`__TIME__`) seed, so values may differ between builds.
+    - function `GetHash(std::string_view)`: as `GetHash64` but folded through a per-build (`__DATE__`/`__TIME__`) seed, so values may differ between builds. Templated over the implementation and seed: `GetHash<&Fn, Seed>(data)`.
     - function `simple::GetHash64(std::string_view)`: the previous hash implementation (`simple::GetHash` is deprecated).
+    - function `fnv1a::GetHash64(std::string_view)`: canonical FNV-1a 64 (constexpr-safe).
+    - function `xxh64::GetHash64(std::string_view)`: canonical XXH64 / xxHash 64-bit (constexpr-safe).
+    - function `murmur3::GetHash64/GetHash128(std::string_view)`: canonical MurmurHash3 x64 128-bit (constexpr-safe).
 - Json
   - `namespace mbo::json`
   - mbo/json:json_cc, mbo/json/json.h

--- a/mbo/hash/BUILD.bazel
+++ b/mbo/hash/BUILD.bazel
@@ -20,11 +20,14 @@ package(default_visibility = ["//visibility:private"])
 cc_library(
     name = "hash_cc",
     srcs = [
+        "hash_fnv1a.h",
         "hash_internal_util.h",
         "hash_mangle.h",
         "hash_mh.h",
+        "hash_murmur3.h",
         "hash_simple.h",
         "hash_types.h",
+        "hash_xxh64.h",
     ],
     hdrs = ["hash.h"],
     visibility = ["//visibility:public"],

--- a/mbo/hash/hash.h
+++ b/mbo/hash/hash.h
@@ -19,11 +19,14 @@
 #include <cstdint>
 #include <string_view>
 
+#include "mbo/hash/hash_fnv1a.h"          // IWYU pragma: export
 #include "mbo/hash/hash_internal_util.h"  // IWYU pragma: export
 #include "mbo/hash/hash_mangle.h"         // IWYU pragma: export
 #include "mbo/hash/hash_mh.h"             // IWYU pragma: export
+#include "mbo/hash/hash_murmur3.h"        // IWYU pragma: export
 #include "mbo/hash/hash_simple.h"         // IWYU pragma: export
 #include "mbo/hash/hash_types.h"          // IWYU pragma: export
+#include "mbo/hash/hash_xxh64.h"          // IWYU pragma: export
 
 namespace mbo::hash {
 

--- a/mbo/hash/hash.h
+++ b/mbo/hash/hash.h
@@ -34,6 +34,17 @@ namespace mbo::hash {
 using ::mbo::hash::mh::GetHash128;
 using ::mbo::hash::mh::GetHash64;
 
+// Folds a 128-bit hash into a well-mixed 64-bit one (not a plain truncation).
+//
+// Useful to derive a 64-bit value from any 128-bit based algorithm, e.g. a
+// fold-mixed (non-canonical) 64-bit murmur3:
+//
+//   uint64_t hash = mbo::hash::Hash128To64(mbo::hash::murmur3::GetHash128(data));
+//
+// Note that `murmur3::GetHash64` deliberately returns `h1` instead -- the
+// customary truncation that matches other MurmurHash3 implementations.
+using ::mbo::hash::hash_internal::Hash128To64;
+
 // The signature every pluggable 64-bit hash implementation provides:
 // `(data, seed) -> hash`, constexpr-safe and non-throwing.
 using Hash64Fn = uint64_t (*)(std::string_view, uint64_t) noexcept;

--- a/mbo/hash/hash_benchmark.cc
+++ b/mbo/hash/hash_benchmark.cc
@@ -61,7 +61,11 @@ void BmHash128(benchmark::State& state) {
 // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables,cppcoreguidelines-owning-memory)
 BENCHMARK_TEMPLATE(BmHash64, algo::SimpleHash)->RangeMultiplier(kRangeMultiplier)->Range(kMinLen, kMaxLen);
 BENCHMARK_TEMPLATE(BmHash64, algo::DefaultHash)->RangeMultiplier(kRangeMultiplier)->Range(kMinLen, kMaxLen);
+BENCHMARK_TEMPLATE(BmHash64, algo::Fnv1aHash)->RangeMultiplier(kRangeMultiplier)->Range(kMinLen, kMaxLen);
+BENCHMARK_TEMPLATE(BmHash64, algo::Xxh64Hash)->RangeMultiplier(kRangeMultiplier)->Range(kMinLen, kMaxLen);
+BENCHMARK_TEMPLATE(BmHash64, algo::Murmur3Hash)->RangeMultiplier(kRangeMultiplier)->Range(kMinLen, kMaxLen);
 BENCHMARK_TEMPLATE(BmHash128, algo::DefaultHash)->RangeMultiplier(kRangeMultiplier)->Range(kMinLen, kMaxLen);
+BENCHMARK_TEMPLATE(BmHash128, algo::Murmur3Hash)->RangeMultiplier(kRangeMultiplier)->Range(kMinLen, kMaxLen);
 // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables,cppcoreguidelines-owning-memory)
 
 // NOLINTEND(*-magic-numbers)

--- a/mbo/hash/hash_benchmark.cc
+++ b/mbo/hash/hash_benchmark.cc
@@ -19,6 +19,7 @@
 #include <cstdint>
 #include <random>
 #include <string>
+#include <tuple>
 
 #include "benchmark/benchmark.h"
 #include "mbo/hash/hash_test_util.h"
@@ -58,19 +59,38 @@ void BmHash128(benchmark::State& state) {
   state.SetLabel(std::string(Algo::Name()));
 }
 
-// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables,cppcoreguidelines-owning-memory)
-BENCHMARK_TEMPLATE(BmHash64, algo::SimpleHash)->RangeMultiplier(kRangeMultiplier)->Range(kMinLen, kMaxLen);
-BENCHMARK_TEMPLATE(BmHash64, algo::DefaultHash)->RangeMultiplier(kRangeMultiplier)->Range(kMinLen, kMaxLen);
-BENCHMARK_TEMPLATE(BmHash64, algo::Fnv1aHash)->RangeMultiplier(kRangeMultiplier)->Range(kMinLen, kMaxLen);
-BENCHMARK_TEMPLATE(BmHash64, algo::Xxh64Hash)->RangeMultiplier(kRangeMultiplier)->Range(kMinLen, kMaxLen);
-BENCHMARK_TEMPLATE(BmHash64, algo::Murmur3Hash)->RangeMultiplier(kRangeMultiplier)->Range(kMinLen, kMaxLen);
-BENCHMARK_TEMPLATE(BmHash128, algo::DefaultHash)->RangeMultiplier(kRangeMultiplier)->Range(kMinLen, kMaxLen);
-BENCHMARK_TEMPLATE(BmHash128, algo::Murmur3Hash)->RangeMultiplier(kRangeMultiplier)->Range(kMinLen, kMaxLen);
-// NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables,cppcoreguidelines-owning-memory)
+// Registers the 64-bit benchmark for one algorithm, plus the 128-bit one where
+// the descriptor provides it (detected via the framework's HasHash128).
+template<typename Algo>
+void RegisterAlgo() {
+  const std::string name(Algo::Name());
+  benchmark::RegisterBenchmark("BmHash64<" + name + ">", BmHash64<Algo>)
+      ->RangeMultiplier(kRangeMultiplier)
+      ->Range(kMinLen, kMaxLen);
+  if constexpr (algo::HasHash128<Algo>) {
+    benchmark::RegisterBenchmark("BmHash128<" + name + ">", BmHash128<Algo>)
+        ->RangeMultiplier(kRangeMultiplier)
+        ->Range(kMinLen, kMaxLen);
+  }
+}
+
+// Registers benchmarks for every descriptor in the central algo::AllAlgorithms
+// list -- an algorithm added there is automatically benchmarked here. The tuple
+// (of empty descriptor structs) is passed by value purely to deduce the pack.
+template<typename... Algos>
+void RegisterAll(std::tuple<Algos...> /*algorithms*/) {
+  (RegisterAlgo<Algos>(), ...);
+}
 
 // NOLINTEND(*-magic-numbers)
 
 }  // namespace
 }  // namespace mbo::hash
 
-BENCHMARK_MAIN();  // NOLINT
+int main(int argc, char** argv) {
+  mbo::hash::RegisterAll(mbo::hash::algo::AllAlgorithms{});
+  benchmark::Initialize(&argc, argv);
+  benchmark::RunSpecifiedBenchmarks();
+  benchmark::Shutdown();
+  return 0;
+}

--- a/mbo/hash/hash_fnv1a.h
+++ b/mbo/hash/hash_fnv1a.h
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MBO_HASH_HASH_FNV1A_H_
+#define MBO_HASH_HASH_FNV1A_H_
+
+// IWYU pragma: private, include "mbo/hash/hash.h"
+
+#include <cstdint>
+#include <string_view>
+
+// FNV-1a, 64-bit (Fowler-Noll-Vo; public domain). Byte-at-a-time, tiny and
+// portable, matching the canonical reference values. Weak final diffusion --
+// prefer `mbo::hash::mh` unless FNV-1a compatibility is required.
+namespace mbo::hash::fnv1a {
+
+// The standard 64-bit FNV offset basis, used as the default seed.
+inline constexpr uint64_t kOffsetBasis = 0xCBF29CE484222325ULL;
+
+// The standard 64-bit FNV prime.
+inline constexpr uint64_t kPrime = 0x100000001B3ULL;
+
+// Canonical FNV-1a: for each byte `hash = (hash ^ byte) * kPrime`. With the
+// default seed this matches published FNV-1a 64 reference values.
+constexpr uint64_t GetHash64(std::string_view data, uint64_t seed = kOffsetBasis) noexcept {
+  uint64_t hash = seed;
+  for (const char chr : data) {
+    hash ^= static_cast<uint8_t>(chr);
+    hash *= kPrime;
+  }
+  return hash;
+}
+
+}  // namespace mbo::hash::fnv1a
+
+#endif  // MBO_HASH_HASH_FNV1A_H_

--- a/mbo/hash/hash_internal_util.h
+++ b/mbo/hash/hash_internal_util.h
@@ -49,7 +49,16 @@ constexpr uint64_t Load64(const char* ptr) noexcept {
   return result;
 }
 
-// Loads the 1..7 remaining tail bytes as a little-endian `uint64_t` without any
+// Loads 4 bytes as a **little-endian** `uint32_t` (same rationale as `Load64`).
+constexpr uint32_t Load32(const char* ptr) noexcept {
+  uint32_t result = 0;
+  for (std::size_t i = 0; i < 4; ++i) {
+    result |= static_cast<uint32_t>(static_cast<uint8_t>(ptr[i])) << (i * 8U);
+  }
+  return result;
+}
+
+// Loads the 1..8 remaining tail bytes as a little-endian `uint64_t` without any
 // out-of-bounds reads.
 constexpr uint64_t LoadTail(const char* ptr, std::size_t remaining) noexcept {
   uint64_t result = 0;

--- a/mbo/hash/hash_murmur3.h
+++ b/mbo/hash/hash_murmur3.h
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MBO_HASH_HASH_MURMUR3_H_
+#define MBO_HASH_HASH_MURMUR3_H_
+
+// IWYU pragma: private, include "mbo/hash/hash.h"
+
+#include <bit>
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+
+#include "mbo/hash/hash_internal_util.h"
+#include "mbo/hash/hash_types.h"
+
+// MurmurHash3 x64 128-bit (Austin Appleby; public domain): a constexpr-safe
+// implementation producing the canonical MurmurHash3_x64_128 values (`h1` is the
+// first 8 output bytes, `h2` the second; the algorithm is little-endian defined,
+// and loads here are little-endian on every platform). `GetHash64` returns `h1`,
+// the customary 64-bit truncation.
+namespace mbo::hash::murmur3 {
+
+// NOLINTBEGIN(*-magic-numbers,*-pointer-arithmetic)
+
+// 128-bit variant, canonical MurmurHash3_x64_128 (default seed 0 as in the
+// reference implementation; the reference takes a 32-bit seed -- pass seeds
+// within uint32_t range for value compatibility).
+constexpr Hash128 GetHash128(std::string_view str, uint64_t seed = 0) noexcept {
+  constexpr uint64_t kMul1 = 0x87C37B91114253D5ULL;
+  constexpr uint64_t kMul2 = 0x4CF5AD432745937FULL;
+
+  const std::size_t len = str.size();
+  const char* ptr = str.data();
+
+  uint64_t hash1 = seed;
+  uint64_t hash2 = seed;
+
+  const std::size_t blocks = len / 16;
+  for (std::size_t i = 0; i < blocks; ++i) {
+    uint64_t key1 = hash_internal::Load64(ptr);
+    uint64_t key2 = hash_internal::Load64(ptr + 8);
+    ptr += 16;
+
+    key1 *= kMul1;
+    key1 = std::rotl(key1, 31);
+    key1 *= kMul2;
+    hash1 ^= key1;
+    hash1 = std::rotl(hash1, 27);
+    hash1 += hash2;
+    hash1 = (hash1 * 5) + 0x52DCE729ULL;
+
+    key2 *= kMul2;
+    key2 = std::rotl(key2, 33);
+    key2 *= kMul1;
+    hash2 ^= key2;
+    hash2 = std::rotl(hash2, 31);
+    hash2 += hash1;
+    hash2 = (hash2 * 5) + 0x38495AB5ULL;
+  }
+
+  const std::size_t tail = len % 16;
+  if (tail > 8) {
+    uint64_t key2 = hash_internal::LoadTail(ptr + 8, tail - 8);
+    key2 *= kMul2;
+    key2 = std::rotl(key2, 33);
+    key2 *= kMul1;
+    hash2 ^= key2;
+  }
+  if (tail > 0) {
+    uint64_t key1 = hash_internal::LoadTail(ptr, tail < 8 ? tail : 8);
+    key1 *= kMul1;
+    key1 = std::rotl(key1, 31);
+    key1 *= kMul2;
+    hash1 ^= key1;
+  }
+
+  hash1 ^= len;
+  hash2 ^= len;
+  hash1 += hash2;
+  hash2 += hash1;
+  hash1 = hash_internal::Fmix64(hash1);  // Fmix64 *is* MurmurHash3's fmix64.
+  hash2 = hash_internal::Fmix64(hash2);
+  hash1 += hash2;
+  hash2 += hash1;
+
+  return {.h1 = hash1, .h2 = hash2};
+}
+
+// 64-bit variant: the first 64 output bits (`h1`), the customary truncation.
+constexpr uint64_t GetHash64(std::string_view str, uint64_t seed = 0) noexcept {
+  return GetHash128(str, seed).h1;
+}
+
+// NOLINTEND(*-magic-numbers,*-pointer-arithmetic)
+
+}  // namespace mbo::hash::murmur3
+
+#endif  // MBO_HASH_HASH_MURMUR3_H_

--- a/mbo/hash/hash_test.cc
+++ b/mbo/hash/hash_test.cc
@@ -164,6 +164,14 @@ TEST(Murmur3HashTest, Hash64IsH1) {
   EXPECT_EQ(murmur3::GetHash64("truncation-check"), murmur3::GetHash128("truncation-check").h1);
 }
 
+// The documented composition: a fold-mixed (non-canonical) 64-bit value can be
+// derived from any 128-bit based algorithm via the public Hash128To64.
+TEST(Murmur3HashTest, FoldedHash64ByComposition) {
+  constexpr uint64_t kFolded = Hash128To64(murmur3::GetHash128("fold-check"));  // constexpr-safe
+  EXPECT_EQ(kFolded, hash_internal::Hash128To64(murmur3::GetHash128("fold-check")));
+  EXPECT_NE(kFolded, murmur3::GetHash64("fold-check"));  // distinct from the canonical truncation
+}
+
 // ---------------------------------------------------------------------------
 // Known-answer tests: fnv1a / xxh64 / murmur3 must produce the canonical
 // reference values (vectors generated with the reference implementations:

--- a/mbo/hash/hash_test.cc
+++ b/mbo/hash/hash_test.cc
@@ -53,7 +53,8 @@ constexpr uint64_t kSeed = 5'381;
 template<typename Algo>
 class HashTest : public ::testing::Test {};
 
-using HashAlgorithms = ::testing::Types<algo::SimpleHash, algo::DefaultHash>;
+using HashAlgorithms =
+    ::testing::Types<algo::SimpleHash, algo::DefaultHash, algo::Fnv1aHash, algo::Xxh64Hash, algo::Murmur3Hash>;
 TYPED_TEST_SUITE(HashTest, HashAlgorithms);
 
 // The framework detects 64- vs 128-bit algorithms from the descriptor.
@@ -137,6 +138,8 @@ TYPED_TEST(HashTest, Avalanche) {
 }
 
 // 128-bit-only checks; skipped for 64-bit-based algorithms via the detection trait.
+// How Get64 relates to Get128 is algorithm-specific (mh folds, murmur3 truncates)
+// and covered by per-algorithm tests below.
 TYPED_TEST(HashTest, Hash128) {
   if constexpr (algo::HasHash128<TypeParam>) {
     EXPECT_EQ(TypeParam::Get128("abc", kSeed), TypeParam::Get128("abc", kSeed));  // deterministic
@@ -144,12 +147,110 @@ TYPED_TEST(HashTest, Hash128) {
     constexpr std::string_view kLong = "this input is longer than the small-input cutoff.";
     const Hash128 hash = TypeParam::Get128(kLong, kSeed);
     EXPECT_NE(hash.h1, hash.h2);
-    // Above the small-input cutoff, the 64-bit variant folds the 128-bit state.
-    EXPECT_EQ(TypeParam::Get64(kLong, kSeed), hash_internal::Hash128To64(TypeParam::Get128(kLong, kSeed)));
   } else {
     GTEST_SKIP() << TypeParam::Name() << " is 64-bit only";
   }
 }
+
+// mh-specific: above the small-input cutoff the 64-bit variant folds the 128-bit state.
+TEST(MhHashTest, Hash64FoldsHash128AboveCutoff) {
+  constexpr std::string_view kLong = "this input is longer than the small-input cutoff.";
+  static_assert(kLong.size() > mh::kSmallInputCutoff);
+  EXPECT_EQ(mh::GetHash64(kLong, kSeed), hash_internal::Hash128To64(mh::GetHash128(kLong, kSeed)));
+}
+
+// murmur3-specific: the 64-bit variant is the canonical `h1` truncation.
+TEST(Murmur3HashTest, Hash64IsH1) {
+  EXPECT_EQ(murmur3::GetHash64("truncation-check"), murmur3::GetHash128("truncation-check").h1);
+}
+
+// ---------------------------------------------------------------------------
+// Known-answer tests: fnv1a / xxh64 / murmur3 must produce the canonical
+// reference values (vectors generated with the reference implementations:
+// python `xxhash` and `mmh3` packages, FNV-1a per its published spec).
+// The inputs cover the block/tail boundaries of each algorithm.
+// ---------------------------------------------------------------------------
+
+// Positional rows read better than repeating field names in a homogeneous table.
+// NOLINTBEGIN(modernize-use-designated-initializers)
+
+struct KnownAnswer64 {
+  uint64_t seed;
+  std::string_view data;
+  uint64_t expected;
+};
+
+TEST(KnownAnswerTest, Fnv1a) {
+  // Canonical FNV-1a 64 with the standard offset basis.
+  static constexpr std::array<KnownAnswer64, 6> kVectors{{
+      {fnv1a::kOffsetBasis, "", 0xcbf29ce484222325ULL},
+      {fnv1a::kOffsetBasis, "a", 0xaf63dc4c8601ec8cULL},
+      {fnv1a::kOffsetBasis, "abc", 0xe71fa2190541574bULL},
+      {fnv1a::kOffsetBasis, "12345678", 0x173932c41a90a42dULL},
+      {fnv1a::kOffsetBasis, "1234567890123456", 0x3d30e6aa7c1d4bd3ULL},
+      {fnv1a::kOffsetBasis, "The quick brown fox jumps over the lazy dog", 0xf3f9b7f5e7e47110ULL},
+  }};
+  static_assert(fnv1a::GetHash64("") == 0xcbf29ce484222325ULL);  // constexpr-safe & canonical
+  for (const auto& [seed, data, expected] : kVectors) {
+    EXPECT_EQ(fnv1a::GetHash64(data, seed), expected) << "input: \"" << data << "\"";
+  }
+}
+
+TEST(KnownAnswerTest, Xxh64) {
+  static constexpr std::array<KnownAnswer64, 13> kVectors{{
+      // seed 0; lengths cover <4, 4..7, 8..31, one 32-byte stripe, and beyond.
+      {0, "", 0xef46db3751d8e999ULL},
+      {0, "a", 0xd24ec4f1a98c6e5bULL},
+      {0, "abc", 0x44bc2cf5ad770999ULL},
+      {0, "1234", 0xd8316e61d84f6ba4ULL},
+      {0, "12345678", 0xd2d02f08cf7cfd4aULL},
+      {0, "123456789012345", 0xc377d78ade001a3cULL},
+      {0, "1234567890123456", 0xb61c33dc6c59f270ULL},
+      {0, "1234567890123456789012345678901", 0x8f367cb873a5376eULL},
+      {0, "12345678901234567890123456789012", 0x40fd1aa52d98274cULL},
+      {0, "The quick brown fox jumps over the lazy dog", 0x0b242d361fda71bcULL},
+      // Non-zero seed.
+      {5'381, "", 0xaf382146d5c3cacfULL},
+      {5'381, "abc", 0x19d1c1b5c673451fULL},
+      {5'381, "12345678901234567890123456789012", 0x38ea26e7c55f8095ULL},
+  }};
+  static_assert(xxh64::GetHash64("") == 0xef46db3751d8e999ULL);  // constexpr-safe & canonical
+  for (const auto& [seed, data, expected] : kVectors) {
+    EXPECT_EQ(xxh64::GetHash64(data, seed), expected) << "input: \"" << data << "\", seed: " << seed;
+  }
+}
+
+struct KnownAnswer128 {
+  uint64_t seed;
+  std::string_view data;
+  Hash128 expected;
+};
+
+TEST(KnownAnswerTest, Murmur3) {
+  static constexpr std::array<KnownAnswer128, 13> kVectors{{
+      // seed 0; lengths cover empty, tail-only, one 16-byte block, block+tail.
+      {0, "", {.h1 = 0x0000000000000000ULL, .h2 = 0x0000000000000000ULL}},
+      {0, "a", {.h1 = 0x85555565f6597889ULL, .h2 = 0xe6b53a48510e895aULL}},
+      {0, "abc", {.h1 = 0xb4963f3f3fad7867ULL, .h2 = 0x3ba2744126ca2d52ULL}},
+      {0, "1234", {.h1 = 0x0897364d218fe7b4ULL, .h2 = 0x341e8bd92437fda5ULL}},
+      {0, "12345678", {.h1 = 0x3b4a640638b1419cULL, .h2 = 0x913b0e676bd42557ULL}},
+      {0, "123456789012345", {.h1 = 0x887001aea2afcfd6ULL, .h2 = 0x1ec326364f0801b3ULL}},
+      {0, "1234567890123456", {.h1 = 0x4fbe5dc5c0e32cf8ULL, .h2 = 0xc0c8e96b60c322c1ULL}},
+      {0, "1234567890123456789012345678901", {.h1 = 0x834b6c169e6c76d0ULL, .h2 = 0x9fb1ab235cc38195ULL}},
+      {0, "12345678901234567890123456789012", {.h1 = 0xfb942466dfc9d856ULL, .h2 = 0x383859a6263746cfULL}},
+      {0, "The quick brown fox jumps over the lazy dog", {.h1 = 0xe34bbc7bbc071b6cULL, .h2 = 0x7a433ca9c49a9347ULL}},
+      // Non-zero seed (the reference takes a 32-bit seed; 5381 is in range).
+      {5'381, "", {.h1 = 0xef2b598707a4bc70ULL, .h2 = 0x702e1ccf5cc2c6d8ULL}},
+      {5'381, "abc", {.h1 = 0x5ff46b62f90afefaULL, .h2 = 0xa5d8a2001713a02eULL}},
+      {5'381, "1234567890123456", {.h1 = 0x17e206afe56af6d7ULL, .h2 = 0xe73148f7ad58bae2ULL}},
+  }};
+  static_assert(murmur3::GetHash128("").h1 == 0);  // constexpr-safe & canonical
+  for (const auto& [seed, data, expected] : kVectors) {
+    EXPECT_EQ(murmur3::GetHash128(data, seed), expected) << "input: \"" << data << "\", seed: " << seed;
+  }
+}
+
+// NOLINTEND(modernize-use-designated-initializers)
 
 // ---------------------------------------------------------------------------
 // Hash128 value-type behaviour (not per-algorithm).

--- a/mbo/hash/hash_test.cc
+++ b/mbo/hash/hash_test.cc
@@ -23,6 +23,7 @@
 #include <set>
 #include <string>
 #include <string_view>
+#include <tuple>
 
 #include "absl/container/flat_hash_set.h"
 #include "absl/strings/str_cat.h"
@@ -53,8 +54,17 @@ constexpr uint64_t kSeed = 5'381;
 template<typename Algo>
 class HashTest : public ::testing::Test {};
 
-using HashAlgorithms =
-    ::testing::Types<algo::SimpleHash, algo::DefaultHash, algo::Fnv1aHash, algo::Xxh64Hash, algo::Murmur3Hash>;
+// Derive the gtest type list from the central algo::AllAlgorithms tuple, so a
+// descriptor added there is automatically tested here.
+template<typename Tuple>
+struct TupleToGtestTypes;
+
+template<typename... Ts>
+struct TupleToGtestTypes<std::tuple<Ts...>> {
+  using type = ::testing::Types<Ts...>;
+};
+
+using HashAlgorithms = TupleToGtestTypes<algo::AllAlgorithms>::type;
 TYPED_TEST_SUITE(HashTest, HashAlgorithms);
 
 // The framework detects 64- vs 128-bit algorithms from the descriptor.

--- a/mbo/hash/hash_test_util.h
+++ b/mbo/hash/hash_test_util.h
@@ -66,6 +66,43 @@ struct SimpleHash {
   }
 };
 
+// FNV-1a 64 (canonical values; byte-at-a-time, weak final diffusion).
+struct Fnv1aHash {
+  static constexpr bool kStrongAvalanche = false;
+
+  static constexpr std::string_view Name() { return "fnv1a"; }
+
+  static constexpr uint64_t Get64(std::string_view data, uint64_t seed) {
+    return ::mbo::hash::fnv1a::GetHash64(data, seed);
+  }
+};
+
+// XXH64 (canonical xxHash 64-bit values).
+struct Xxh64Hash {
+  static constexpr bool kStrongAvalanche = true;
+
+  static constexpr std::string_view Name() { return "xxh64"; }
+
+  static constexpr uint64_t Get64(std::string_view data, uint64_t seed) {
+    return ::mbo::hash::xxh64::GetHash64(data, seed);
+  }
+};
+
+// MurmurHash3 x64 128 (canonical values; 128-bit based, Get64 == h1).
+struct Murmur3Hash {
+  static constexpr bool kStrongAvalanche = true;
+
+  static constexpr std::string_view Name() { return "murmur3"; }
+
+  static constexpr uint64_t Get64(std::string_view data, uint64_t seed) {
+    return ::mbo::hash::murmur3::GetHash64(data, seed);
+  }
+
+  static constexpr ::mbo::hash::Hash128 Get128(std::string_view data, uint64_t seed) {
+    return ::mbo::hash::murmur3::GetHash128(data, seed);
+  }
+};
+
 // Detects whether an algorithm provides a 128-bit variant (is "128-bit based").
 template<typename Algo>
 concept HasHash128 = requires(std::string_view data, uint64_t seed) {

--- a/mbo/hash/hash_test_util.h
+++ b/mbo/hash/hash_test_util.h
@@ -35,6 +35,7 @@
 #include <random>
 #include <string>
 #include <string_view>
+#include <tuple>
 
 #include "mbo/hash/hash.h"
 
@@ -102,6 +103,11 @@ struct Murmur3Hash {
     return ::mbo::hash::murmur3::GetHash128(data, seed);
   }
 };
+
+// All registered algorithm descriptors. The typed tests and the benchmark both
+// derive their coverage from this single list, so adding a descriptor here is
+// sufficient to test AND benchmark a new algorithm.
+using AllAlgorithms = std::tuple<SimpleHash, DefaultHash, Fnv1aHash, Xxh64Hash, Murmur3Hash>;
 
 // Detects whether an algorithm provides a 128-bit variant (is "128-bit based").
 template<typename Algo>

--- a/mbo/hash/hash_xxh64.h
+++ b/mbo/hash/hash_xxh64.h
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MBO_HASH_HASH_XXH64_H_
+#define MBO_HASH_HASH_XXH64_H_
+
+// IWYU pragma: private, include "mbo/hash/hash.h"
+
+#include <bit>
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+
+#include "mbo/hash/hash_internal_util.h"
+
+// XXH64: a constexpr-safe implementation of the xxHash 64-bit algorithm
+// (https://xxhash.com, algorithm spec is BSD-2-Clause). Produces the canonical
+// XXH64 values (the algorithm is little-endian defined; loads here are
+// little-endian on every platform), so results can be compared against other
+// xxHash implementations and tools.
+namespace mbo::hash::xxh64 {
+
+// NOLINTBEGIN(*-magic-numbers,*-pointer-arithmetic)
+
+inline constexpr uint64_t kPrime1 = 0x9E3779B185EBCA87ULL;
+inline constexpr uint64_t kPrime2 = 0xC2B2AE3D27D4EB4FULL;
+inline constexpr uint64_t kPrime3 = 0x165667B19E3779F9ULL;
+inline constexpr uint64_t kPrime4 = 0x85EBCA77C2B2AE63ULL;
+inline constexpr uint64_t kPrime5 = 0x27D4EB2F165667C5ULL;
+
+namespace xxh64_internal {
+
+constexpr uint64_t Round(uint64_t acc, uint64_t input) noexcept {
+  return std::rotl(acc + (input * kPrime2), 31) * kPrime1;
+}
+
+constexpr uint64_t MergeRound(uint64_t hash, uint64_t lane) noexcept {
+  return ((hash ^ Round(0, lane)) * kPrime1) + kPrime4;
+}
+
+}  // namespace xxh64_internal
+
+// Canonical XXH64 (default seed 0, as in the reference implementation).
+constexpr uint64_t GetHash64(std::string_view str, uint64_t seed = 0) noexcept {
+  const std::size_t len = str.size();
+  const char* ptr = str.data();
+  std::size_t remaining = len;
+
+  uint64_t hash = 0;
+  if (remaining >= 32) {
+    uint64_t acc1 = seed + kPrime1 + kPrime2;
+    uint64_t acc2 = seed + kPrime2;
+    uint64_t acc3 = seed;
+    uint64_t acc4 = seed - kPrime1;
+    while (remaining >= 32) {
+      acc1 = xxh64_internal::Round(acc1, hash_internal::Load64(ptr));
+      acc2 = xxh64_internal::Round(acc2, hash_internal::Load64(ptr + 8));
+      acc3 = xxh64_internal::Round(acc3, hash_internal::Load64(ptr + 16));
+      acc4 = xxh64_internal::Round(acc4, hash_internal::Load64(ptr + 24));
+      ptr += 32;
+      remaining -= 32;
+    }
+    hash = std::rotl(acc1, 1) + std::rotl(acc2, 7) + std::rotl(acc3, 12) + std::rotl(acc4, 18);
+    hash = xxh64_internal::MergeRound(hash, acc1);
+    hash = xxh64_internal::MergeRound(hash, acc2);
+    hash = xxh64_internal::MergeRound(hash, acc3);
+    hash = xxh64_internal::MergeRound(hash, acc4);
+  } else {
+    hash = seed + kPrime5;
+  }
+
+  hash += len;
+
+  while (remaining >= 8) {
+    hash ^= xxh64_internal::Round(0, hash_internal::Load64(ptr));
+    hash = (std::rotl(hash, 27) * kPrime1) + kPrime4;
+    ptr += 8;
+    remaining -= 8;
+  }
+  if (remaining >= 4) {
+    hash ^= static_cast<uint64_t>(hash_internal::Load32(ptr)) * kPrime1;
+    hash = (std::rotl(hash, 23) * kPrime2) + kPrime3;
+    ptr += 4;
+    remaining -= 4;
+  }
+  while (remaining > 0) {
+    hash ^= static_cast<uint64_t>(static_cast<uint8_t>(*ptr)) * kPrime5;
+    hash = std::rotl(hash, 11) * kPrime1;
+    ++ptr;
+    --remaining;
+  }
+
+  hash ^= hash >> 33U;
+  hash *= kPrime2;
+  hash ^= hash >> 29U;
+  hash *= kPrime3;
+  hash ^= hash >> 32U;
+  return hash;
+}
+
+// NOLINTEND(*-magic-numbers,*-pointer-arithmetic)
+
+}  // namespace mbo::hash::xxh64
+
+#endif  // MBO_HASH_HASH_XXH64_H_


### PR DESCRIPTION
Follow-up to #208: more hash algorithms, plugged into the templated test/benchmark framework.

## What
Three well-known algorithms as constexpr-safe, dependency-free headers, each in its own namespace and usable via `GetHash<&Fn>`:

- `mbo::hash::fnv1a::GetHash64` — FNV-1a 64 (public domain)
- `mbo::hash::xxh64::GetHash64` — XXH64 / xxHash 64-bit (BSD-2 spec)
- `mbo::hash::murmur3::GetHash64/GetHash128` — MurmurHash3 x64 128 (public domain); the second 128-bit-based algorithm, exercising the framework's width detection

All produce the **published reference values on every platform** — the algorithms are little-endian defined and the loads use the endian-independent `hash_internal` helpers (new `Load32` for XXH64's tail).

`mbo::hash::Hash128To64` is now public API, with the fold recipe documented at the alias: `Hash128To64(murmur3::GetHash128(data))` gives a fold-mixed (non-canonical) 64-bit murmur3; `murmur3::GetHash64` stays the canonical `h1` truncation.

## Testing
- **Known-answer tests**: vectors generated with the reference implementations (python `xxhash` / `mmh3`, FNV per spec), covering each algorithm's block/tail boundaries and non-zero seeds. These caught a wrong Murmur3 constant during development — the vectors are doing their job.
- **Single algorithm list**: `algo::AllAlgorithms` in `hash_test_util.h` is the single source of truth — the typed test suite and the benchmark both derive from it, so one added descriptor is tested *and* benchmarked automatically (128-bit benchmarks auto-register where `HasHash128` detects them).
- 47 tests: 44 pass, 3 skips = exactly the 64-bit-only algorithms skipping the 128-bit test.

## Benchmark

Apple M-series, `bazel run -c opt //mbo/hash:hash_benchmark -- --benchmark_min_time=0.2s`. Throughput in GiB/s (higher is better), random data per length.

### 64-bit (`GetHash64`)

| len | simple | mh | fnv1a | xxh64 | murmur3 |
|---:|---:|---:|---:|---:|---:|
| 1 B | 1.15 | 0.54 | **1.91** | 0.52 | 0.31 |
| 4 B | **3.85** | 1.43 | 2.58 | 1.87 | 0.84 |
| 16 B | 6.87 | **9.75** | 2.25 | 4.90 | 3.81 |
| 64 B | 6.06 | 7.11 | 1.45 | **8.75** | 6.62 |
| 256 B | 3.31 | 6.27 | 0.83 | **14.68** | 7.07 |
| 1 KB | 2.45 | 4.70 | 0.70 | **17.17** | 5.75 |
| 4 KB | 2.20 | 4.36 | 0.68 | **16.73** | 5.36 |

### 128-bit (`GetHash128`)

| len | mh | murmur3 |
|---:|---:|---:|
| 1 B | **0.42** | 0.30 |
| 16 B | **5.21** | 3.80 |
| 256 B | 6.52 | **7.07** |
| 4 KB | 4.44 | **5.38** |

Takeaways: `mh` is the best all-rounder at typical key sizes (≈9.8 GiB/s @ 16 B); `xxh64`'s 4-accumulator stripes dominate from ~64 B up (≈17 GiB/s peak) — a possible future direction for `mh`'s block loop; `fnv1a` only wins at ~1 byte and falls off hard; `murmur3` is a solid mid-fielder and slightly beats `mh` on large 128-bit hashing.