### PR TITLE
ci: run the hash benchmark per-OS as an informational job

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,8 @@
+# Configuration for actionlint (run via pre-commit).
+self-hosted-runner:
+  # Not actually self-hosted: newer GitHub-hosted runner images that the pinned
+  # actionlint release does not know about yet. The `test-*` jobs already use
+  # macos-26 via `${{inputs.os}}` (which actionlint cannot resolve); this makes
+  # the label usable in literal `runs-on`/matrix values too.
+  labels:
+    - macos-26

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,32 @@ jobs:
       - uses: pre-commit-ci/lite-action@v1.0.2
         if: always()
 
+  benchmark:
+    # Informational only (hence continue-on-error): shared runners are noisy, so
+    # these numbers are for architecture/compiler shape comparisons (x86_64 gcc
+    # vs arm64 Apple clang) and gross regressions, not precise gating. Results
+    # appear in the job log and as a JSON artifact per OS.
+    continue-on-error: true
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-26]
+    runs-on: ${{matrix.os}}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: bazelbuild/setup-bazelisk@v3
+      - name: Run hash benchmark
+        run: |
+          bazel run -c opt //mbo/hash:hash_benchmark -- \
+            --benchmark_min_time=0.2s \
+            --benchmark_repetitions=3 \
+            --benchmark_report_aggregates_only=true \
+            --benchmark_out="${GITHUB_WORKSPACE}/hash_benchmark.json" \
+            --benchmark_out_format=json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: hash-benchmark-${{matrix.os}}
+          path: hash_benchmark.json
+
   test-gcc:
     needs: pre-commit
     secrets: inherit
@@ -154,7 +180,7 @@ jobs:
       bazel_config: ${{ matrix.bazel_config }}
 
   done:
-    needs: [trunk, pre-commit, test-gcc, test-clang, test-bcr]
+    needs: [trunk, pre-commit, benchmark, test-gcc, test-clang, test-bcr]
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Runs `//mbo/hash:hash_benchmark` (`-c opt`, 3 repetitions, aggregates) on `ubuntu-latest` (x86_64, gcc) and `macos-26` (arm64, Apple clang), uploading JSON artifacts per OS.

**Why:** all benchmark numbers so far are from one Apple M-series machine with clang. Upcoming `mh` performance work (4-lane stripes + tiny-input path, prototyped ~3-4x on large inputs) needs (a) x86_64/gcc shape data — e.g. whether gcc folds the endian-independent byte-assembly loads into single loads like clang does — and (b) a baseline *before* the change lands.

**Deliberately non-gating** (`continue-on-error`): shared runners are noisy (±20-50%), so this is for per-arch/compiler comparisons and gross regressions, not precise thresholds. Job is wired into the `done` gate like all others.

Also registers the `macos-26` runner label in `.github/actionlint.yaml` (the pinned actionlint predates that image; existing `macos-26` uses hide behind `${{inputs.os}}`).