### PR TITLE
Bump hermetic LLVM/clang toolchain pin to 22.1.8

### DIFF
--- a/bazelmod/llvm.MODULE.bazel
+++ b/bazelmod/llvm.MODULE.bazel
@@ -20,7 +20,7 @@ bazel_dep(name = "toolchains_llvm", version = "1.8.0")
 llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm", dev_dependency = True)
 llvm.toolchain(
     name = "llvm_toolchain_llvm",
-    llvm_version = "20.1.8",
+    llvm_version = "22.1.8",
     extra_llvm_distributions = {
         # 22.1.8 — newest released; a forward-looking rung in the CI clang matrix
         "LLVM-22.1.8-Linux-ARM64.tar.xz": "805efad2bb91cb4967fa569e0881d10c0f69c04461cf671cccbae19f547acc34",


### PR DESCRIPTION
Flips the pinned hermetic LLVM/clang toolchain (`--config=clang`) from **20.1.8 → 22.1.8** (the 22.1.8 distributions were already registered as a forward-looking matrix rung). This is the toolchain the measurement `--config clang` (#247) records, and the newer clang for the CI matrix.

Validated locally: `bazel build --config=clang -c opt //mbo/hash:hash_benchmark` succeeds on 22.1.8 (reports `clang-22`).

**Watch in CI:** `absolute_paths` is not set on the toolchain. Per prior notes, LLVM 22 on macos-26 ASAN wanted `absolute_paths` to avoid a compiler-rt `FindDynamicShadowStart` hang - if the macos-26 ASAN job hangs/fails, the fix is `absolute_paths = True` on the `llvm.toolchain(...)` call. CI's clang matrix + ASAN is the real validation here.