### PR TITLE
docs(hash): release-audit tidy-up

### DIFF
--- a/mbo/hash/README.md
+++ b/mbo/hash/README.md
@@ -191,8 +191,8 @@ benchmark plus both SMHasher3 batteries):
 3. v3 (188/188 both widths): data loads into both product operands (products
    quadratic in the data), the length folded into the seed, distinct
    bulk-chain initializers.
-4. v4 (64-bit re-verified PASS 188/188; the 128-bit battery result is
-   recorded in the table above): the length moved from the seed into
+4. v4 (re-verified PASS 188/188 in both widths): the length moved from the
+   seed into
    the finalizer's product operands - equally protective, but known only at
    finalize, which is what makes streaming possible; the 128-bit lane seeds
    derive from secret pairs distinct from the 64-bit chain, so no lane ever


### PR DESCRIPTION
Single finding from the pre-release consistency audit of mbo/hash, mbo/digest, mbo/diff and the top-level files: the mumbo design-iteration item 4 was worded mid-rig-run ('64-bit re-verified; 128-bit recorded in the table') - both widths were re-verified PASS 188/188.

Everything else checked clean: no stale mh/mh2/SMHASHER3.md/TODO.md/EXPERIMENTAL references, version aligned (0.13.0), NOTICE <-> README third-party tables <-> BUILD targets consistent, and the full test suite (101/101, incl. the manual differential test) passes.