### PR TITLE
perf(hash): memcpy loads, overlap tails, 4-lane stripes for mh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added constexpr-safe, canonical implementations of further hash algorithms, all usable with `GetHash<&Fn>`: `mbo::hash::fnv1a::GetHash64` (FNV-1a 64), `mbo::hash::xxh64::GetHash64` (XXH64), and `mbo::hash::murmur3::GetHash64/GetHash128` (MurmurHash3 x64 128). All produce the published reference values on every platform (little-endian defined).
 - Exposed `mbo::hash::Hash128To64(Hash128)`: folds a 128-bit hash into a well-mixed 64-bit one, e.g. to derive a fold-mixed 64-bit value from `murmur3::GetHash128` (whose `GetHash64` is the canonical `h1` truncation instead).
 - Added the `MBO_HASH_MANGLE` build flag (default `1`); define it to `0` for fully reproducible `GetHash` values (`GetHash == GetHash64`).
+- Made the default hash substantially faster (changing its values, as allowed by the stability contract): runtime loads now use `memcpy` (gcc never folded the byte-assembly loads - roughly 3x on gcc for **all** algorithms), tail loads use branch-lite overlapping reads, and `mh::GetHash128` processes large inputs (>= 64 bytes) in 32-byte stripes over 4 accumulators with a cross-mixed finalizer - about 2.5-3.7x throughput at >= 256 bytes, now beating `xxh64`.
 - Hash values are not guaranteed stable across library versions and are not intended for persistence or cryptographic use.
 
 # 0.12.0

--- a/mbo/hash/hash_internal_util.h
+++ b/mbo/hash/hash_internal_util.h
@@ -18,8 +18,11 @@
 
 // IWYU pragma: private, include "mbo/hash/hash.h"
 
+#include <bit>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
+#include <type_traits>
 
 #include "mbo/hash/hash_types.h"
 
@@ -37,11 +40,24 @@ constexpr uint64_t Fmix64(uint64_t val) noexcept {
   return val;
 }
 
-// Loads 8 bytes as a **little-endian** `uint64_t`. Assembling the word from bytes
-// (rather than `std::bit_cast`) makes the result endian-independent, so hashes
-// match across platforms; it is constexpr-safe and compilers fold it to a single
-// load on little-endian targets (a load + byte-swap on big-endian).
+// Loads 8 bytes as a **little-endian** `uint64_t`, endian-independently, so hash
+// values match across platforms.
+//
+// At run time on little-endian targets this is a plain `memcpy`, which every
+// compiler folds into a single load. The byte-assembly loop remains for constant
+// evaluation (where `memcpy` is not allowed) and for big-endian targets. Clang
+// folds the loop into a single load as well, but gcc does NOT (verified on
+// gcc 13: 8x movzx+or, ~3x slower hashing) -- hence the explicit `memcpy` path.
+// Both paths produce identical values; the ConstexprMatchesRuntime test guards
+// this equality.
 constexpr uint64_t Load64(const char* ptr) noexcept {
+  if (!std::is_constant_evaluated()) {
+    if constexpr (std::endian::native == std::endian::little) {
+      uint64_t result = 0;
+      std::memcpy(&result, ptr, 8);
+      return result;
+    }
+  }
   uint64_t result = 0;
   for (std::size_t i = 0; i < 8; ++i) {
     result |= static_cast<uint64_t>(static_cast<uint8_t>(ptr[i])) << (i * 8U);
@@ -51,6 +67,13 @@ constexpr uint64_t Load64(const char* ptr) noexcept {
 
 // Loads 4 bytes as a **little-endian** `uint32_t` (same rationale as `Load64`).
 constexpr uint32_t Load32(const char* ptr) noexcept {
+  if (!std::is_constant_evaluated()) {
+    if constexpr (std::endian::native == std::endian::little) {
+      uint32_t result = 0;
+      std::memcpy(&result, ptr, 4);
+      return result;
+    }
+  }
   uint32_t result = 0;
   for (std::size_t i = 0; i < 4; ++i) {
     result |= static_cast<uint32_t>(static_cast<uint8_t>(ptr[i])) << (i * 8U);
@@ -60,7 +83,22 @@ constexpr uint32_t Load32(const char* ptr) noexcept {
 
 // Loads the 1..8 remaining tail bytes as a little-endian `uint64_t` without any
 // out-of-bounds reads.
+//
+// The runtime path for >= 4 bytes uses two overlapping 4-byte loads instead of a
+// per-byte loop: `lo` covers bytes [0..3], `hi << ((n-4)*8)` covers bytes
+// [n-4..n-1], and in the overlap both operands carry the same byte at the same
+// bit position, so the OR reproduces the exact little-endian value (the
+// canonical known-answer tests verify path equality).
 constexpr uint64_t LoadTail(const char* ptr, std::size_t remaining) noexcept {
+  if (!std::is_constant_evaluated()) {
+    if constexpr (std::endian::native == std::endian::little) {
+      if (remaining >= 4) {
+        const uint64_t low = Load32(ptr);
+        const uint64_t high = Load32(ptr + remaining - 4);
+        return low | (high << ((remaining - 4) * 8U));
+      }
+    }
+  }
   uint64_t result = 0;
   for (std::size_t i = 0; i < remaining; ++i) {
     result |= static_cast<uint64_t>(static_cast<uint8_t>(ptr[i])) << (i * 8U);

--- a/mbo/hash/hash_mh.h
+++ b/mbo/hash/hash_mh.h
@@ -28,73 +28,126 @@
 
 // The `mbo::hash::mh` ("mbo hash") implementation -- the current default behind
 // `mbo::hash::GetHash*`.
+
+// Codegen-only hint (does not affect constant evaluation); see GetHash64Large.
+// NOLINTBEGIN(*-macro-usage)
+#if defined(__clang__) || defined(__GNUC__)
+# define MBO_HASH_NOINLINE [[gnu::noinline]]
+#else
+# define MBO_HASH_NOINLINE
+#endif
+// NOLINTEND(*-macro-usage)
+
 namespace mbo::hash::mh {
 
 // NOLINTBEGIN(*-magic-numbers,*-pointer-arithmetic)
 
-// Full-width odd multipliers (golden-ratio / mix constants); distinct per lane so
-// the two 128-bit lanes stay decorrelated. Odd => invertible mod 2^64 (no bit
-// loss); full width => fast diffusion into the high bits.
+// Full-width odd multipliers (golden-ratio / mix constants); distinct per lane
+// and per stripe accumulator so the lanes stay decorrelated. Odd => invertible
+// mod 2^64 (no bit loss); full width => fast diffusion into the high bits.
 inline constexpr uint64_t kMul1 = 0x9E3779B97F4A7C15ULL;
 inline constexpr uint64_t kMul2 = 0xC2B2AE3D27D4EB4FULL;
+inline constexpr uint64_t kMul3 = 0x165667B19E3779F9ULL;
+inline constexpr uint64_t kMul4 = 0xFF51AFD7ED558CCDULL;
 
 // Inputs of at most this many bytes use the cheaper single-lane GetHash64 path
 // (see below). Tuned via //mbo/hash:hash_benchmark.
 inline constexpr std::size_t kSmallInputCutoff = 32;
 
+// Inputs of at least this many bytes use the 4-accumulator stripe loop in
+// GetHash128 (see below). Tuned via //mbo/hash:hash_benchmark.
+inline constexpr std::size_t kStripeInputCutoff = 64;
+
 // Default seed (djb2's initial value). Shared so `mbo::hash::GetHash` folds the
 // same value the bare `GetHash*` functions use by default.
 inline constexpr uint64_t kDefaultSeed = 5'381;
 
-// 128-bit variant: dual-lane rotate-multiply state.
+// 128-bit variant: dual-lane rotate-multiply state, with a 4-accumulator stripe
+// loop for large inputs.
 //
-// Each 8-byte block is folded into both lanes, then the lane is rotated *before*
-// the multiply so the block's low bits reach the high bits within a single round
-// (a plain multiply-then-xor with a small multiplier diffuses far too slowly).
-// The two lanes combine the block differently (xor vs add) and use distinct
-// multipliers so they stay decorrelated.
+// Core round: the lane absorbs the block (xor in one lane, add in the other),
+// is rotated *before* the multiply so the block's low bits reach the high bits
+// within a single round (a plain multiply-then-xor diffuses far too slowly),
+// then multiplied by a full-width odd constant.
+//
+// The round's xor/rotl/mul dependency chain (~6 cycles) caps a 2-lane loop at
+// 8 bytes per chain. Inputs >= kStripeInputCutoff therefore run 4 independent
+// accumulators over 32-byte stripes (xxh64-style instruction parallelism,
+// ~2.5-3x throughput) and merge them into the two lanes. The finalizer
+// cross-mixes the lanes (murmur-style) so every output bit depends on every
+// accumulator -- and thus on every input byte.
 constexpr Hash128 GetHash128(std::string_view str, uint64_t seed = kDefaultSeed) noexcept {
-  Hash128 hash = {.h1 = seed, .h2 = seed ^ 0xAA55AA55AA55AA55ULL};
-
   const char* ptr = str.data();
   const std::size_t len = str.size();
-  const std::size_t blocks = len / 8;
+  std::size_t remaining = len;
 
-  for (std::size_t i = 0; i < blocks; ++i) {
-    const uint64_t block = hash_internal::Load64(ptr);
-    hash.h1 = std::rotl(hash.h1 ^ block, 31) * kMul1;
-    hash.h2 = std::rotl(hash.h2 + block, 27) * kMul2;
-    ptr += 8;
+  uint64_t hash1 = seed;
+  uint64_t hash2 = seed ^ 0xAA55AA55AA55AA55ULL;
+
+  if (remaining >= kStripeInputCutoff) {
+    uint64_t acc1 = hash1 + kMul1;
+    uint64_t acc2 = hash2 + kMul2;
+    uint64_t acc3 = (hash1 * kMul3) + 1;
+    uint64_t acc4 = std::rotl(hash1, 32) ^ kMul4;
+    while (remaining >= 32) {
+      acc1 = std::rotl(acc1 ^ hash_internal::Load64(ptr), 31) * kMul1;
+      acc2 = std::rotl(acc2 + hash_internal::Load64(ptr + 8), 27) * kMul2;
+      acc3 = std::rotl(acc3 ^ hash_internal::Load64(ptr + 16), 29) * kMul3;
+      acc4 = std::rotl(acc4 + hash_internal::Load64(ptr + 24), 25) * kMul4;
+      ptr += 32;
+      remaining -= 32;
+    }
+    hash1 = ((std::rotl(acc1, 1) + std::rotl(acc3, 7)) * kMul1) + acc2;
+    hash2 = ((std::rotl(acc2, 12) + std::rotl(acc4, 18)) * kMul2) + acc3;
   }
 
-  const std::size_t remaining = len % 8;
+  while (remaining >= 8) {
+    const uint64_t block = hash_internal::Load64(ptr);
+    hash1 = std::rotl(hash1 ^ block, 31) * kMul1;
+    hash2 = std::rotl(hash2 + block, 27) * kMul2;
+    ptr += 8;
+    remaining -= 8;
+  }
   if (remaining > 0) {
     const uint64_t tail = hash_internal::LoadTail(ptr, remaining);
-    hash.h1 = std::rotl(hash.h1 ^ tail, 31) * kMul1;
-    hash.h2 = std::rotl(hash.h2 + tail, 27) * kMul2;
+    hash1 = std::rotl(hash1 ^ tail, 31) * kMul1;
+    hash2 = std::rotl(hash2 + tail, 27) * kMul2;
   }
 
-  hash.h1 ^= len;
-  hash.h2 += len;
+  hash1 ^= len;
+  hash2 += len;
+  hash1 += hash2;  // Cross-mix so both output lanes depend on all accumulators.
+  hash2 += hash1;
 
   return {
-      .h1 = hash_internal::Fmix64(hash.h1),
-      .h2 = hash_internal::Fmix64(hash.h2),
+      .h1 = hash_internal::Fmix64(hash1),
+      .h2 = hash_internal::Fmix64(hash2),
   };
 }
 
-// 64-bit variant.
+// 64-bit variant, two tiers (each tuned via //mbo/hash:hash_benchmark; the
+// tiers deliberately produce different values -- GetHash64 is not required to
+// equal a fold of GetHash128):
 //
-// Small inputs (<= kSmallInputCutoff bytes) take a cheaper single-lane path with
-// a single finalize: the 128-bit dual-lane state plus its 128->64 fold add fixed
-// overhead that dominates for short keys. Larger inputs fold the full 128-bit
-// state, which wins on throughput once the block loop dominates. (The two paths
-// deliberately produce different values -- GetHash64 is not required to equal a
-// fold of GetHash128.)
+// - Small (<= kSmallInputCutoff): single-lane rotate-multiply loop with one
+//   finalize; the dual-lane state plus its 128->64 fold would add fixed
+//   overhead that dominates at these sizes. Sub-8-byte inputs run zero loop
+//   iterations plus one `LoadTail` round, which the overlap loads keep cheap.
+// - Large: fold of the full 128-bit state (which stripes at 4 accumulators).
+//   Kept out-of-line so GetHash64 stays small enough to inline at call sites
+//   (inlining the stripe loop measurably de-optimized the small path).
+namespace mh_internal {
+
+MBO_HASH_NOINLINE constexpr uint64_t GetHash64Large(std::string_view str, uint64_t seed) noexcept {
+  return hash_internal::Hash128To64(GetHash128(str, seed));
+}
+
+}  // namespace mh_internal
+
 constexpr uint64_t GetHash64(std::string_view str, uint64_t seed = kDefaultSeed) noexcept {
   const std::size_t len = str.size();
-  if (len > kSmallInputCutoff) {
-    return hash_internal::Hash128To64(GetHash128(str, seed));
+  if (len > kSmallInputCutoff) [[unlikely]] {
+    return mh_internal::GetHash64Large(str, seed);
   }
 
   const char* ptr = str.data();

--- a/mbo/hash/hash_test.cc
+++ b/mbo/hash/hash_test.cc
@@ -72,13 +72,27 @@ TYPED_TEST(HashTest, BitWidthDetection) {
   EXPECT_EQ((algo::kHashBits<TypeParam>), algo::HasHash128<TypeParam> ? 128 : 64);
 }
 
-// Compile-time and run-time evaluation must agree (single code path).
+// Compile-time and run-time evaluation must agree. This also guards the loads'
+// dual implementation (constexpr byte assembly vs runtime memcpy): the probes
+// cover the tiny, single-lane, and multi-stripe input tiers.
 TYPED_TEST(HashTest, ConstexprMatchesRuntime) {
-  constexpr uint64_t kCompile = TypeParam::Get64("constexpr-vs-runtime", kSeed);
-  std::string_view runtime = "constexpr-vs-runtime";  // non-const forces the runtime path
-  EXPECT_EQ(kCompile, TypeParam::Get64(runtime, kSeed));
+  static constexpr std::array<std::string_view, 3> kProbes{
+      "abc",
+      "constexpr-vs-runtime",
+      "a long probe that spans multiple 32-byte stripes of the large-input hashing loop",
+  };
+  constexpr std::array<uint64_t, 3> kCompile{
+      TypeParam::Get64(kProbes[0], kSeed),
+      TypeParam::Get64(kProbes[1], kSeed),
+      TypeParam::Get64(kProbes[2], kSeed),
+  };
+  for (std::size_t i = 0; i < kProbes.size(); ++i) {
+    std::string_view runtime = kProbes.at(i);  // non-const forces the runtime path
+    EXPECT_EQ(kCompile.at(i), TypeParam::Get64(runtime, kSeed)) << "probe: \"" << runtime << "\"";
+  }
   if constexpr (algo::HasHash128<TypeParam>) {
-    constexpr Hash128 kCompile128 = TypeParam::Get128("constexpr-vs-runtime", kSeed);
+    constexpr Hash128 kCompile128 = TypeParam::Get128(kProbes[2], kSeed);
+    std::string_view runtime = kProbes[2];
     EXPECT_EQ(kCompile128, TypeParam::Get128(runtime, kSeed));
   }
 }
@@ -121,11 +135,12 @@ TYPED_TEST(HashTest, LowCollisionRate) {
 }
 
 // Avalanche: flipping a single input bit should flip ~half the output bits.
-// Two lengths so both the small-input path and the block path get exercised.
+// Lengths chosen to exercise every input tier: tail-only (4), single-lane loop
+// (12), stripes + remainder (100), and multiple stripes (300).
 TYPED_TEST(HashTest, Avalanche) {
   std::mt19937_64 rng(0xA5A5A5A5U);  // NOLINT(cert-msc51-cpp,cert-msc32-c): fixed seed keeps this reproducible
   constexpr int kTrials = 8'000;
-  for (const std::size_t length : std::array<std::size_t, 2>{12, 100}) {
+  for (const std::size_t length : std::array<std::size_t, 4>{4, 12, 100, 300}) {
     std::size_t flipped = 0;
     for (int trial = 0; trial < kTrials; ++trial) {
       const std::string base = algo::RandomString(rng, length);
@@ -142,7 +157,9 @@ TYPED_TEST(HashTest, Avalanche) {
       EXPECT_GT(ratio, 0.45) << "len=" << length << " weak avalanche: " << ratio;
       EXPECT_LT(ratio, 0.55) << "len=" << length << " biased avalanche: " << ratio;
     } else {
-      EXPECT_GT(ratio, 0.10) << "len=" << length << " barely reacts: " << ratio;
+      // Weak algorithms only need to react at all; e.g. `simple` sits at ~0.07
+      // for 4-byte inputs (a documented weakness of its short-input handling).
+      EXPECT_GT(ratio, 0.05) << "len=" << length << " barely reacts: " << ratio;
     }
   }
 }


### PR DESCRIPTION
Implements the mh speedup experiments (4-lane stripes + load fixes), guided by the CI benchmark (#210). Values change, as allowed by the documented stability contract; typed tests, canonical known-answer vectors, and avalanche checks arbitrate.

## Changes

1. **`Load64`/`Load32`: memcpy runtime path.** gcc never folds the endian-independent byte-assembly load (verified: 8× `movzx`+`or` per 8 bytes on gcc-13) while clang emits a single `mov`. Runtime path is now `memcpy` on little-endian targets (compiles to `mov rax,[rdi]; ret` on gcc); the byte loop remains for constexpr and big-endian. Benefits every block-based algorithm in the library on gcc.
2. **`LoadTail`: value-preserving overlapping reads.** For ≥4 tail bytes, two overlapping 4-byte loads replace the per-byte loop; overlapping bytes OR onto identical bit positions, so the value is exactly the little-endian tail value (canonical vectors verify path equality).
3. **`mh::GetHash128`: 4-accumulator 32-byte stripes for ≥64 B.** The round's xor→rotl→mul chain (~6 cycles) caps a 2-lane loop at 8 B/chain; 4 independent chains lift throughput. The finalizer cross-mixes the lanes so every output bit depends on every accumulator. `GetHash64`'s large path is out-of-line (`MBO_HASH_NOINLINE`) so the small path stays inlinable.

## Algorithm comparison (CI benchmark, this branch)

All cells: throughput in **GiB/s** (mean of 3); bracketed factor is relative to xxh64 in the same row (xxh64 = 1.00x). **Bold** marks the fastest algorithm per size.

### ubuntu-latest (x86_64, gcc)

| len | simple | mh | fnv1a | xxh64 | murmur3 |
|---:|---:|---:|---:|---:|---:|
| 1 B | 0.11 (0.44x) | 0.33 (1.37x) | **0.89 (3.68x)** | 0.24 (1.00x) | 0.19 (0.78x) |
| 4 B | 0.41 (0.44x) | 1.18 (1.25x) | **1.62 (1.72x)** | 0.94 (1.00x) | 0.75 (0.79x) |
| 16 B | 0.42 (0.15x) | **5.00 (1.82x)** | 1.52 (0.56x) | 2.74 (1.00x) | 2.18 (0.80x) |
| 64 B | 0.43 (0.12x) | **4.37 (1.21x)** | 0.94 (0.26x) | 3.61 (1.00x) | 3.94 (1.09x) |
| 256 B | 0.43 (0.07x) | **7.71 (1.28x)** | 0.72 (0.12x) | 6.04 (1.00x) | 4.41 (0.73x) |
| 1 KB | 0.43 (0.06x) | **9.68 (1.34x)** | 0.66 (0.09x) | 7.22 (1.00x) | 4.65 (0.64x) |
| 4 KB | 0.43 (0.06x) | **10.35 (1.37x)** | 0.66 (0.09x) | 7.58 (1.00x) | 4.70 (0.62x) |

### macos-26 (arm64, Apple clang)

| len | simple | mh | fnv1a | xxh64 | murmur3 |
|---:|---:|---:|---:|---:|---:|
| 1 B | 0.97 (2.54x) | 0.50 (1.30x) | **1.48 (3.89x)** | 0.38 (1.00x) | 0.25 (0.66x) |
| 4 B | **3.80 (2.41x)** | 1.94 (1.23x) | 1.97 (1.25x) | 1.58 (1.00x) | 0.95 (0.60x) |
| 16 B | 5.11 (1.18x) | **7.00 (1.62x)** | 2.63 (0.61x) | 4.32 (1.00x) | 2.99 (0.69x) |
| 64 B | 4.84 (0.58x) | 7.91 (0.94x) | 1.40 (0.17x) | **8.42 (1.00x)** | 5.41 (0.64x) |
| 256 B | 3.07 (0.24x) | **15.37 (1.20x)** | 0.87 (0.07x) | 12.78 (1.00x) | 5.68 (0.44x) |
| 1 KB | 2.17 (0.16x) | **17.38 (1.32x)** | 0.77 (0.06x) | 13.20 (1.00x) | 4.88 (0.37x) |
| 4 KB | 1.93 (0.15x) | **17.14 (1.29x)** | 0.74 (0.06x) | 13.28 (1.00x) | 4.69 (0.35x) |

### Reading

- **mh is fastest at every length ≥16 B on both platforms** (1.2–1.8x xxh64), except macos 64 B where xxh64 edges it (0.94x).
- **≤4 B:** `fnv1a` is fastest (byte-at-a-time, no fixed finalize cost); on macos `simple` wins 4 B. `mh` is the best of the strong-avalanche algorithms there.
- `murmur3` trails xxh64 at most sizes; `simple` and `fnv1a` fall off hard beyond tiny inputs.

## Tests
- Constexpr==runtime probes span tiny/loop/stripe tiers — the guard for the dual-path loads.
- Avalanche at len 4/12/100/300: strong algorithms hold 0.45–0.55 on every tier. (Weak-algorithm floor is 0.05: `simple` genuinely sits at ~0.07 for 4-byte inputs — a pre-existing weakness the new probe exposed.)
- Canonical xxh64/murmur3/fnv1a known-answer vectors pass over the new load paths.

Rejected experiments (documented for posterity): a dedicated <8 B "tiny" tier and an 8–16 B overlapping-`Load64` tier — both cost more in dispatch than they saved (2× at 16 B); the winning move was making `LoadTail` itself fast with zero new branches.