### PR TITLE
docs(hash): SMHASHER3.md leads with current state; add same-rig comparison table

### DIFF
--- a/mbo/hash/SMHASHER3.md
+++ b/mbo/hash/SMHASHER3.md
@@ -4,6 +4,24 @@ One-off run recorded 2026-07-04 (see TODO.md). SMHasher3 is the research-grade
 hash test battery (successor of SMHasher); passing it is the community bar for
 a production-quality general-purpose hash.
 
+## Current state: 183 / 188 (five failures remaining)
+
+After the seed hardening that accompanied the default switch to rapidhash
+(`Fmix64(seed)` before lane derivation), the battery result is:
+
+```text
+Overall result: FAIL            ( 183 / 188 passed)
+Failures:
+    BIC                 : [3, 11, 15]
+    Sparse              : [9/4]
+    Bitflip             : [4]
+```
+
+The five remaining failures are the core-round diffusion cluster (one
+rotate-multiply per lane per absorb does not reach full bit independence);
+fixing them means strengthening the round at a throughput cost - tracked in
+TODO.md as part of the "mh is WIP" item.
+
 ## Methodology
 
 - SMHasher3 @ gitlab.com/fwojcik/smhasher3, HEAD of 2026-07-04, built with
@@ -15,7 +33,7 @@ a production-quality general-purpose hash.
   64-bit output, seeded.
 - Full default battery: `./SMHasher3 mbo_mh64` (~712 s).
 
-## Result: FAIL — 147 / 188
+## Initial run (historical): FAIL — 147 / 188
 
 ```text
 Failures:
@@ -57,25 +75,12 @@ collision batteries pass; the failures cluster in two areas:
   lane derivation, targeting the Seed* families). Core-round hardening remains a
   TODO; `mh` stays available as a non-default algorithm.
 
-## Re-run after seed hardening: 183 / 188
+## From 147 to 183
 
-Re-running the identical battery after the seed finalization (`Fmix64(seed)`
-before lane derivation, part of the same change set that made rapidhash the
-default) confirms the analysis: **all Seed\* families now pass**
-(SeedBlockLen, SeedBlockOffset, SeedBIC, SeedBitflip), as does PerlinNoise.
-
-```text
-Overall result: FAIL            ( 183 / 188 passed)
-Failures:
-    BIC                 : [3, 11, 15]
-    Sparse              : [9/4]
-    Bitflip             : [4]
-```
-
-The remaining five failures are exactly the core-round diffusion cluster
-(one rotate-multiply per lane per absorb does not reach full bit
-independence); fixing them means strengthening the round at a throughput
-cost - tracked in TODO.md.
+The seed finalization cleared **all Seed\* families** (SeedBlockLen,
+SeedBlockOffset, SeedBIC, SeedBitflip) and PerlinNoise in a single cheap
+change, confirming the interpretation above; the initial run's failure list is
+kept for the record. Current state: see the top of this document.
 
 The full log is not committed (10k+ lines); regenerate with the methodology
 above.

--- a/mbo/hash/SMHASHER3.md
+++ b/mbo/hash/SMHASHER3.md
@@ -1,86 +1,61 @@
-# SMHasher3 evaluation of `mbo::hash::mh`
+# SMHasher3 results for mbo/hash algorithms
 
-One-off run recorded 2026-07-04 (see TODO.md). SMHasher3 is the research-grade
-hash test battery (successor of SMHasher); passing it is the community bar for
-a production-quality general-purpose hash.
+[SMHasher3](https://gitlab.com/fwojcik/smhasher3) is the research-grade hash
+test battery; passing it is the community bar for a production-quality
+general-purpose hash. All results below are **our own measurements on one
+rig** (same build, container, flags, and machine - see Methodology), so the
+numbers are directly comparable.
 
-## Current state: 183 / 188 (five failures remaining)
+## Results
 
-After the seed hardening that accompanied the default switch to rapidhash
-(`Fmix64(seed)` before lane derivation), the battery result is:
+| Algorithm   | Role in mbo/hash         | SMHasher3 result | Failures                                                                                                |
+| ----------- | ------------------------ | ---------------- | ------------------------------------------------------------------------------------------------------- |
+| `rapidhash` | default (64/mangle)      | PASS - 188 / 188 | none                                                                                                    |
+| `mh`        | in-house, WIP            | FAIL - 183 / 188 | BIC [3, 11, 15], Sparse [9/4], Bitflip [4]                                                              |
+| `xxh64`     | canonical algorithm      | FAIL - 181 / 188 | SeedBlockLen [15, 19, 21, 26, 29, 30], SeedBIC [8]                                                      |
+| `xxh3`-64   | 64-bit sibling of `xxh3` | FAIL - 166 / 188 | BIC [3, 8, 11], Sparse [20/3], PerlinNoise [2], Bitflip [8], SeedZeroes [1280, 8448], SeedSparse [2, 3] |
 
-```text
-Overall result: FAIL            ( 183 / 188 passed)
-Failures:
-    BIC                 : [3, 11, 15]
-    Sparse              : [9/4]
-    Bitflip             : [4]
-```
+Reading the results:
 
-The five remaining failures are the core-round diffusion cluster (one
-rotate-multiply per lane per absorb does not reach full bit independence);
-fixing them means strengthening the round at a throughput cost - tracked in
-TODO.md as part of the "mh is WIP" item.
+- SMHasher3 is substantially stricter than the original SMHasher: `xxh64` and
+  `xxh3` pass the original battery, and most of their failures above are in
+  the newer `Seed*` families (weak seed handling), which the original battery
+  does not probe.
+- `rapidhash` is the only clean pass, which - together with winning the
+  mixed-length latency benchmark - is why it is the 64-bit and mangled
+  `GetHash` default.
+- The tested `xxh3`-64 is the 64-bit variant; the library's 128-bit default is
+  the 128-bit variant, a separate SMHasher3 registration not run here. It
+  remains the 128-bit default as the only native 128-bit algorithm in the
+  library and the de-facto interchange format with canonical values.
+- `mh` places above the xxHash family and below `rapidhash` on this battery;
+  its remaining failures are analyzed below.
 
-## Methodology
+## mh: the five remaining failures
 
-- SMHasher3 @ gitlab.com/fwojcik/smhasher3, HEAD of 2026-07-04, built with
-  gcc 13 in a linux/arm64 container (`-march=armv8-a+crc`; two upstream build
-  fixes: a missing `<cstdlib>` include and avoiding `-march=native`, which
-  emits SHA3 `eor3` unsupported by the container toolchain).
-- `mbo::hash::mh` (as of PR #217, i.e. including the input premultiplication)
-  transcribed standalone into `hashes/mbo_mh.cpp`, registered as `mbo-mh64`,
-  64-bit output, seeded.
-- Full default battery: `./SMHasher3 mbo_mh64` (~712 s).
+`mh`'s failures form one cluster - core-round diffusion. One rotate-multiply
+per lane per absorb does not reach full bit independence (BIC), which sparse
+keys and single-bit flips expose. Fixing this means strengthening the absorb
+round at a throughput cost; that work (or replacing/renaming the algorithm)
+is tracked in [TODO.md](TODO.md) under the "mh is WIP" item. An earlier,
+larger failure set in the seed-handling families was eliminated by finalizing
+the seed through `Fmix64` before lane derivation - `mh`'s seed now avalanches
+properly.
 
-## Initial run (historical): FAIL — 147 / 188
+`mh` remains fine for its documented purpose: a fast, constexpr-safe,
+non-adversarial table hash with no value-stability guarantee.
 
-```text
-Failures:
-    BIC                 : [3, 11, 15]
-    Sparse              : [9/4]
-    PerlinNoise         : [2]
-    Bitflip             : [4]
-    SeedBlockLen        : [8..31]
-    SeedBlockOffset     : [0..5]
-    SeedBIC             : [3, 8]
-    SeedBitflip         : [3, 4, 8]
-```
+## Methodology (reproduction)
 
-Sanity, thread-safety, zero-padding, and the majority of the avalanche /
-collision batteries pass; the failures cluster in two areas:
-
-1. **Seed handling (the bulk: SeedBlockLen 8..31, SeedBlockOffset, SeedBIC,
-   SeedBitflip).** The seed enters the state almost raw (`h1 = seed`,
-   `h2 = seed ^ const`, stripe accumulators derived by single ops), so
-   structured seed/input combinations correlate. A cheap candidate fix is
-   finalizing the seed through `Fmix64` before lane derivation.
-2. **Core-round diffusion (BIC, Sparse 9/4, Bitflip, PerlinNoise).** One
-   rotate-multiply per lane per absorb does not achieve full bit independence;
-   these are the same class of weakness that the structured-key test caught
-   (and PR #217 partially fixed via input premultiplication), now measured
-   with research-grade sensitivity. Fixing these means strengthening the
-   round itself, i.e. giving up part of mh's speed advantage.
-
-## Interpretation
-
-- `mh` is fine for its documented purpose: a fast, constexpr-safe,
-  non-adversarial table hash with no stability guarantee.
-- It is NOT SMHasher3-clean, unlike `rapidhash` and `xxh3` (both pass the
-  full battery upstream, are canonical, and are already in this library --
-  and rapidhash additionally wins the mixed-length latency benchmark).
-- **Decision (2026-07-04): (b) + (c).** `rapidhash` is now
-  `DefaultHashAlgorithm` (with 128-bit-native `xxh3` as `Default128HashAlgorithm`),
-  and `mh`'s seed handling was hardened (seed finalized through `Fmix64` before
-  lane derivation, targeting the Seed* families). Core-round hardening remains a
-  TODO; `mh` stays available as a non-default algorithm.
-
-## From 147 to 183
-
-The seed finalization cleared **all Seed\* families** (SeedBlockLen,
-SeedBlockOffset, SeedBIC, SeedBitflip) and PerlinNoise in a single cheap
-change, confirming the interpretation above; the initial run's failure list is
-kept for the record. Current state: see the top of this document.
-
-The full log is not committed (10k+ lines); regenerate with the methodology
-above.
+- SMHasher3 @ gitlab.com/fwojcik/smhasher3, commit `6ab4343` (2026-03-26),
+  built with gcc 13 in a linux/arm64 container, `-march=armv8-a+crc` (two build fixes
+  needed: a missing `<cstdlib>` include in `lib/AEStest.cpp`, and replacing
+  `-march=native` in CMakeLists.txt, which emits SHA3 `eor3` instructions the
+  container toolchain rejects).
+- `rapidhash`, `XXH3-64`, and `XXH-64` are SMHasher3's built-in registrations
+  of the same reference algorithms our headers transcribe (transcriptions are
+  vector- and differential-verified equal, so the results transfer).
+- `mh` was transcribed standalone into `hashes/mbo_mh.cpp` (registered as
+  `mbo-mh64`, 64-bit, seeded), matching `hash_mh.h` at the current commit.
+- Full default battery per hash: `./SMHasher3 <name>` (~12 minutes each).
+  Full logs are not committed; regenerate as above.

--- a/mbo/hash/SMHASHER3.md
+++ b/mbo/hash/SMHASHER3.md
@@ -9,11 +9,11 @@ numbers are directly comparable.
 ## Results
 
 | Algorithm   | Bits | Role in mbo/hash         | SMHasher3 result | Failures                                                                                                |
-| ----------- | ---- | ------------------------ | ---------------- | ------------------------------------------------------------------------------------------------------- |
-| `rapidhash` | 64   | default (64/mangle)      | PASS - 188 / 188 | none                                                                                                    |
-| `mh`        | 64   | in-house, WIP            | FAIL - 183 / 188 | BIC [3, 11, 15], Sparse [9/4], Bitflip [4]                                                              |
-| `xxh64`     | 64   | canonical algorithm      | FAIL - 181 / 188 | SeedBlockLen [15, 19, 21, 26, 29, 30], SeedBIC [8]                                                      |
-| `xxh3`-64   | 64   | 64-bit sibling of `xxh3` | FAIL - 166 / 188 | BIC [3, 8, 11], Sparse [20/3], PerlinNoise [2], Bitflip [8], SeedZeroes [1280, 8448], SeedSparse [2, 3] |
+| ----------- | ---: | ------------------------ | ---------------- | ------------------------------------------------------------------------------------------------------- |
+| `rapidhash` |   64 | default (64/mangle)      | PASS - 188 / 188 | none                                                                                                    |
+| `mh`        |   64 | in-house, WIP            | FAIL - 183 / 188 | BIC [3, 11, 15], Sparse [9/4], Bitflip [4]                                                              |
+| `xxh64`     |   64 | canonical algorithm      | FAIL - 181 / 188 | SeedBlockLen [15, 19, 21, 26, 29, 30], SeedBIC [8]                                                      |
+| `xxh3`-64   |   64 | 64-bit sibling of `xxh3` | FAIL - 166 / 188 | BIC [3, 8, 11], Sparse [20/3], PerlinNoise [2], Bitflip [8], SeedZeroes [1280, 8448], SeedSparse [2, 3] |
 
 Reading the results:
 

--- a/mbo/hash/SMHASHER3.md
+++ b/mbo/hash/SMHASHER3.md
@@ -8,12 +8,12 @@ numbers are directly comparable.
 
 ## Results
 
-| Algorithm   | Role in mbo/hash         | SMHasher3 result | Failures                                                                                                |
-| ----------- | ------------------------ | ---------------- | ------------------------------------------------------------------------------------------------------- |
-| `rapidhash` | default (64/mangle)      | PASS - 188 / 188 | none                                                                                                    |
-| `mh`        | in-house, WIP            | FAIL - 183 / 188 | BIC [3, 11, 15], Sparse [9/4], Bitflip [4]                                                              |
-| `xxh64`     | canonical algorithm      | FAIL - 181 / 188 | SeedBlockLen [15, 19, 21, 26, 29, 30], SeedBIC [8]                                                      |
-| `xxh3`-64   | 64-bit sibling of `xxh3` | FAIL - 166 / 188 | BIC [3, 8, 11], Sparse [20/3], PerlinNoise [2], Bitflip [8], SeedZeroes [1280, 8448], SeedSparse [2, 3] |
+| Algorithm   | Bits | Role in mbo/hash         | SMHasher3 result | Failures                                                                                                |
+| ----------- | ---- | ------------------------ | ---------------- | ------------------------------------------------------------------------------------------------------- |
+| `rapidhash` | 64   | default (64/mangle)      | PASS - 188 / 188 | none                                                                                                    |
+| `mh`        | 64   | in-house, WIP            | FAIL - 183 / 188 | BIC [3, 11, 15], Sparse [9/4], Bitflip [4]                                                              |
+| `xxh64`     | 64   | canonical algorithm      | FAIL - 181 / 188 | SeedBlockLen [15, 19, 21, 26, 29, 30], SeedBIC [8]                                                      |
+| `xxh3`-64   | 64   | 64-bit sibling of `xxh3` | FAIL - 166 / 188 | BIC [3, 8, 11], Sparse [20/3], PerlinNoise [2], Bitflip [8], SeedZeroes [1280, 8448], SeedSparse [2, 3] |
 
 Reading the results:
 

--- a/mbo/hash/SMHASHER3.md
+++ b/mbo/hash/SMHASHER3.md
@@ -8,12 +8,14 @@ numbers are directly comparable.
 
 ## Results
 
-| Algorithm   | Bits | Role in mbo/hash         | SMHasher3 result | Failures                                                                                                |
-| ----------- | ---: | ------------------------ | ---------------- | ------------------------------------------------------------------------------------------------------- |
-| `rapidhash` |   64 | default (64/mangle)      | PASS - 188 / 188 | none                                                                                                    |
-| `mh`        |   64 | in-house, WIP            | FAIL - 183 / 188 | BIC [3, 11, 15], Sparse [9/4], Bitflip [4]                                                              |
-| `xxh64`     |   64 | canonical algorithm      | FAIL - 181 / 188 | SeedBlockLen [15, 19, 21, 26, 29, 30], SeedBIC [8]                                                      |
-| `xxh3`-64   |   64 | 64-bit sibling of `xxh3` | FAIL - 166 / 188 | BIC [3, 8, 11], Sparse [20/3], PerlinNoise [2], Bitflip [8], SeedZeroes [1280, 8448], SeedSparse [2, 3] |
+| Algorithm   | Bits | Role in mbo/hash              | SMHasher3 result | Failures                                                                                                                                                                      |
+| ----------- | ---: | ----------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `rapidhash` |   64 | default (64/mangle)           | PASS - 188 / 188 | none                                                                                                                                                                          |
+| `mh`        |   64 | in-house, WIP                 | FAIL - 183 / 188 | BIC [3, 11, 15], Sparse [9/4], Bitflip [4]                                                                                                                                    |
+| `xxh64`     |   64 | canonical algorithm           | FAIL - 181 / 188 | SeedBlockLen [15, 19, 21, 26, 29, 30], SeedBIC [8]                                                                                                                            |
+| `xxh3`      |   64 | 64-bit sibling of the default | FAIL - 166 / 188 | BIC [3, 8, 11], Sparse [20/3], PerlinNoise [2], Bitflip [8], SeedZeroes [1280, 8448], SeedSparse [2, 3]                                                                       |
+| `mh`        |  128 | in-house, WIP                 | FAIL - 163 / 188 | BIC [3, 11, 15], Zeroes, Sparse [9/4], Permutation [4-byte keys, 10 variants], TwoBytes [20], Bitflip [4], SeedZeroes [1280, 8448], SeedBlockOffset [0-5]                     |
+| `xxh3`      |  128 | default (128)                 | FAIL - 162 / 188 | BIC [3, 8, 15], Sparse [20/3], PerlinNoise [2], Bitflip [3, 4, 8], SeedZeroes [1280, 8448], SeedSparse [2, 3], SeedBlockLen [8, 12-16], SeedBlockOffset [0-5], SeedBIC [3, 8] |
 
 Reading the results:
 
@@ -24,23 +26,36 @@ Reading the results:
 - `rapidhash` is the only clean pass, which - together with winning the
   mixed-length latency benchmark - is why it is the 64-bit and mangled
   `GetHash` default.
-- The tested `xxh3`-64 is the 64-bit variant; the library's 128-bit default is
-  the 128-bit variant, a separate SMHasher3 registration not run here. It
-  remains the 128-bit default as the only native 128-bit algorithm in the
-  library and the de-facto interchange format with canonical values.
+- Both 128-bit variants fail more of the battery than their 64-bit siblings:
+  the wider output gives the statistics more surface to catch bias and lane
+  correlation on. No tested 128-bit variant passes cleanly.
+- `xxh3` (128) remains the 128-bit default regardless: it is the library's
+  only native 128-bit algorithm with canonical values (the de-facto
+  interchange format), its failures are again dominated by the `Seed*`
+  families, and no cleaner 128-bit alternative exists in-library.
 - `mh` places above the xxHash family and below `rapidhash` on this battery;
   its remaining failures are analyzed below.
 
-## mh: the five remaining failures
+## mh: remaining failure analysis
 
-`mh`'s failures form one cluster - core-round diffusion. One rotate-multiply
-per lane per absorb does not reach full bit independence (BIC), which sparse
-keys and single-bit flips expose. Fixing this means strengthening the absorb
-round at a throughput cost; that work (or replacing/renaming the algorithm)
-is tracked in [TODO.md](TODO.md) under the "mh is WIP" item. An earlier,
-larger failure set in the seed-handling families was eliminated by finalizing
-the seed through `Fmix64` before lane derivation - `mh`'s seed now avalanches
-properly.
+`mh`'s 64-bit failures form one cluster - core-round diffusion. One
+rotate-multiply per lane per absorb does not reach full bit independence
+(BIC), which sparse keys and single-bit flips expose. Fixing this means
+strengthening the absorb round at a throughput cost; that work (or
+replacing/renaming the algorithm) is tracked in [TODO.md](TODO.md) under the
+"mh is WIP" item. An earlier, larger failure set in the seed-handling
+families was eliminated by finalizing the seed through `Fmix64` before lane
+derivation - `mh`'s seed now avalanches properly.
+
+The native 128-bit variant additionally exposes **lane correlation**: both
+lanes absorb the identical premultiplied block and differ only in the
+absorb operation (xor vs add), rotation, and multiplier, and the second
+lane's initial state is just `seed ^ constant`. Short-key and seed
+differences therefore stay correlated across the two output halves, which
+the 128-bit-only failure families (Zeroes, Permutation, TwoBytes,
+SeedZeroes, SeedBlockOffset) detect. The 64-bit fold cross-mixes the lanes
+and hides exactly this - which is why `mh` (64) does not show them. Lane
+decorrelation is part of the same WIP item.
 
 `mh` remains fine for its documented purpose: a fast, constexpr-safe,
 non-adversarial table hash with no value-stability guarantee.
@@ -52,10 +67,13 @@ non-adversarial table hash with no value-stability guarantee.
   needed: a missing `<cstdlib>` include in `lib/AEStest.cpp`, and replacing
   `-march=native` in CMakeLists.txt, which emits SHA3 `eor3` instructions the
   container toolchain rejects).
-- `rapidhash`, `XXH3-64`, and `XXH-64` are SMHasher3's built-in registrations
-  of the same reference algorithms our headers transcribe (transcriptions are
-  vector- and differential-verified equal, so the results transfer).
+- `rapidhash`, `XXH3-64`, `XXH-64`, and `XXH3-128` are SMHasher3's built-in
+  registrations of the same reference algorithms our headers transcribe
+  (transcriptions are vector- and differential-verified equal, so the results
+  transfer; the built-in `XXH3-128` ran its NEON implementation on this rig,
+  which produces the identical canonical values).
 - `mh` was transcribed standalone into `hashes/mbo_mh.cpp` (registered as
-  `mbo-mh64`, 64-bit, seeded), matching `hash_mh.h` at the current commit.
+  `mbo-mh64` and `mbo-mh128`, seeded), matching `hash_mh.h` at the current
+  commit.
 - Full default battery per hash: `./SMHasher3 <name>` (~12 minutes each).
   Full logs are not committed; regenerate as above.

--- a/mbo/hash/TODO.md
+++ b/mbo/hash/TODO.md
@@ -12,7 +12,9 @@ Gap analysis vs state of the art (SMHasher3, abseil, xxhash/wyhash ecosystems),
       strengthening the absorb round, i.e. trading some throughput; the
       alternative is replacing the algorithm outright. Either way the `mh`
       name may change. The seed families were addressed by seed finalization;
-      `rapidhash` is the default since then (see SMHASHER3.md).
+      `rapidhash` is the default since then (see SMHASHER3.md). The native
+      128-bit variant additionally needs lane decorrelation (163/188; see
+      SMHASHER3.md's failure analysis).
 
 ## Hard / needs design
 


### PR DESCRIPTION
Redoes `mbo/hash/SMHASHER3.md` as a pure current-state document — the historical narrative (initial 147/188 run, hardening chronology) is gone; a status doc, not a chronicle.

**Same-rig comparison table** — all six variants measured by us under identical conditions (same SMHasher3 build @ `6ab4343`, container, flags, machine); no quoting of upstream results:

| Algorithm | Bits | SMHasher3 result | Failure families |
| --- | ---: | --- | --- |
| `rapidhash` | 64 | PASS - 188/188 | none |
| `mh` | 64 | FAIL - 183/188 | BIC, Sparse, Bitflip |
| `xxh64` | 64 | FAIL - 181/188 | SeedBlockLen, SeedBIC |
| `xxh3` | 64 | FAIL - 166/188 | BIC, Sparse, PerlinNoise, Bitflip, SeedZeroes, SeedSparse |
| `mh` | 128 | FAIL - 163/188 | + Zeroes, Permutation, TwoBytes, SeedZeroes, SeedBlockOffset |
| `xxh3` | 128 | FAIL - 162/188 | + Bitflip, SeedBlockLen, SeedBlockOffset, SeedBIC |

Notable:

- SMHasher3 is much stricter than the original SMHasher — the xxHash family fails its newer `Seed*` batteries. `rapidhash` is the only clean pass, making the 64-bit default rationale self-evident from data; `mh` (WIP) places above the xxHash family.
- Every 128-bit variant fails more than its 64-bit sibling (wider output = more statistical surface); no tested 128-bit variant passes cleanly. `xxh3` stays the 128-bit default as the only canonical-value 128-bit format in the library.
- `mh`'s native 128-bit variant exposes lane correlation that the 64-bit fold hides; analyzed in the doc and added to the "mh is WIP" TODO item (lane decorrelation).

The doc keeps: results table + interpretation, mh's failure analysis (core-round diffusion + 128-bit lane correlation, TODO pointers), and a reproduction-grade methodology section.