### PR TITLE
Bump version from 0.13.1 to 0.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 0.13.2
+
 # 0.13.1
 
 - Switched the build-seed mangle constant header to per-build generation (no longer committed): removed `internal/hash_mangle_seed.h.in` and `hash_mangle_seed_default_test`, so a version bump no longer needs a committed regeneration. `hash_mangle.h` includes the generated header directly (missing is an `#error`; clangd falls back under `-DIS_CLANGD`).

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,7 +17,7 @@
 
 module(
     name = "helly25_mbo",
-    version = "0.13.1",
+    version = "0.13.2",
 )
 
 # For local development we include LLVM and Hedron-Compile-Commands.


### PR DESCRIPTION
Post-release dev-version bump to 0.13.2 (verified local commit). The Trigger Release run cut 0.13.1 fine (tag + release), but its automated bump 409'd on required-signatures: the Contents-API commit was not GitHub-verified. Recovering the bump here; the reusable workflow is being fixed to (a) use `createCommitOnBranch` (always signed) and (b) treat the bump as best-effort (warn, don't fail the release).