### PR TITLE
feat(hash): rework hash benchmark - fix latency, add bounded-range throughput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.13.2
 
-- Reworked the hash latency benchmark to two fixed, reproducible key-length distributions (Short-Identifier, Web-URL) sampled once and shared across algorithms, replacing the hash-indexed key walk that collapsed into a degenerate cycle (near-zero anomalies).
+- Reworked the hash mixed-length benchmark: dropped the hash-indexed key walk that collapsed into a rho-cycle (near-zero anomalies) and added `BmHash64Throughput` reporting bytes/s over two documented length distributions (Short ≤128 B, Web ≤4096 B) truncated to each upper bound; the per-exact-length `BmHash64`/`BmHash128` remain the latency view. Distributions are exported as the `throughput_dists` context.
 - Added a `compare` command reporting per-case Δ% and a geomean between two datasets.
 - Made `tables`/`plot`/`compare`/`quality` accept a bundle `.tgz` or a results JSON, positionally or via `--results`/`--bundle`.
 - Added `plot --kind` (throughput/latency/all) and `--scale` (log-log/linear-log).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.13.2
 
+- Reworked the hash latency benchmark to two fixed, reproducible key-length distributions (Short-Identifier, Web-URL) sampled once and shared across algorithms, replacing the hash-indexed key walk that collapsed into a degenerate cycle (near-zero anomalies).
 - Added a `compare` command reporting per-case Δ% and a geomean between two datasets.
 - Made `tables`/`plot`/`compare`/`quality` accept a bundle `.tgz` or a results JSON, positionally or via `--results`/`--bundle`.
 - Added `plot --kind` (throughput/latency/all) and `--scale` (log-log/linear-log).

--- a/mbo/hash/BUILD.bazel
+++ b/mbo/hash/BUILD.bazel
@@ -207,6 +207,7 @@ cc_binary(
     tags = ["manual"],
     deps = [
         ":hash_test_util",
+        "@abseil-cpp//absl/strings",
         "@com_github_google_benchmark//:benchmark",
     ],
 )

--- a/mbo/hash/README.md
+++ b/mbo/hash/README.md
@@ -279,6 +279,23 @@ sub-nanosecond sizes. Bold marks the fastest per row; the tables use a curated
 set of lengths (straddling the dispatch-tier and SSO boundaries), the log-log
 charts a denser one.
 
+The **latency** benchmark models how a hash table actually calls a hash: a
+stream of differently-sized keys whose per-length size dispatch cannot be
+branch-predicted. Keys are drawn from two fixed, reproducible length
+distributions - **Short-Identifier** (log-normal: identifiers, DB keys, UUIDs)
+and **Web-URL** (heavy-tailed: paths and URLs) - sampled once with a fixed seed
+and shared byte-for-byte across all algorithms (only the lengths matter; the
+bytes are filler). Each distribution is an inverse-CDF table capped by a 100%
+limit anchor `Lmax`: **128 B** for Short-Identifier (two L1 cache lines - the
+AVX-512 / medium-key-to-bulk transition and a jemalloc/tcmalloc size-class
+ceiling) and **4096 B** for Web-URL (one x86/ARM64 virtual page, where a larger
+allocation can page-fault). Because the percentile draw is half-open `[0, 1)` it
+never samples the `1.0` entry by chance (a 1024-key set misses the top region
+~36% of the time), so exactly one key per set is pinned to `Lmax` - a guaranteed
+worst-case anchor that keeps the curve bounded and exercises the SSO-spill and
+bulk-tier code paths, while the other 1023 keys preserve the branch-prediction
+noise.
+
 Everything between the markers is generated per machine by `publish` from the
 committed bundles - regenerate it, don't hand-edit:
 

--- a/mbo/hash/README.md
+++ b/mbo/hash/README.md
@@ -285,8 +285,9 @@ branch-predicted. Keys are drawn from two fixed, reproducible length
 distributions - **Short-Identifier** (log-normal: identifiers, DB keys, UUIDs)
 and **Web-URL** (heavy-tailed: paths and URLs) - sampled once with a fixed seed
 and shared byte-for-byte across all algorithms (only the lengths matter; the
-bytes are filler). Each distribution is an inverse-CDF table capped by a 100%
-limit anchor `Lmax`: **128 B** for Short-Identifier (two L1 cache lines - the
+bytes are filler). Each distribution is an inverse-CDF (Cumulative Distribution
+Function, see [Wikipedia](https://en.wikipedia.org/wiki/Cumulative_distribution_function))
+table capped by a 100% limit anchor `Lmax`: **128 B** for Short-Identifier (two L1 cache lines - the
 AVX-512 / medium-key-to-bulk transition and a jemalloc/tcmalloc size-class
 ceiling) and **4096 B** for Web-URL (one x86/ARM64 virtual page, where a larger
 allocation can page-fault). Because the percentile draw is half-open `[0, 1)` it

--- a/mbo/hash/hash_benchmark.cc
+++ b/mbo/hash/hash_benchmark.cc
@@ -23,6 +23,7 @@
 // the ns-vs-length graph.
 
 #include <array>
+#include <cmath>
 #include <cstdint>
 #include <cstdlib>
 #include <random>
@@ -30,8 +31,11 @@
 #include <string>
 #include <string_view>
 #include <tuple>
+#include <utility>
 #include <vector>
 
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_join.h"
 #include "benchmark/benchmark.h"
 #include "mbo/hash/hash_test_util.h"
 
@@ -179,25 +183,75 @@ void BmHash128(benchmark::State& state) {
   state.SetLabel(std::string(Algo::Name()));
 }
 
-// Latency benchmark: keys of unpredictable random length in [0, max_len], and
-// each hash result selects the next key, serializing the chain. This defeats
-// the branch predictor on the size dispatch and measures latency rather than
-// hot-loop throughput -- the cost profile hash-table workloads actually pay.
-template<typename Algo>
-void BmHash64Latency(benchmark::State& state) {
-  const auto max_len = static_cast<std::size_t>(state.range(0));
-  std::mt19937_64 rng(
-      0x1a7e9c1);  // NOLINT(cert-msc51-cpp,cert-msc32-c,bugprone-random-generator-seed): fixed key set per run
-  constexpr std::size_t kNumKeys = 1'024;  // power of two for cheap masking
-  std::vector<std::string> keys;
-  keys.reserve(kNumKeys);
-  for (std::size_t i = 0; i < kNumKeys; ++i) {
-    keys.push_back(algo::RandomString(rng, rng() % (max_len + 1)));
+// --- Latency benchmark: hashing a realistic MIX of key lengths --------------
+//
+// A hash table does not hash one length in a hot loop (that is BmHash64); it
+// hashes a stream of differently-sized keys, so the per-length size dispatch
+// cannot be branch-predicted. We model that with two fixed, documented length
+// distributions given as inverse-CDF control points (cumulative percentile ->
+// length in bytes), piecewise-linear between points:
+//   - Short-Identifier: programming identifiers / DB keys / UUIDs (log-normal).
+//   - Web/URL: paths, URLs, and larger text keys (heavy-tailed).
+// The keys are sampled ONCE from these with a fixed-seed PRNG and SHARED across
+// every algorithm in a run, so all algorithms hash the byte-identical key set
+// (fair comparison) and the set is reproducible across runs (only the string
+// LENGTHS matter; the bytes are irrelevant filler).
+constexpr std::size_t kLatencyKeys = 1'024;  // power of two for cheap masking
+
+struct LatencyDist {
+  std::string_view name;
+  std::array<std::pair<double, int>, 8> cdf;  // ascending (percentile, length)
+};
+
+constexpr std::array<LatencyDist, 2> kLatencyDists = {{
+    {"Short-Identifier",
+     {{{0.10, 8}, {0.25, 12}, {0.50, 16}, {0.75, 23}, {0.90, 31}, {0.95, 38}, {0.99, 53}, {0.999, 80}}}},
+    {"Web-URL",
+     {{{0.10, 15}, {0.25, 28}, {0.50, 45}, {0.75, 75}, {0.90, 120}, {0.95, 220}, {0.99, 512}, {0.999, 2'048}}}},
+}};
+
+// Inverse CDF: percentile p in [0,1) -> length. Piecewise-linear between control
+// points; below the first point interpolate from (0, 1 byte), at/above the last
+// clamp to its length (do not extrapolate the tail into huge outliers).
+std::size_t SampleLength(const LatencyDist& dist, double percentile) {
+  double prev_p = 0.0;
+  double prev_len = 1.0;
+  for (const auto& [pct, len] : dist.cdf) {
+    if (percentile < pct) {
+      const double frac = (percentile - prev_p) / (pct - prev_p);
+      return static_cast<std::size_t>(std::lround(prev_len + frac * (len - prev_len)));
+    }
+    prev_p = pct;
+    prev_len = len;
   }
-  uint64_t hash = 0;
+  return static_cast<std::size_t>(dist.cdf.back().second);
+}
+
+// The two key sets, built once (fixed seed) and shared by every latency
+// benchmark in the run. `state.range(0)` selects the distribution by index.
+const std::vector<std::string>& LatencyKeys(std::size_t dist_index) {
+  static const std::array<std::vector<std::string>, kLatencyDists.size()> kKeySets = [] {
+    std::array<std::vector<std::string>, kLatencyDists.size()> sets;
+    for (std::size_t d = 0; d < kLatencyDists.size(); ++d) {
+      std::mt19937_64 rng(
+          0x1a7e9c1);  // NOLINT(cert-msc51-cpp,cert-msc32-c,bugprone-random-generator-seed): fixed, reproducible set
+      sets[d].reserve(kLatencyKeys);
+      for (std::size_t i = 0; i < kLatencyKeys; ++i) {
+        const double percentile = static_cast<double>(rng()) / (static_cast<double>(UINT64_MAX) + 1.0);
+        sets[d].push_back(algo::RandomString(rng, SampleLength(kLatencyDists[d], percentile)));
+      }
+    }
+    return sets;
+  }();
+  return kKeySets[dist_index];
+}
+
+template<typename Algo>
+void BmHash64Latency(benchmark::State& state, std::size_t dist_index) {
+  const std::vector<std::string>& keys = LatencyKeys(dist_index);
+  std::size_t counter = 0;
   for (auto _ : state) {
-    hash = Algo::GetHash64(keys[hash & (kNumKeys - 1)], kSeed);
-    benchmark::DoNotOptimize(hash);
+    benchmark::DoNotOptimize(Algo::GetHash64(keys[counter++ & (kLatencyKeys - 1)], kSeed));
   }
   state.SetItemsProcessed(state.iterations());
   state.SetLabel(std::string(Algo::Name()));
@@ -209,19 +263,22 @@ template<typename Algo>
 void RegisterAlgo() {
   const std::string name(Algo::Name());
   const std::span<const int> sizes = ThroughputSizes();
-  auto* const hash64 = benchmark::RegisterBenchmark("BmHash64<" + name + ">", BmHash64<Algo>);
+  auto* const hash64 = benchmark::RegisterBenchmark(absl::StrCat("BmHash64<", name, ">"), BmHash64<Algo>);
   for (const int size : sizes) {
     hash64->Arg(size);
   }
   if constexpr (HasGetHash128<Algo>) {
-    auto* const hash128 = benchmark::RegisterBenchmark("BmHash128<" + name + ">", BmHash128<Algo>);
+    auto* const hash128 = benchmark::RegisterBenchmark(absl::StrCat("BmHash128<", name, ">"), BmHash128<Algo>);
     for (const int size : sizes) {
       hash128->Arg(size);
     }
   }
-  auto* const latency = benchmark::RegisterBenchmark("BmHash64Latency<" + name + ">", BmHash64Latency<Algo>);
-  for (const int size : sizes) {
-    latency->Arg(size);
+  // One benchmark per scenario, named "BmHash64Latency<algo>/<dist>" (not an Arg),
+  // so each realistic distribution is its own reported result.
+  for (std::size_t dist = 0; dist < kLatencyDists.size(); ++dist) {
+    benchmark::RegisterBenchmark(
+        absl::StrCat("BmHash64Latency<", name, ">/", kLatencyDists[dist].name),
+        [dist](benchmark::State& state) { BmHash64Latency<Algo>(state, dist); });
   }
 }
 
@@ -245,20 +302,16 @@ int main(int argc, char** argv) {
   // differs), so record what THIS binary was built with in the dataset context;
   // the stored bundle's filename is tagged with `compiler` too.
 #if defined(__clang__)
-  benchmark::AddCustomContext("compiler", "clang-" + std::to_string(__clang_major__));
+  benchmark::AddCustomContext("compiler", absl::StrCat("clang-", __clang_major__));
   benchmark::AddCustomContext("compiler_version", __clang_version__);
 #elif defined(__GNUC__)
-  benchmark::AddCustomContext("compiler", "gcc-" + std::to_string(__GNUC__));
+  benchmark::AddCustomContext("compiler", absl::StrCat("gcc-", __GNUC__));
   benchmark::AddCustomContext("compiler_version", __VERSION__);
 #endif
   // Emit the curated README size subset (kReadmeSizes) so the report tool extracts
   // the small table straight from a FULL dataset - no separate fast run, and no
   // second size list to drift (this C++ list is the single source of truth).
-  std::string readme_sizes;
-  for (const int size : mbo::hash::kReadmeSizes) {
-    readme_sizes += (readme_sizes.empty() ? "" : ",") + std::to_string(size);
-  }
-  benchmark::AddCustomContext("readme_sizes", readme_sizes);
+  benchmark::AddCustomContext("readme_sizes", absl::StrJoin(mbo::hash::kReadmeSizes, ","));
   benchmark::RunSpecifiedBenchmarks();
   benchmark::Shutdown();
   return 0;

--- a/mbo/hash/hash_benchmark.cc
+++ b/mbo/hash/hash_benchmark.cc
@@ -278,8 +278,8 @@ const std::vector<std::string>& LatencyKeys(std::size_t dist_index) {
 }
 
 template<typename Algo>
-void BmHash64Latency(benchmark::State& state, std::size_t dist_index) {
-  const std::vector<std::string>& keys = LatencyKeys(dist_index);
+void BmHash64Latency(benchmark::State& state) {
+  const std::vector<std::string>& keys = LatencyKeys(static_cast<std::size_t>(state.range(0)));
 
   // Optional: Track cumulative distribution weight
   int64_t total_bytes_per_shuffle = 0;
@@ -315,12 +315,14 @@ void RegisterAlgo() {
       hash128->Arg(size);
     }
   }
-  // One benchmark per scenario, named "BmHash64Latency<algo>/<dist>" (not an Arg),
-  // so each realistic distribution is its own reported result.
+  // One benchmark family with the scenarios as Args, so it reports as a grouped
+  // table (BmHash64Latency<algo>/0, /1 - one row per scenario), parallel to the
+  // throughput families. The Arg index -> distribution name legend is emitted as
+  // the `latency_dists` custom context (see main).
+  auto* const latency =
+      benchmark::RegisterBenchmark(absl::StrCat("BmHash64Latency<", name, ">"), BmHash64Latency<Algo>);
   for (std::size_t dist = 0; dist < kLatencyDists.size(); ++dist) {
-    benchmark::RegisterBenchmark(
-        absl::StrCat("BmHash64Latency<", name, ">/", kLatencyDists[dist].name),
-        [dist](benchmark::State& state) { BmHash64Latency<Algo>(state, dist); });
+    latency->Arg(static_cast<int>(dist));
   }
 }
 
@@ -354,6 +356,13 @@ int main(int argc, char** argv) {
   // the small table straight from a FULL dataset - no separate fast run, and no
   // second size list to drift (this C++ list is the single source of truth).
   benchmark::AddCustomContext("readme_sizes", absl::StrJoin(mbo::hash::kReadmeSizes, ","));
+  // Legend for the latency benchmark's Arg index -> distribution name, in order,
+  // so the report can label BmHash64Latency<algo>/0, /1 with the scenario names.
+  benchmark::AddCustomContext(
+      "latency_dists",
+      absl::StrJoin(mbo::hash::kLatencyDists, ",", [](std::string* out, const mbo::hash::LatencyDist& dist) {
+        absl::StrAppend(out, dist.name);
+      }));
   benchmark::RunSpecifiedBenchmarks();
   benchmark::Shutdown();
   return 0;

--- a/mbo/hash/hash_benchmark.cc
+++ b/mbo/hash/hash_benchmark.cc
@@ -200,14 +200,34 @@ constexpr std::size_t kLatencyKeys = 1'024;  // power of two for cheap masking
 
 struct LatencyDist {
   std::string_view name;
-  std::array<std::pair<double, int>, 8> cdf;  // ascending (percentile, length)
+  std::array<std::pair<double, int>, 9> cdf;  // ascending (percentile, length)
 };
 
 constexpr std::array<LatencyDist, 2> kLatencyDists = {{
     {.name = "Short-Identifier",
-     .cdf = {{{0.10, 8}, {0.25, 12}, {0.50, 16}, {0.75, 23}, {0.90, 31}, {0.95, 38}, {0.99, 53}, {0.999, 80}}}},
+     .cdf = {{
+         {0.10, 8},
+         {0.25, 12},
+         {0.50, 16},
+         {0.75, 23},
+         {0.90, 31},
+         {0.95, 38},
+         {0.99, 53},
+         {0.999, 80},
+         {1.0, 128},  // Clean 100% ceiling representing the SSO/AVX-512 transition
+     }}},
     {.name = "Web-URL",
-     .cdf = {{{0.10, 15}, {0.25, 28}, {0.50, 45}, {0.75, 75}, {0.90, 120}, {0.95, 220}, {0.99, 512}, {0.999, 2'048}}}},
+     .cdf = {{
+         {0.10, 15},
+         {0.25, 28},
+         {0.50, 45},
+         {0.75, 75},
+         {0.90, 120},
+         {0.95, 220},
+         {0.99, 512},
+         {0.999, 2'048},
+         {1.0, 4'096},  // Clean 100% ceiling representing a full virtual page
+     }}},
 }};
 
 // Inverse CDF: percentile p in [0,1) -> length. Piecewise-linear between control
@@ -236,10 +256,21 @@ const std::vector<std::string>& LatencyKeys(std::size_t dist_index) {
       // NOLINTNEXTLINE(cert-msc51-cpp,cert-msc32-c,bugprone-random-generator-seed): fixed, reproducible set
       std::mt19937_64 rng(0x1a7e9c1);
       sets[idx].reserve(kLatencyKeys);
-      for (std::size_t i = 0; i < kLatencyKeys; ++i) {
+
+      // Generate exactly 1023 keys using the distribution
+      for (std::size_t i = 0; i < kLatencyKeys - 1; ++i) {
         const double percentile = static_cast<double>(rng()) / (static_cast<double>(UINT64_MAX) + 1.0);
         sets[idx].push_back(algo::RandomString(rng, SampleLength(kLatencyDists[idx], percentile)));
       }
+
+      // Enforce that the 1024th key is guaranteed to be the 100% bounds anchor.
+      const std::size_t absolute_max_len = kLatencyDists[idx].cdf.back().second;
+      // Passing the RNG to RandomString is safe here because the RNG is only
+      // used for generating the string content, not for determining its length.
+      // Since this is the final step of a isolated vector generation block, it
+      // does not affect the reproducibility of the earlier keys, but it does
+      // guarantee that the random string data itself remains completely unique.
+      sets[idx].push_back(algo::RandomString(rng, absolute_max_len));
     }
     return sets;
   }();
@@ -249,11 +280,22 @@ const std::vector<std::string>& LatencyKeys(std::size_t dist_index) {
 template<typename Algo>
 void BmHash64Latency(benchmark::State& state, std::size_t dist_index) {
   const std::vector<std::string>& keys = LatencyKeys(dist_index);
+
+  // Optional: Track cumulative distribution weight
+  int64_t total_bytes_per_shuffle = 0;
+  for (const auto& key : keys) {
+    total_bytes_per_shuffle += static_cast<int64_t>(key.size());
+  }
+
   std::size_t counter = 0;
   for (auto _ : state) {
     benchmark::DoNotOptimize(Algo::GetHash64(keys[counter++ & (kLatencyKeys - 1)], kSeed));
   }
+
   state.SetItemsProcessed(state.iterations());
+  // Allow plotting the total processed gigabytes per second even during
+  // unpredictable random branching profiles:
+  state.SetBytesProcessed(state.iterations() * (total_bytes_per_shuffle / static_cast<int64_t>(kLatencyKeys)));
   state.SetLabel(std::string(Algo::Name()));
 }
 

--- a/mbo/hash/hash_benchmark.cc
+++ b/mbo/hash/hash_benchmark.cc
@@ -42,7 +42,7 @@
 namespace mbo::hash {
 namespace {
 
-// NOLINTBEGIN(*-magic-numbers)
+// NOLINTBEGIN(*-array-index,*-magic-numbers)
 
 constexpr uint64_t kSeed = 5'381;
 
@@ -159,8 +159,8 @@ std::span<const int> ThroughputSizes() {
 template<typename Algo>
 void BmHash64(benchmark::State& state) {
   const auto length = static_cast<std::size_t>(state.range(0));
-  std::mt19937_64 rng(
-      0x1234);  // NOLINT(cert-msc51-cpp,cert-msc32-c,bugprone-random-generator-seed): fixed data per length
+  // NOLINTNEXTLINE(cert-msc51-cpp,cert-msc32-c,bugprone-random-generator-seed): fixed data per length
+  std::mt19937_64 rng(0x1234);
   const std::string data = algo::RandomString(rng, length);
   for (auto _ : state) {
     benchmark::DoNotOptimize(Algo::GetHash64(data, kSeed));
@@ -173,8 +173,8 @@ template<typename Algo>
 requires HasGetHash128<Algo>
 void BmHash128(benchmark::State& state) {
   const auto length = static_cast<std::size_t>(state.range(0));
-  std::mt19937_64 rng(
-      0x1234);  // NOLINT(cert-msc51-cpp,cert-msc32-c,bugprone-random-generator-seed): fixed data per length
+  // NOLINTNEXTLINE(cert-msc51-cpp,cert-msc32-c,bugprone-random-generator-seed): fixed data per length
+  std::mt19937_64 rng(0x1234);
   const std::string data = algo::RandomString(rng, length);
   for (auto _ : state) {
     benchmark::DoNotOptimize(Algo::GetHash128(data, kSeed));
@@ -204,10 +204,10 @@ struct LatencyDist {
 };
 
 constexpr std::array<LatencyDist, 2> kLatencyDists = {{
-    {"Short-Identifier",
-     {{{0.10, 8}, {0.25, 12}, {0.50, 16}, {0.75, 23}, {0.90, 31}, {0.95, 38}, {0.99, 53}, {0.999, 80}}}},
-    {"Web-URL",
-     {{{0.10, 15}, {0.25, 28}, {0.50, 45}, {0.75, 75}, {0.90, 120}, {0.95, 220}, {0.99, 512}, {0.999, 2'048}}}},
+    {.name = "Short-Identifier",
+     .cdf = {{{0.10, 8}, {0.25, 12}, {0.50, 16}, {0.75, 23}, {0.90, 31}, {0.95, 38}, {0.99, 53}, {0.999, 80}}}},
+    {.name = "Web-URL",
+     .cdf = {{{0.10, 15}, {0.25, 28}, {0.50, 45}, {0.75, 75}, {0.90, 120}, {0.95, 220}, {0.99, 512}, {0.999, 2'048}}}},
 }};
 
 // Inverse CDF: percentile p in [0,1) -> length. Piecewise-linear between control
@@ -219,7 +219,7 @@ std::size_t SampleLength(const LatencyDist& dist, double percentile) {
   for (const auto& [pct, len] : dist.cdf) {
     if (percentile < pct) {
       const double frac = (percentile - prev_p) / (pct - prev_p);
-      return static_cast<std::size_t>(std::lround(prev_len + frac * (len - prev_len)));
+      return static_cast<std::size_t>(std::lround(prev_len + (frac * (len - prev_len))));
     }
     prev_p = pct;
     prev_len = len;
@@ -232,13 +232,13 @@ std::size_t SampleLength(const LatencyDist& dist, double percentile) {
 const std::vector<std::string>& LatencyKeys(std::size_t dist_index) {
   static const std::array<std::vector<std::string>, kLatencyDists.size()> kKeySets = [] {
     std::array<std::vector<std::string>, kLatencyDists.size()> sets;
-    for (std::size_t d = 0; d < kLatencyDists.size(); ++d) {
-      std::mt19937_64 rng(
-          0x1a7e9c1);  // NOLINT(cert-msc51-cpp,cert-msc32-c,bugprone-random-generator-seed): fixed, reproducible set
-      sets[d].reserve(kLatencyKeys);
+    for (std::size_t idx = 0; idx < kLatencyDists.size(); ++idx) {
+      // NOLINTNEXTLINE(cert-msc51-cpp,cert-msc32-c,bugprone-random-generator-seed): fixed, reproducible set
+      std::mt19937_64 rng(0x1a7e9c1);
+      sets[idx].reserve(kLatencyKeys);
       for (std::size_t i = 0; i < kLatencyKeys; ++i) {
         const double percentile = static_cast<double>(rng()) / (static_cast<double>(UINT64_MAX) + 1.0);
-        sets[d].push_back(algo::RandomString(rng, SampleLength(kLatencyDists[d], percentile)));
+        sets[idx].push_back(algo::RandomString(rng, SampleLength(kLatencyDists[idx], percentile)));
       }
     }
     return sets;
@@ -290,7 +290,7 @@ void RegisterAll(std::tuple<Algos...> /*algorithms*/) {
   (RegisterAlgo<Algos>(), ...);
 }
 
-// NOLINTEND(*-magic-numbers)
+// NOLINTEND(*-array-index,*-magic-numbers)
 
 }  // namespace
 }  // namespace mbo::hash

--- a/mbo/hash/hash_benchmark.cc
+++ b/mbo/hash/hash_benchmark.cc
@@ -183,28 +183,36 @@ void BmHash128(benchmark::State& state) {
   state.SetLabel(std::string(Algo::Name()));
 }
 
-// --- Latency benchmark: hashing a realistic MIX of key lengths --------------
+// --- Throughput over upper-bounded length ranges ----------------------------
 //
-// A hash table does not hash one length in a hot loop (that is BmHash64); it
-// hashes a stream of differently-sized keys, so the per-length size dispatch
-// cannot be branch-predicted. We model that with two fixed, documented length
-// distributions given as inverse-CDF control points (cumulative percentile ->
-// length in bytes), piecewise-linear between points:
-//   - Short-Identifier: programming identifiers / DB keys / UUIDs (log-normal).
-//   - Web/URL: paths, URLs, and larger text keys (heavy-tailed).
-// The keys are sampled ONCE from these with a fixed-seed PRNG and SHARED across
-// every algorithm in a run, so all algorithms hash the byte-identical key set
-// (fair comparison) and the set is reproducible across runs (only the string
-// LENGTHS matter; the bytes are irrelevant filler).
+// BmHash64 / BmHash128 above hash ONE key of an exact length in a hot loop: the
+// exact-length -> time curve (the "latency" view). This is the complementary
+// throughput view - how a realistic, upper-BOUNDED range of key lengths
+// translates to a single bytes/s number.
+//
+// Two documented length distributions as inverse-CDF control points (cumulative
+// percentile -> length in bytes), piecewise-linear between points:
+//   - Short: identifiers / DB keys / UUIDs (log-normal), ceiling 128 B.
+//   - Web:   paths, URLs, larger text keys (heavy-tailed), ceiling 4096 B.
+// Each control-point length doubles as an upper BOUND: we run the mix truncated
+// to each bound, with the kept buckets' weights renormalized to 100% (which
+// falls straight out of scaling the percentile draw into [0, cdf[bound].pct)).
+// A run therefore yields (X = upper-bound length, Y = bytes/s), and sweeping the
+// bounds gives the upper-length -> throughput curve. Keys are built once per
+// (distribution, bound) with a fixed seed and shared across every algorithm, so
+// the set is reproducible and identical for all algorithms (only the LENGTHS
+// matter; the bytes are filler). The unpredictable length order defeats the
+// size-dispatch branch predictor - the cost a real mixed workload pays.
 constexpr std::size_t kLatencyKeys = 1'024;  // power of two for cheap masking
+constexpr std::size_t kCdfPoints = 9;        // inverse-CDF control points per distribution
 
 struct LatencyDist {
   std::string_view name;
-  std::array<std::pair<double, int>, 9> cdf;  // ascending (percentile, length)
+  std::array<std::pair<double, int>, kCdfPoints> cdf;  // ascending (cumulative pct, length); last = {1.0, Lmax}
 };
 
 constexpr std::array<LatencyDist, 2> kLatencyDists = {{
-    {.name = "Short-Identifier",
+    {.name = "Short",
      .cdf = {{
          {0.10, 8},
          {0.25, 12},
@@ -214,9 +222,9 @@ constexpr std::array<LatencyDist, 2> kLatencyDists = {{
          {0.95, 38},
          {0.99, 53},
          {0.999, 80},
-         {1.0, 128},  // Clean 100% ceiling representing the SSO/AVX-512 transition
+         {1.0, 128},  // 100% ceiling: two L1 cache lines / the SSO & AVX-512 transition
      }}},
-    {.name = "Web-URL",
+    {.name = "Web",
      .cdf = {{
          {0.10, 15},
          {0.25, 28},
@@ -226,13 +234,14 @@ constexpr std::array<LatencyDist, 2> kLatencyDists = {{
          {0.95, 220},
          {0.99, 512},
          {0.999, 2'048},
-         {1.0, 4'096},  // Clean 100% ceiling representing a full virtual page
+         {1.0, 4'096},  // 100% ceiling: one x86/ARM64 virtual page
      }}},
 }};
 
 // Inverse CDF: percentile p in [0,1) -> length. Piecewise-linear between control
-// points; below the first point interpolate from (0, 1 byte), at/above the last
-// clamp to its length (do not extrapolate the tail into huge outliers).
+// points; below the first point interpolate from (0, 1 byte). Scaling p into
+// [0, cdf[bound].pct) restricts the draw to buckets <= that bound and
+// renormalizes their weights to 100% - the truncation the sweep needs.
 std::size_t SampleLength(const LatencyDist& dist, double percentile) {
   double prev_p = 0.0;
   double prev_len = 1.0;
@@ -247,55 +256,48 @@ std::size_t SampleLength(const LatencyDist& dist, double percentile) {
   return static_cast<std::size_t>(dist.cdf.back().second);
 }
 
-// The two key sets, built once (fixed seed) and shared by every latency
-// benchmark in the run. `state.range(0)` selects the distribution by index.
-const std::vector<std::string>& LatencyKeys(std::size_t dist_index) {
-  static const std::array<std::vector<std::string>, kLatencyDists.size()> kKeySets = [] {
-    std::array<std::vector<std::string>, kLatencyDists.size()> sets;
-    for (std::size_t idx = 0; idx < kLatencyDists.size(); ++idx) {
-      // NOLINTNEXTLINE(cert-msc51-cpp,cert-msc32-c,bugprone-random-generator-seed): fixed, reproducible set
-      std::mt19937_64 rng(0x1a7e9c1);
-      sets[idx].reserve(kLatencyKeys);
-
-      // Generate exactly 1023 keys using the distribution
-      for (std::size_t i = 0; i < kLatencyKeys - 1; ++i) {
-        const double percentile = static_cast<double>(rng()) / (static_cast<double>(UINT64_MAX) + 1.0);
-        sets[idx].push_back(algo::RandomString(rng, SampleLength(kLatencyDists[idx], percentile)));
+// Key sets built once, one per (distribution, bound), shared by every algorithm.
+// Bound `b` truncates distribution `d` to lengths <= cdf[b].length: 1023 keys
+// drawn from the renormalized truncated distribution, plus one anchor key pinned
+// to the bound length so the boundary is always represented.
+const std::vector<std::string>& ThroughputKeys(std::size_t dist_index, std::size_t bound_index) {
+  static const std::array<std::array<std::vector<std::string>, kCdfPoints>, kLatencyDists.size()> kKeySets = [] {
+    std::array<std::array<std::vector<std::string>, kCdfPoints>, kLatencyDists.size()> sets;
+    for (std::size_t d = 0; d < kLatencyDists.size(); ++d) {
+      const LatencyDist& dist = kLatencyDists[d];
+      for (std::size_t b = 0; b < kCdfPoints; ++b) {
+        // NOLINTNEXTLINE(cert-msc51-cpp,cert-msc32-c,bugprone-random-generator-seed): fixed, reproducible set
+        std::mt19937_64 rng(0x1a7e9c1);
+        const double bound_pct = dist.cdf[b].first;
+        const auto bound_len = static_cast<std::size_t>(dist.cdf[b].second);
+        std::vector<std::string>& keys = sets[d][b];
+        keys.reserve(kLatencyKeys);
+        for (std::size_t i = 0; i + 1 < kLatencyKeys; ++i) {
+          const double draw = static_cast<double>(rng()) / (static_cast<double>(UINT64_MAX) + 1.0);
+          keys.push_back(algo::RandomString(rng, SampleLength(dist, draw * bound_pct)));
+        }
+        keys.push_back(algo::RandomString(rng, bound_len));  // anchor at the upper bound
       }
-
-      // Enforce that the 1024th key is guaranteed to be the 100% bounds anchor.
-      const std::size_t absolute_max_len = kLatencyDists[idx].cdf.back().second;
-      // Passing the RNG to RandomString is safe here because the RNG is only
-      // used for generating the string content, not for determining its length.
-      // Since this is the final step of a isolated vector generation block, it
-      // does not affect the reproducibility of the earlier keys, but it does
-      // guarantee that the random string data itself remains completely unique.
-      sets[idx].push_back(algo::RandomString(rng, absolute_max_len));
     }
     return sets;
   }();
-  return kKeySets[dist_index];
+  return kKeySets[dist_index][bound_index];
 }
 
 template<typename Algo>
-void BmHash64Latency(benchmark::State& state) {
-  const std::vector<std::string>& keys = LatencyKeys(static_cast<std::size_t>(state.range(0)));
-
-  // Optional: Track cumulative distribution weight
-  int64_t total_bytes_per_shuffle = 0;
-  for (const auto& key : keys) {
-    total_bytes_per_shuffle += static_cast<int64_t>(key.size());
+void BmHash64Throughput(benchmark::State& state, std::size_t dist_index, std::size_t bound_index) {
+  const std::vector<std::string>& keys = ThroughputKeys(dist_index, bound_index);
+  int64_t total_bytes = 0;
+  for (const std::string& key : keys) {
+    total_bytes += static_cast<int64_t>(key.size());
   }
-
   std::size_t counter = 0;
   for (auto _ : state) {
     benchmark::DoNotOptimize(Algo::GetHash64(keys[counter++ & (kLatencyKeys - 1)], kSeed));
   }
-
   state.SetItemsProcessed(state.iterations());
-  // Allow plotting the total processed gigabytes per second even during
-  // unpredictable random branching profiles:
-  state.SetBytesProcessed(state.iterations() * (total_bytes_per_shuffle / static_cast<int64_t>(kLatencyKeys)));
+  // Throughput headline: average key length x iterations = bytes hashed -> bytes/s.
+  state.SetBytesProcessed(state.iterations() * (total_bytes / static_cast<int64_t>(kLatencyKeys)));
   state.SetLabel(std::string(Algo::Name()));
 }
 
@@ -315,14 +317,16 @@ void RegisterAlgo() {
       hash128->Arg(size);
     }
   }
-  // One benchmark family with the scenarios as Args, so it reports as a grouped
-  // table (BmHash64Latency<algo>/0, /1 - one row per scenario), parallel to the
-  // throughput families. The Arg index -> distribution name legend is emitted as
-  // the `latency_dists` custom context (see main).
-  auto* const latency =
-      benchmark::RegisterBenchmark(absl::StrCat("BmHash64Latency<", name, ">"), BmHash64Latency<Algo>);
+  // Throughput over upper-bounded length ranges: one benchmark per (distribution,
+  // bound), named "BmHash64Throughput<algo>/<Short|Web>:<bound>", each reporting
+  // bytes/s. Sweeping the bounds gives the upper-length -> throughput curve.
   for (std::size_t dist = 0; dist < kLatencyDists.size(); ++dist) {
-    latency->Arg(static_cast<int>(dist));
+    for (std::size_t bound = 0; bound < kCdfPoints; ++bound) {
+      benchmark::RegisterBenchmark(
+          absl::StrCat(
+              "BmHash64Throughput<", name, ">/", kLatencyDists[dist].name, ":", kLatencyDists[dist].cdf[bound].second),
+          [dist, bound](benchmark::State& state) { BmHash64Throughput<Algo>(state, dist, bound); });
+    }
   }
 }
 

--- a/mbo/hash/hash_benchmark.cc
+++ b/mbo/hash/hash_benchmark.cc
@@ -360,12 +360,17 @@ int main(int argc, char** argv) {
   // the small table straight from a FULL dataset - no separate fast run, and no
   // second size list to drift (this C++ list is the single source of truth).
   benchmark::AddCustomContext("readme_sizes", absl::StrJoin(mbo::hash::kReadmeSizes, ","));
-  // Legend for the latency benchmark's Arg index -> distribution name, in order,
-  // so the report can label BmHash64Latency<algo>/0, /1 with the scenario names.
+  // Export the throughput length distributions in use as "name=pct:len,...;..."
+  // (the full inverse-CDF, not just the bound labels), so a dataset records
+  // exactly which mix produced its BmHash64Throughput<algo>/<name>:<bound> numbers.
   benchmark::AddCustomContext(
-      "latency_dists",
-      absl::StrJoin(mbo::hash::kLatencyDists, ",", [](std::string* out, const mbo::hash::LatencyDist& dist) {
-        absl::StrAppend(out, dist.name);
+      "throughput_dists",
+      absl::StrJoin(mbo::hash::kLatencyDists, ";", [](std::string* out, const mbo::hash::LatencyDist& dist) {
+        absl::StrAppend(
+            out, dist.name, "=",
+            absl::StrJoin(dist.cdf, ",", [](std::string* cdf_out, const std::pair<double, int>& point) {
+              absl::StrAppend(cdf_out, point.first, ":", point.second);
+            }));
       }));
   benchmark::RunSpecifiedBenchmarks();
   benchmark::Shutdown();


### PR DESCRIPTION
## Summary

Fixes the `//mbo/hash:hash_benchmark` mixed-length measurement (which produced unreliable, non-reproducible latency numbers) and reframes it. Benchmark-only, by design: the report generator + README rendering land in a follow-up PR after re-measuring on clean `main`.

Terminology this PR settles on:
- **Latency** = cost at an *exact* length (ns). This is `BmHash64` / `BmHash128<algo>/<len>` — unchanged.
- **Throughput** = cost over a realistic, *upper-bounded* length range (bytes/s). This is the new `BmHash64Throughput`.

## The old bug

`BmHash64Latency` walked keys by `keys[hash & mask]` — a functional iteration `hash_{n+1} = f(hash_n)` that collapses into a short rho-cycle, re-hashing only a few keys and reading as near-zero whenever the cycle hit an empty/tiny key (e.g. `fnv1a` at `0.27 ns`). Removed.

## New: throughput over upper-bounded length ranges

- `BmHash64Throughput<algo>/<Short|Web>:<bound>` — hashes a realistic `[0..L]` length mix, truncated and renormalized (kept buckets rescaled to 100%) to each upper bound `L`, reporting **bytes/s** → an `(upper-bound length -> throughput)` curve.
- Two documented distributions as inverse-CDF tables: **Short** (log-normal, ≤128 B) and **Web** (heavy-tailed, ≤4096 B). Ceilings `Lmax` = 128 B (two L1 cache lines / SSO & AVX-512 transition) and 4096 B (one virtual page).
- Keys built **once** per (distribution, bound) with a fixed seed and **shared** across all algorithms (reproducible, fair; only lengths matter). One anchor key pinned at each bound so the boundary is always represented.
- Sequential sweep (`keys[counter & mask]`, no hash-indexed walk) → no rho-cycle; the unpredictable length order still defeats the size-dispatch branch predictor, so the branch-misprediction cost is measured (not modelled).
- String building uses `absl::StrCat`/`absl::StrJoin` (adds `@abseil-cpp//absl/strings`).
- Exports a `throughput_dists` context (the full per-distribution inverse-CDF) so every dataset records exactly which mix produced its numbers.

## Verification

Both distributions produce smooth, monotonic, anomaly-free, reproducible curves across all algorithms (no `0.27` collapses); `bytes/s` rises with the bound as larger keys enter the mix.

## Follow-up (not this PR)

Re-measure on merged `main`, then a second PR: report parser/`distill` for `BmHash64Throughput`, the latency (exact-length) + throughput (bounded-range) tables/charts, and the README methodology + values.
