### PR TITLE
mbo/hash: SMHasher3 in-house plugin + verified quality (mumbo/jumbo PASS 188/188)

### DIFF
--- a/mbo/hash/README.md
+++ b/mbo/hash/README.md
@@ -58,7 +58,7 @@ Three entry points, split by contract:
 | `murmur3`   | 64/128 | `hash.h`                          | none (public domain)    | yes    | no        | FAIL (123)     |
 | `siphash`   | 64     | `hash.h`                          | none (CC0)              | keyed  | yes       | PASS (186)     |
 | `fnv1a`     | 64     | `hash.h`                          | none (public domain)    | yes    | no        | FAIL (7!)      |
-| `dumbo`     | 64     | `hash.h`                          | none (in-house)         | weak   | no        | n/a (legacy)   |
+| `dumbo`     | 64     | `hash.h`                          | none (in-house)         | weak   | no        | FAIL (40)      |
 | `rapidhash` | 64     | `hash_extra.h` + `:hash_extra_cc` | **MIT - ship NOTICE**   | yes    | no        | PASS           |
 | `xxh64`     | 64     | `hash_extra.h` + `:hash_extra_cc` | **BSD-2 - ship NOTICE** | yes    | yes       | FAIL (181)     |
 | `xxh3`      | 64/128 | `hash_extra.h` + `:hash_extra_cc` | **BSD-2 - ship NOTICE** | yes    | no        | FAIL (166/162) |
@@ -333,6 +333,7 @@ numbers are directly comparable.
 
 | Algorithm   | Bits | Role in mbo/hash          | SMHasher3 result | Failures                                                                                                                                                                      |
 | ----------- | ---: | ------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dumbo`     |   64 | `hash.h` (legacy)         | FAIL - 40 / 188  | nearly every family (weak legacy hash): Avalanche, BIC, the keyset tests (Sparse/Permutation/Cyclic/TwoBytes/Text/Zeroes), and the complete Seed* cluster                     |
 | `fnv1a`     |   64 | `hash.h`                  | FAIL - 7 / 186   | nearly every family: Avalanche, BIC, Sparse, Cyclic, Permutation, Text, TwoBytes, Bitflip, PerlinNoise, and the complete Seed* cluster                                        |
 | `mumbo`     |   64 | default (64/32/streaming) | PASS - 188 / 188 | none                                                                                                                                                                          |
 | `rapidhash` |   64 | extra (`hash_extra_cc`)   | PASS - 188 / 188 | none                                                                                                                                                                          |
@@ -413,8 +414,13 @@ benchmark plus both SMHasher3 batteries):
   (transcriptions are vector- and differential-verified equal, so the results
   transfer; the built-in `XXH3-128` ran its NEON implementation on this rig,
   which produces the identical canonical values).
-- `mumbo` was transcribed standalone into a plugin source (registered as
-  `mumbo-64` and `jumbo-128`, seeded), matching `hash_mumbo.h` at the current
-  commit.
+- The in-house `mumbo-64`, `jumbo-128`, and `dumbo-64` are registered by
+  `mbo/hash/measurements/smhasher3/mbohash.cpp`, which `#include`s the ACTUAL
+  `mbo/hash` headers (so the real implementation is verified, not a
+  transcription). `mbo/hash/measurements/build_smhasher3.sh` clones SMHasher3,
+  applies the fixes above, installs the plugin + headers, and builds it (the
+  plugin needs C++20). Reproduce all of it with that one script.
 - Full default battery per hash: `./SMHasher3 <name>` (~12 minutes each).
-  Full logs are not committed; regenerate as above.
+  Full logs are not committed; regenerate as above. Last run (2026-07):
+  `mumbo-64` and `jumbo-128` PASS 188 / 188; `dumbo-64` FAIL 40 / 188 (the weak
+  legacy hash).

--- a/mbo/hash/measurements/README.md
+++ b/mbo/hash/measurements/README.md
@@ -33,7 +33,8 @@ mbo/hash/measurements/
   README.md                    # this design doc
   MODULE.bazel                 # separate dev module (isolates plotting deps)
   hash_benchmark_report.py     # run / store / tables / plot / smhasher (stdlib only)
-  build_smhasher3.sh           # reproducible SMHasher3 build (clone + fixes + container gcc)
+  build_smhasher3.sh           # reproducible SMHasher3 build (clone + fixes + install plugin + container gcc)
+  smhasher3/mbohash.cpp        # in-house mumbo/jumbo/dumbo SMHasher3 registration (includes the real headers)
   hash_benchmark_results.json  # canonical distilled results (committed provenance for the README tables)
   data/                        # complete raw datasets + SMHasher3 logs (see "Data storage")
 ```
@@ -146,12 +147,15 @@ two documented fixes (missing `<cstdlib>` in `lib/AEStest.cpp`; replace
 methodology in `../README.md`. The third-party algorithms are SMHasher3
 built-ins and work immediately.
 
-The in-house `mumbo`/`jumbo`/`dumbo` still need a **registration source** dropped
-into SMHasher3's `hashes/` tree before the build (a transcription registering
-`mumbo-64` / `jumbo-128` / `dumbo-64`, matching `hash_mumbo.h` / `hash_dumbo.h`)
+The in-house `mumbo`/`jumbo`/`dumbo` are registered by `smhasher3/mbohash.cpp`,
+which `#include`s the ACTUAL `mbo/hash` headers (so the real implementation is
+verified, not a transcription). `build_smhasher3.sh` copies the headers + plugin
+into the tree and registers the source, so one script run yields a SMHasher3
+that recognizes `mumbo-64` / `jumbo-128` / `dumbo-64`. Registration names live
+in `_SMHASHER_NAMES` and match `SMHasher3 --list`.
 
-- that plugin is the outstanding piece. Registration names live in
-  `_SMHASHER_NAMES` and are confirmed against `SMHasher3 --list`.
+Last verified run (2026-07): **mumbo-64 PASS 188/188**, **jumbo-128 PASS
+188/188**, **dumbo-64 FAIL 40/188** (the weak legacy hash).
 
 ## Output filenames
 
@@ -170,10 +174,9 @@ for architecture/compiler shape comparison, not a gate.
 
 ## Open items
 
-- **SMHasher3 in-house plugin**: `build_smhasher3.sh` builds stock SMHasher3
-  (third-party algorithms verify today), but the `mumbo`/`jumbo`/`dumbo`
-  registration source is not written yet - it is the verification gate for any
-  value-changing hash work. Run on merged `main` for an authoritative result.
+- **Authoritative results JSON**: the README scores come from a verified run,
+  but a committed `smhasher_results.json` (via the `smhasher` mode) is not stored
+  yet - run it on merged `main` if a machine-readable record is wanted.
 - Plotter: self-contained SVG is implemented (`plot`); decide whether to commit
   a generated curve or render it on demand.
 - Optional guard: a check that the README tables match the committed canonical

--- a/mbo/hash/measurements/README.md
+++ b/mbo/hash/measurements/README.md
@@ -28,7 +28,7 @@ even invert the true ordering. So we:
 
 ## Layout
 
-```
+```text
 mbo/hash/measurements/
   README.md                    # this design doc
   MODULE.bazel                 # separate dev module (isolates plotting deps)

--- a/mbo/hash/measurements/build_smhasher3.sh
+++ b/mbo/hash/measurements/build_smhasher3.sh
@@ -68,13 +68,34 @@ else
 fi
 sed -i.bak "s/-march=native/-march=${march}/g" "${SRC_DIR}/CMakeLists.txt"
 
+# Install the in-house plugin: it #includes the ACTUAL mbo/hash headers (so the
+# real implementation is verified, not a transcription). Copy the four headers
+# preserving the mbo/hash/ path, drop in the registration source, register it,
+# and switch to C++20 (mumbo/dumbo need it).
+REPO="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+mkdir -p "${SRC_DIR}/mbo_include/mbo/hash"
+cp "${REPO}"/mbo/hash/hash_types.h "${REPO}"/mbo/hash/hash_internal_util.h \
+  "${REPO}"/mbo/hash/hash_mumbo.h "${REPO}"/mbo/hash/hash_dumbo.h \
+  "${SRC_DIR}/mbo_include/mbo/hash/"
+cp "${REPO}/mbo/hash/measurements/smhasher3/mbohash.cpp" "${SRC_DIR}/hashes/mbohash.cpp"
+grep -q 'hashes/mbohash.cpp' "${SRC_DIR}/hashes/Hashsrc.cmake" \
+  || sed -i.bak 's#\(set(HASH_SRC_FILES\)#\1\n  hashes/mbohash.cpp#' "${SRC_DIR}/hashes/Hashsrc.cmake"
+sed -i.bak 's/set(CMAKE_CXX_STANDARD 11)/set(CMAKE_CXX_STANDARD 20)/' "${SRC_DIR}/CMakeLists.txt"
+# The ${CMAKE_*} tokens are meant to land literally in CMakeLists.txt, not expand here.
+# shellcheck disable=SC2016
+grep -q 'mbo_include' "${SRC_DIR}/CMakeLists.txt" \
+  || sed -i.bak 's#\(include_directories(${CMAKE_BINARY_DIR}/include)\)#\1\ninclude_directories(${CMAKE_SOURCE_DIR}/mbo_include)#' \
+    "${SRC_DIR}/CMakeLists.txt"
+
 # Build with gcc in a container (native on arm64 hosts; matches the README rig).
+# NOTE: the work dir must be under a path Docker Desktop shares with the VM
+# (e.g. under $HOME on macOS); /private/tmp is not shared by default.
 docker run --rm -v "${SRC_DIR}:/src" -w /src "${BUILD_IMAGE}" bash -c '
   set -euo pipefail
-  apt-get update -qq && apt-get install -y -qq cmake >/dev/null
+  command -v cmake >/dev/null || { apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq cmake >/dev/null; }
   cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
   cmake --build build -j"$(nproc)"
 '
 
 echo "SMHasher3 built: ${SRC_DIR}/build/SMHasher3"
-echo "Confirm registrations:  ${SRC_DIR}/build/SMHasher3 --list | grep -Ei 'mumbo|jumbo|dumbo|rapid|xxh|murmur|sip|fnv'"
+echo "In-house hashes: ${SRC_DIR}/build/SMHasher3 --list | grep -Ei 'mumbo|jumbo|dumbo'"

--- a/mbo/hash/measurements/smhasher3/mbohash.cpp
+++ b/mbo/hash/measurements/smhasher3/mbohash.cpp
@@ -1,0 +1,75 @@
+/*
+ * mbo/hash in-house family: mumbo (64), jumbo (128), dumbo (legacy 64)
+ * Copyright (C) The helly25 authors (helly25.com)
+ *
+ * Apache-2.0. This plugin includes the ACTUAL mbo/hash headers (copied into
+ * mbo_include/) so SMHasher3 verifies the real implementation, not a
+ * transcription. See mbo/hash/measurements/README.md.
+ */
+#include "Hashlib.h"
+#include "Platform.h"
+#include "mbo/hash/hash_dumbo.h"
+#include "mbo/hash/hash_mumbo.h"
+
+//------------------------------------------------------------
+// mumbo (64-bit) and jumbo (128-bit) both seed directly from SMHasher3's seed.
+// The algorithms are little-endian defined and portable, so the value is the
+// same on every platform; PUT_U64<bswap> only serializes the output.
+
+template<bool bswap>
+static void MumboHash64(const void* in, const size_t len, const seed_t seed, void* out) {
+  const std::string_view data((const char*)in, len);
+  const uint64_t h = ::mbo::hash::mumbo::GetHash64(data, (uint64_t)seed);
+  PUT_U64<bswap>(h, (uint8_t*)out, 0);
+}
+
+template<bool bswap>
+static void JumboHash128(const void* in, const size_t len, const seed_t seed, void* out) {
+  const std::string_view data((const char*)in, len);
+  const ::mbo::hash::Hash128 h = ::mbo::hash::jumbo::GetHash128(data, (uint64_t)seed);
+  PUT_U64<bswap>(h.h1, (uint8_t*)out, 0);
+  PUT_U64<bswap>(h.h2, (uint8_t*)out, 8);
+}
+
+template<bool bswap>
+static void DumboHash64(const void* in, const size_t len, const seed_t seed, void* out) {
+  const std::string_view data((const char*)in, len);
+  const uint64_t h = ::mbo::hash::dumbo::Algorithm::GetHash64(data, (uint64_t)seed);
+  PUT_U64<bswap>(h, (uint8_t*)out, 0);
+}
+
+//------------------------------------------------------------
+REGISTER_FAMILY(mbo_hash, $.src_url = "https://github.com/helly25/mbo", $.src_status = HashFamilyInfo::SRC_ACTIVE);
+
+REGISTER_HASH(
+    mumbo_64,
+    $.desc = "mumbo, mbo/hash in-house 64-bit (MUM widening-multiply)",
+    $.hash_flags = 0,
+    $.impl_flags = FLAG_IMPL_MULTIPLY_64_128 | FLAG_IMPL_CANONICAL_LE,
+    $.bits = 64,
+    $.verification_LE = 0x0DAE1DCD,
+    $.verification_BE = 0xFBC5E0C5,
+    $.hashfn_native = MumboHash64<false>,
+    $.hashfn_bswap = MumboHash64<true>);
+
+REGISTER_HASH(
+    jumbo_128,
+    $.desc = "jumbo, mbo/hash in-house native 128-bit (MUM dual-lane)",
+    $.hash_flags = 0,
+    $.impl_flags = FLAG_IMPL_MULTIPLY_64_128 | FLAG_IMPL_CANONICAL_LE,
+    $.bits = 128,
+    $.verification_LE = 0xE595E9E3,
+    $.verification_BE = 0x008B1206,
+    $.hashfn_native = JumboHash128<false>,
+    $.hashfn_bswap = JumboHash128<true>);
+
+REGISTER_HASH(
+    dumbo_64,
+    $.desc = "dumbo, mbo/hash legacy in-house 64-bit (weak, weakly seeded)",
+    $.hash_flags = 0,
+    $.impl_flags = FLAG_IMPL_CANONICAL_LE,
+    $.bits = 64,
+    $.verification_LE = 0x8569BC38,
+    $.verification_BE = 0x3EAC66FF,
+    $.hashfn_native = DumboHash64<false>,
+    $.hashfn_bswap = DumboHash64<true>);


### PR DESCRIPTION
Completes the measurement module's SMHasher3 path: it could build stock SMHasher3, but not verify the in-house hashes. This adds the registration plugin and records the verified results.

## What
- **`mbo/hash/measurements/smhasher3/mbohash.cpp`** — registers `mumbo-64`, `jumbo-128`, `dumbo-64`, and crucially **`#include`s the actual `mbo/hash` headers** (so SMHasher3 verifies the *real* implementation, not a re-typed transcription). Verification values baked in.
- **`build_smhasher3.sh`** — now copies the headers + plugin into the SMHasher3 tree, registers the source, and switches the build to C++20 (mumbo/dumbo need it). One run yields a SMHasher3 that recognizes the in-house hashes. **Validated end-to-end from a clean clone** — all three PASS the verification-value check.
- **README quality table** — `dumbo` now shows its real result instead of `n/a`; methodology points at the reproducible plugin build.

## Results (arm64 / gcc-13 container, documented methodology)
- **mumbo-64: PASS 188 / 188** — confirmed against the real implementation.
- **jumbo-128: PASS 188 / 188** — the only clean native-128 on the rig, now verified for real.
- **dumbo-64: FAIL 40 / 188** — the weak legacy hash, as expected.

## Test plan
- `bash mbo/hash/measurements/build_smhasher3.sh` builds SMHasher3 with the plugin from a clean clone; `--list` shows the three in-house names; each PASSes its verification value.
- Full battery per hash reproduces the results above (~12 min each).

Follow-ups (separate branches): a dumbo32 32-bit-MUM experiment, and mumbo/jumbo latency tuning.