### PR TITLE
mbo/hash: measurements --config pass-through + bump hermetic LLVM/clang to 22.1.8

### DIFF
--- a/bazelmod/llvm.MODULE.bazel
+++ b/bazelmod/llvm.MODULE.bazel
@@ -20,7 +20,7 @@ bazel_dep(name = "toolchains_llvm", version = "1.8.0")
 llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm", dev_dependency = True)
 llvm.toolchain(
     name = "llvm_toolchain_llvm",
-    llvm_version = "20.1.8",
+    llvm_version = "22.1.8",
     extra_llvm_distributions = {
         # 22.1.8 — newest released; a forward-looking rung in the CI clang matrix
         "LLVM-22.1.8-Linux-ARM64.tar.xz": "805efad2bb91cb4967fa569e0881d10c0f69c04461cf671cccbae19f547acc34",

--- a/mbo/hash/measurements/README.md
+++ b/mbo/hash/measurements/README.md
@@ -130,6 +130,10 @@ per-machine LFS bundle, and prints exactly what to commit:
 ```sh
 # Everything, SMHasher3 batteries 4-at-a-time (perf runs first and alone):
 mbo/hash/measurements/run_measurements.py --jobs 4
+# Pick the toolchain (and thus the recorded compiler): --config clang uses the
+# hermetic LLVM clang; omit --config for the native toolchain (gcc on Linux).
+# Run once per compiler to compare them - the bundle filenames won't collide:
+mbo/hash/measurements/run_measurements.py --config clang --jobs 4
 # In-house family only, or perf/chart only:
 mbo/hash/measurements/run_measurements.py --algos mumbo,jumbo,dumbo --jobs 1
 mbo/hash/measurements/run_measurements.py --skip-smhasher

--- a/mbo/hash/measurements/hash_benchmark_report.py
+++ b/mbo/hash/measurements/hash_benchmark_report.py
@@ -136,8 +136,12 @@ def _machine_augment():
     return augment
 
 
-def _run_benchmark(mode, reps, min_time, warmup):
-    """Runs the bazel benchmark with the measurement precautions; returns parsed JSON."""
+def _run_benchmark(mode, reps, min_time, warmup, config=None):
+    """Runs the bazel benchmark with the measurement precautions; returns parsed JSON.
+
+    `config` selects a bazel `--config` (e.g. 'clang' / 'gcc'), so the toolchain -
+    and therefore the compiler the benchmark records into the dataset - is the one
+    you want to measure."""
     env = dict(os.environ)
     if mode == "full":
         env["MBO_HASH_BENCHMARK_FULL"] = "1"
@@ -146,6 +150,7 @@ def _run_benchmark(mode, reps, min_time, warmup):
         "run",
         "-c",
         "opt",
+        *([f"--config={config}"] if config else []),
         _BENCHMARK_TARGET,
         "--",
         "--benchmark_format=json",
@@ -549,6 +554,7 @@ def main(argv):
     p_run.add_argument("--raw", help="write google/benchmark raw JSON here (.gz compresses)")
     p_run.add_argument("--out", help="write the distilled canonical results JSON here")
     p_run.add_argument("--tables", action="store_true")
+    p_run.add_argument("--config", help="bazel --config for the benchmark build (e.g. clang, gcc); picks the toolchain and the recorded compiler")
 
     p_store = sub.add_parser("store", help="distill raw benchmark JSON to canonical results JSON")
     p_store.add_argument("--raw", required=True)
@@ -599,7 +605,7 @@ def main(argv):
     stamp = _timestamp()
 
     if args.command == "run":
-        raw = _run_benchmark(args.mode, args.reps, args.min_time, args.warmup)
+        raw = _run_benchmark(args.mode, args.reps, args.min_time, args.warmup, args.config)
         if args.raw:
             raw_path = _timestamped(args.raw, stamp)
             opener = gzip.open if raw_path.endswith(".gz") else open

--- a/mbo/hash/measurements/run_measurements.py
+++ b/mbo/hash/measurements/run_measurements.py
@@ -63,6 +63,7 @@ def main(argv):
     parser.add_argument("--algos", default="all", help="SMHasher3 algorithms (default 'all'; e.g. mumbo,jumbo,dumbo)")
     parser.add_argument("--jobs", type=int, default=4, help="SMHasher3 batteries to run concurrently (default 4)")
     parser.add_argument("--reps", type=int, default=9, help="benchmark repetitions (default 9)")
+    parser.add_argument("--config", help="bazel --config for the perf benchmark (e.g. clang, gcc); picks the toolchain + recorded compiler")
     parser.add_argument(
         "--workdir",
         default=os.path.expanduser("~/.cache/mbo-hash-smh"),
@@ -101,7 +102,8 @@ def main(argv):
         with open(os.path.join(data, "README_tables.md"), "w") as tables:
             subprocess.run(
                 [*report, "run", "--mode", "full", "--reps", str(args.reps),
-                 "--raw", os.path.join(data, "raw.json.gz"), "--out", os.path.join(data, "results.json"), "--tables"],
+                 "--raw", os.path.join(data, "raw.json.gz"), "--out", os.path.join(data, "results.json"), "--tables"]
+                + (["--config", args.config] if args.config else []),
                 stdout=tables, check=True,
             )
         canonical = newest(os.path.join(data, "*_results.json"))


### PR DESCRIPTION
Toolchain prep so the authoritative benchmark runs can pick a compiler cleanly. Both together, since we want to measure under each toolchain.

**`--config` pass-through.** `run_measurements.py` / `hash_benchmark_report.py run` gain `--config`, forwarded to the perf `bazel run` (e.g. `--config clang`; omit for native gcc). So a machine can be measured under each compiler and the recorded compiler + bundle filename (from #246) match the toolchain used.

**LLVM pin 20.1.8 → 22.1.8.** The hermetic clang toolchain `--config=clang` resolves to; the 22.1.8 distributions were already registered. Validated locally: `bazel build --config=clang -c opt //mbo/hash:hash_benchmark` builds and reports `clang-22`.

**Watch on CI:** `absolute_paths` is not set - per prior notes LLVM 22 on macos-26 ASAN wanted it to avoid a compiler-rt `FindDynamicShadowStart` hang; if that job hangs, the fix is `absolute_paths = True` on the `llvm.toolchain(...)` call.