### PR TITLE
mbo/hash/measurements: tag build compiler into bundle name + provenance; drop placeholder bundle

### DIFF
--- a/mbo/hash/hash_benchmark.cc
+++ b/mbo/hash/hash_benchmark.cc
@@ -178,6 +178,16 @@ void RegisterAll(std::tuple<Algos...> /*algorithms*/) {
 int main(int argc, char** argv) {
   mbo::hash::RegisterAll(mbo::hash::algo::AllAlgorithms{});
   benchmark::Initialize(&argc, argv);
+  // The build compiler is a first-class axis of a measurement (GCC vs Clang perf
+  // differs), so record what THIS binary was built with in the dataset context;
+  // the stored bundle's filename is tagged with `compiler` too.
+#if defined(__clang__)
+  benchmark::AddCustomContext("compiler", "clang-" + std::to_string(__clang_major__));
+  benchmark::AddCustomContext("compiler_version", __clang_version__);
+#elif defined(__GNUC__)
+  benchmark::AddCustomContext("compiler", "gcc-" + std::to_string(__GNUC__));
+  benchmark::AddCustomContext("compiler_version", __VERSION__);
+#endif
   benchmark::RunSpecifiedBenchmarks();
   benchmark::Shutdown();
   return 0;

--- a/mbo/hash/measurements/README.md
+++ b/mbo/hash/measurements/README.md
@@ -101,7 +101,7 @@ distilled canonical JSON is ~38 KB / ~100 KB, plus the per-algorithm SMHasher3
 logs. Across several machines that accumulates, so:
 
 - **Per-machine bundle, Git LFS**
-  (`data/<os>-<arch>-<cpu-brand>/<slug>_<cores>c_<gitsha8>_<stamp>.tgz`): one
+  (`data/<os>-<arch>-<cpu-brand>/<slug>_<cores>c_<compiler>_<gitsha8>_<stamp>.tgz`): one
   gzipped tarball per run holds the _whole_ dataset - the canonical
   `results.json`, the raw `*_raw.json.gz` (for `compare.py` U-tests), and the
   `smhasher.json` + per-algorithm logs. It is Git-LFS-tracked (`.gitattributes`),
@@ -196,9 +196,11 @@ Last verified run (2026-07): **mumbo-64/jumbo-128** and **dumbo-64** all PASS
 Loose staging files the tool writes are prefixed `YYYYMMDD_HHMMSS_` (local wall
 clock, one stamp per invocation) so runs never overwrite each other. The
 committed artifact is the per-machine bundle
-`data/<os>-<arch>-<cpu-brand>/<slug>_<cores>c_<gitsha8>_<stamp>.tgz` - the slug
-derived from the dataset's own `uname` + CPU brand, the SHA from its provenance -
-so a bundle is self-identifying and collision-free across machines.
+`data/<os>-<arch>-<cpu-brand>/<slug>_<cores>c_<compiler>_<gitsha8>_<stamp>.tgz` - the slug
+derived from the dataset's own `uname` + CPU brand, the `compiler` reported by the
+benchmark binary (`clang-NN` / `gcc-NN`, so GCC and Clang builds on one machine
+stay distinct), the SHA from its provenance - so a bundle is self-identifying and
+collision-free across machines and toolchains.
 
 ## CI
 

--- a/mbo/hash/measurements/data/macos-arm64-apple-m5-pro/macos-arm64-apple-m5-pro_18c_81ddc2a7_20260710_174715.tgz
+++ b/mbo/hash/measurements/data/macos-arm64-apple-m5-pro/macos-arm64-apple-m5-pro_18c_81ddc2a7_20260710_174715.tgz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4c8e0688da7638136a8d263e916b70b620354cee327832cd60a469ee5981407c
-size 315222

--- a/mbo/hash/measurements/hash_benchmark_report.py
+++ b/mbo/hash/measurements/hash_benchmark_report.py
@@ -120,18 +120,19 @@ def _source_provenance():
 
 def _machine_augment():
     """CPU brand / OS / model not always in google/benchmark's context; fill from the
-    OS. Best-effort and cross-platform: any field that cannot be read is omitted."""
+    OS. Best-effort and cross-platform: any field that cannot be read is omitted.
+    The build compiler is reported by the benchmark binary itself (`compiler` /
+    `compiler_version` custom context) - system `cc` need not be what bazel built
+    with - so it is not captured here."""
     brand = _sh(["sysctl", "-n", "machdep.cpu.brand_string"])  # macOS
     model = _sh(["sysctl", "-n", "hw.model"])  # macOS, e.g. "Mac17,9"
     if not brand:  # Linux
         brand = _sh(["sh", "-c", "grep -m1 'model name' /proc/cpuinfo | cut -d: -f2-"])
     if not model:  # Linux board/product name, best-effort
         model = _sh(["sh", "-c", "cat /sys/devices/virtual/dmi/id/product_name 2>/dev/null"])
-    compiler = _sh(["sh", "-c", "${CC:-cc} --version 2>/dev/null | head -1"])
     augment = {"cpu_brand": (brand or "").strip() or None, "uname": _sh(["uname", "-srm"])}
-    for key, value in (("cpu_model", model), ("compiler", compiler)):
-        if value and value.strip():
-            augment[key] = value.strip()
+    if model and model.strip():
+        augment["cpu_model"] = model.strip()
     return augment
 
 
@@ -671,10 +672,11 @@ def main(argv):
         ctx = results.get("context", {})
         slug = _platform_slug(ctx)
         cores = ctx.get("num_cpus", "?")
+        compiler = _slug(ctx.get("compiler") or "cc")
         sha = ((ctx.get("source") or {}).get("git_sha") or "nogit")[:8]
         dest_dir = os.path.join(args.data_dir, slug)
         os.makedirs(dest_dir, exist_ok=True)
-        dest = os.path.join(dest_dir, f"{slug}_{cores}c_{sha}_{stamp}.tgz")
+        dest = os.path.join(dest_dir, f"{slug}_{cores}c_{compiler}_{sha}_{stamp}.tgz")
         with tarfile.open(dest, "w:gz") as tar:
             tar.add(args.results, arcname="results.json")  # stable name so `verify` finds it
             for path in args.include:


### PR DESCRIPTION
Prep before the authoritative M5/Zen5 runs.

**Compiler as a first-class measurement axis.** We build with both GCC and Clang, and their perf differs, so:
- The benchmark binary self-reports its actual build compiler via google/benchmark custom context: `compiler` (`clang-NN` / `gcc-NN`) + `compiler_version`. The system `cc` capture in `_machine_augment` is dropped (it need not be what bazel built with).
- The per-machine bundle filename gains it: `<slug>_<cores>c_<compiler>_<gitsha8>_<stamp>.tgz`, so clang and gcc builds on one machine are distinct data with distinct names. Verified: a fast run here tagged `clang-21`.

**Drops the placeholder M5 bundle** (old 18-size #243 data) - it is replaced by the authoritative runs anyway, and removing it clears the stale "expected but never pushed" LFS reference the squash-merge left behind. (Charts stay as the current published figures until the authoritative runs refresh them.)