### PR TITLE
Move clang-tidy from trunk to a pre-commit hook, and fix the compile DB

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,8 @@
 ---
+# abseil-unchecked-statusor-access is off because clang-tidy 22.1.8 SEGFAULTS in
+# it: its dataflow analysis (runTypeErasedDataflowAnalysis) crashes on
+# mbo/strings/strip.cc, reproducibly on both macOS and Linux. Re-test on a future
+# LLVM and re-enable if fixed.
 # Two llvm-* checks are off because they fight documented conventions:
 # * llvm-header-guard - STYLE_CPP.md mandates `{PATH}_{FILE}_` guards, not LLVM's
 #   path-derived style. With no header root configured it derives the guard from
@@ -11,6 +15,7 @@
 Checks: >
   *,
   abseil-*,
+  -abseil-unchecked-statusor-access,
   -altera-*,
   -boost-*,
   bugprone-*,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,13 @@
 ---
+# Two llvm-* checks are off because they fight documented conventions:
+# * llvm-header-guard - STYLE_CPP.md mandates `{PATH}_{FILE}_` guards, not LLVM's
+#   path-derived style. With no header root configured it derives the guard from
+#   the absolute checkout path (`USERS_..._MBO_LOG_SCOPED_STREAM_H`), so every
+#   header in the repo is flagged.
+# * llvm-prefer-static-over-anonymous-namespace - internal-linkage helpers are
+#   grouped in an anonymous namespace here, not marked per-function `static`.
+# Comments must stay outside the `Checks: >` folded scalar below: text inside it
+# is content, not YAML comments, and would be parsed as check globs.
 Checks: >
   *,
   abseil-*,
@@ -18,7 +27,9 @@ Checks: >
   -google-build-using-namespace,
   -hicpp-no-assembler,
   -llvm-else-after-return,
+  -llvm-header-guard,
   -llvm-include-order,
+  -llvm-prefer-static-over-anonymous-namespace,
   -llvmlibc-*,
   misc-*,
   modernize-*,
@@ -33,10 +44,12 @@ Checks: >
   -readability-else-after-return,
   -readability-redundant-inline-specifier,
 
-WarningsAsErrors: true
+# A check-name glob, not a bool: the former `true` matched no check, so findings
+# never escalated to a non-zero exit.
+WarningsAsErrors: '*'
 FormatStyle:       '.clang-format'
 CheckOptions:
-  - key:             bugprone-signed-char-misuse.CharTypdefsToIgnore
+  - key:             bugprone-signed-char-misuse.CharTypedefsToIgnore
     value:           'int8_t'
   - key:             google-readability-braces-around-statements.ShortStatementLines
     value:           '1'
@@ -132,6 +145,4 @@ CheckOptions:
     value:           'type'
   - key:             readability-identifier-naming.ConstexprVariableIgnoredRegexp
     value:           'value|index|.*[a-z]V'
-  - key:             llvm-header-guard.HeaderFileExtensions
-    value:           'h,hh,hpp,hxx'
 ...

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,10 +54,67 @@ jobs:
       - uses: pre-commit/action@v3.0.1
         env:
           # The `trunk` job runs the full `trunk check`; do not also run trunk
-          # from pre-commit in CI (see the trunk-fmt hook).
-          SKIP: trunk-fmt
+          # from pre-commit in CI (see the trunk-fmt hook). Likewise the
+          # `clang-tidy` job owns clang-tidy: it needs a compile_commands.json
+          # this job deliberately does not build. `clang-tidy` is `stages:
+          # [manual]` today, so it is already absent here; naming it keeps that
+          # true when the hook is promoted to an automatic gate.
+          SKIP: trunk-fmt,clang-tidy
       - uses: pre-commit-ci/lite-action@v1.0.2
         if: always()
+
+  clang-tidy:
+    needs: [trunk, pre-commit]
+    runs-on: ubuntu-latest
+    # TODO(helly25): drop this once the clang-tidy finding sweep lands.
+    # `.clang-tidy` sets `WarningsAsErrors: '*'` and the tree is not clean yet,
+    # so for now the job must report without blocking.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: bazelbuild/setup-bazelisk@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - uses: actions/cache/restore@v5
+        id: cache_restore
+        with:
+          path: "~/.cache/bazel"
+          key: clang-tidy-${{github.ref}}-${{github.sha}}
+          restore-keys: |
+            clang-tidy-${{github.ref}}
+            clang-tidy-refs/heads/main
+            clang-tidy
+
+      - name: Generate compile_commands.json
+        # The compile DB is a local artifact (gitignored), so it has to be built
+        # here. The script fetches the hermetic LLVM toolchain if needed and
+        # records ITS clang as the compiler, which is what makes the resulting
+        # commands parseable by the matching hermetic clang-tidy.
+        run: ./compile_commands-update.sh
+
+      - uses: actions/upload-artifact@v4
+        # Published so a failing finding can be reproduced locally against the
+        # exact same compile DB, and to inspect flag/toolchain drift.
+        with:
+          name: compile-commands-json
+          path: compile_commands.json
+          retention-days: 14
+          if-no-files-found: error
+
+      - uses: pre-commit/action@v3.0.1
+        with:
+          # Only the clang-tidy hook: every other hook already ran in the
+          # `pre-commit` job. `--hook-stage manual` is required while the hook
+          # is opt-in; it stays harmless once it becomes an automatic gate.
+          extra_args: clang-tidy --all-files --hook-stage manual
+
+      - uses: actions/cache/save@v5
+        if: always() && steps.cache_restore.outputs.cache-hit != 'true'
+        with:
+          path: "~/.cache/bazel"
+          key: clang-tidy-${{github.ref}}-${{github.sha}}
 
   test-gcc:
     needs: [trunk, pre-commit]
@@ -158,7 +215,7 @@ jobs:
       bazel_config: ${{ matrix.bazel_config }}
 
   done:
-    needs: [trunk, pre-commit, test-gcc, test-clang, test-bcr]
+    needs: [trunk, pre-commit, clang-tidy, test-gcc, test-clang, test-bcr]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -149,12 +149,44 @@ jobs:
         # exact same commands and to inspect flag/toolchain drift. A branch run
         # lints only what the branch changed, so its DB describes a near-empty
         # lint and is not worth storing.
+        id: upload_cdb
         if: github.ref == 'refs/heads/main'
         with:
           name: compile-commands-json
           path: compile_commands.json
           retention-days: 14
           if-no-files-found: error
+
+      - name: Summarize the compile DB
+        # Renders at the top of the run page, so the DB's shape and (on main) a
+        # direct link to it are visible without digging through step logs or
+        # scrolling to the artifacts panel.
+        run: |
+          set -euo pipefail
+          STATS="$(python3 -c '
+          import collections, json
+          entries = json.load(open("compile_commands.json"))
+          files = collections.Counter(e["file"] for e in entries)
+          print(len(entries), len(files), sum(n - 1 for n in files.values() if n > 1))
+          ')"
+          read -r ENTRIES UNIQUE DUPES <<<"${STATS}"
+          {
+            echo "### clang-tidy compile database"
+            echo
+            echo "| | |"
+            echo "|---|---|"
+            echo "| Entries | ${ENTRIES} |"
+            echo "| Unique files | ${UNIQUE} |"
+            echo "| Duplicate entries | ${DUPES} |"
+            echo "| Lint scope | \`${CLANG_TIDY_SCOPE}\` |"
+            if [ -n "${CDB_ARTIFACT_URL}" ]; then
+              echo "| Artifact | [compile-commands-json](${CDB_ARTIFACT_URL}) |"
+            else
+              echo "| Artifact | not uploaded (branch run; only \`main\` publishes one) |"
+            fi
+          } >>"${GITHUB_STEP_SUMMARY}"
+        env:
+          CDB_ARTIFACT_URL: ${{steps.upload_cdb.outputs.artifact-url}}
 
       - uses: pre-commit/action@v3.0.1
         # TODO(helly25): drop this once the finding sweep lands, which is what

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,10 +66,9 @@ jobs:
   clang-tidy:
     needs: [trunk, pre-commit]
     runs-on: ubuntu-latest
-    # TODO(helly25): drop this once the clang-tidy finding sweep lands.
-    # `.clang-tidy` sets `WarningsAsErrors: '*'` and the tree is not clean yet,
-    # so for now the job must report without blocking.
-    continue-on-error: true
+    # Note there is deliberately no job-level `continue-on-error`: building the
+    # compile DB must gate, so a broken extractor/toolchain fails this job. Only
+    # the findings themselves are tolerated, at the step below.
     steps:
       - uses: actions/checkout@v6
       - uses: bazelbuild/setup-bazelisk@v3
@@ -104,6 +103,12 @@ jobs:
           if-no-files-found: error
 
       - uses: pre-commit/action@v3.0.1
+        # TODO(helly25): drop this once the finding sweep lands, which is what
+        # turns this job into a real gate. `.clang-tidy` sets
+        # `WarningsAsErrors: '*'` and the tree is not clean yet, so findings are
+        # reported here rather than enforced. Scoped to this step so that a
+        # failure to produce the compile DB above still fails the job.
+        continue-on-error: true
         with:
           # Only the clang-tidy hook: every other hook already ran in the
           # `pre-commit` job. `--hook-stage manual` is required while the hook

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,6 +86,32 @@ jobs:
             clang-tidy-refs/heads/main
             clang-tidy
 
+      - name: Build generated sources and headers
+        # Generated headers must exist on disk before the compile DB is
+        # extracted, or the extractor cannot resolve the sources that include
+        # them (`hash_mangle_seed_gen.h is missing`) and those translation units
+        # land in the DB degraded - which would later read as clang-tidy
+        # findings rather than as the build artifact gap it really is.
+        # Generated headers are the only build output a translation unit needs to
+        # parse, so this builds just those rather than all of `//...`; the query
+        # keeps it correct as generated files are added.
+        run: |
+          set -euo pipefail
+          # Read into an array without `mapfile`, so this snippet can also be run
+          # as-is on stock macOS bash 3.2 when reproducing a CI result locally.
+          GENERATED=()
+          while IFS= read -r target; do
+            GENERATED+=("${target}")
+          done < <(bazel query 'kind("generated file", //...:*)' |
+            grep -E '\.(h|hh|hpp|inc|ipp|cc|cpp|cxx)$')
+          if [ "${#GENERATED[@]}" -eq 0 ]; then
+            echo "::error::No generated sources/headers found. Either the query or the extension filter needs updating; without this the compile DB silently degrades."
+            exit 1
+          fi
+          printf 'Building %s generated file(s):\n' "${#GENERATED[@]}"
+          printf '  %s\n' "${GENERATED[@]}"
+          bazel build --config=clang "${GENERATED[@]}"
+
       - name: Generate compile_commands.json
         # The compile DB is a local artifact (gitignored), so it has to be built
         # here. The script fetches the hermetic LLVM toolchain if needed and

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,10 +71,34 @@ jobs:
     # the findings themselves are tolerated, at the step below.
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Full history so the branch can be diffed against `main` to pick the
+          # changed sources below.
+          fetch-depth: 0
       - uses: bazelbuild/setup-bazelisk@v3
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
+
+      - name: Select the scope to lint
+        # clang-tidy costs ~50s per translation unit here, so linting all 81
+        # sources takes ~24 minutes even though pre-commit already spreads them
+        # over every core. On a branch, lint only what the branch changed; `main`
+        # still gets the whole tree after merge.
+        # Known gap: editing only a header changes findings in the sources that
+        # include it, and none of those are in the branch's changed-file set. The
+        # post-merge run on `main` is what catches that.
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_REF}" = "refs/heads/main" ]; then
+            echo "CLANG_TIDY_SCOPE=--all-files" >>"${GITHUB_ENV}"
+            echo "Linting the whole tree (on main)."
+          else
+            git fetch --no-tags --quiet origin main
+            echo "CLANG_TIDY_SCOPE=--from-ref origin/main --to-ref HEAD" >>"${GITHUB_ENV}"
+            echo "Linting sources changed against origin/main:"
+            git diff --name-only origin/main...HEAD -- '*.cc' '*.cpp' '*.cxx' | sed 's/^/  /'
+          fi
 
       - uses: actions/cache/restore@v5
         id: cache_restore
@@ -139,7 +163,9 @@ jobs:
           # Only the clang-tidy hook: every other hook already ran in the
           # `pre-commit` job. `--hook-stage manual` is required while the hook
           # is opt-in; it stays harmless once it becomes an automatic gate.
-          extra_args: clang-tidy --all-files --hook-stage manual
+          # Scope comes from the step above: changed sources on a branch, the
+          # whole tree on main.
+          extra_args: clang-tidy --hook-stage manual ${{env.CLANG_TIDY_SCOPE}}
 
       - uses: actions/cache/save@v5
         if: always() && steps.cache_restore.outputs.cache-hit != 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,8 +144,12 @@ jobs:
         run: ./compile_commands-update.sh
 
       - uses: actions/upload-artifact@v4
-        # Published so a failing finding can be reproduced locally against the
-        # exact same compile DB, and to inspect flag/toolchain drift.
+        # Only from `main`, which is the run that lints the whole tree: that DB
+        # is the one worth keeping, to reproduce a finding locally against the
+        # exact same commands and to inspect flag/toolchain drift. A branch run
+        # lints only what the branch changed, so its DB describes a near-empty
+        # lint and is not worth storing.
+        if: github.ref == 'refs/heads/main'
         with:
           name: compile-commands-json
           path: compile_commands.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -128,6 +128,32 @@ repos:
         entry: python .pre-commit/check_done_gate.py
         files: ^\.github/workflows/main\.yml$
         pass_filenames: false
+      - id: clang-tidy
+        name: clang-tidy (opt-in; gated by the CI clang-tidy job)
+        description: |
+          Runs clang-tidy over the given C++ sources via tools/clang_tidy.sh, a report-only
+          pass (no --fix, so it never rewrites the tree). It needs a compile_commands.json
+          (a gitignored local artifact; build it with ./compile_commands-update.sh) and a
+          clang-tidy >= 18 for this C++23 codebase.
+          * clang-tidy used to run under trunk, pinned at 16; that version mis-parses C++23
+            and trunk auto-applied its build-breaking fixes. Do not re-add it to trunk.
+          * Run it explicitly: `pre-commit run clang-tidy --all-files --hook-stage manual`.
+          * In CI the dedicated `clang-tidy` job owns this: it builds the compile DB, uploads
+            it as an artifact, and runs this hook. The main `pre-commit` job skips it.
+          * `stages: [manual]` keeps it OFF the automatic commit gate for now, because
+            `WarningsAsErrors: '*'` plus a tree that is not yet clean would block nearly every
+            commit. Promoting it to an automatic gate means: re-tune `.clang-tidy` (the
+            new-in-22 checks are very noisy here - cppcoreguidelines-pro-bounds-avoid-unchecked
+            -container-access alone accounts for the bulk of the findings), then sweep the
+            residual findings across mbo/, then drop `stages` here AND drop the
+            `continue-on-error` from the CI job. When it becomes automatic, tools/clang_tidy.sh
+            should also stop skipping and start failing on a missing/stale compile DB.
+          * To run `pre-commit` without this hook, run `SKIP="clang-tidy" pre-commit`.
+        language: script
+        entry: tools/clang_tidy.sh
+        types_or: [c++]
+        files: \.(cc|cpp|cxx)$
+        stages: [manual]
       - id: trunk-fmt
         name: trunk fmt
         description: |

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -48,25 +48,15 @@ lint:
       version_command:
         parse_regex: ${semver}
         run: buildifier --version
-    # clang-tidy is fundamentally useless without a compile_commands.json. Local
-    # devs generate it via `bazel run @hedron_compile_commands//:refresh_all`;
-    # CI does not. Override the plugin's `run_when` to skip CI so trunk's CI
-    # job doesn't bomb on "<header> file not found".
-    - name: clang-tidy
-      commands:
-        - name: lint
-          output: llvm
-          run: clang-tidy --export-fixes=${tmpfile} ${target} -p ${compile_commands_dir}
-          success_codes: [0, 1]
-          cache_results: true
-          run_from: ${compile_command}
-          read_output_from: tmp_file
-          run_when: [cli, monitor]
-          max_concurrency: 4
+  # clang-tidy is deliberately NOT a trunk linter: trunk pins clang-tidy 16, which
+  # mis-parses this C++23 codebase, and its `--export-fixes` runs then rewrote the
+  # working tree with build-breaking "fixes". trunk.io 403s any modern clang-tidy
+  # download, so a version bump here is not possible. It now lives in the local-only
+  # `clang-tidy` pre-commit hook (tools/clang_tidy.sh, hermetic clang >= 18); CI's
+  # hard gate stays the bazel -Werror matrix. Do not re-add it here.
   enabled:
     - buildifier@8.5.1
     - checkov@3.3.6
-    - clang-tidy@16.0.3
     - git-diff-check
     - markdownlint@0.49.0
     - prettier@3.9.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Added `--cwd` param to `mbo/digest` tool.
 - Added `mbo_log::ScopedStream*` helpers.
 - Added macro `MBO_LOG_CHECK`: A local optimized check implementation, it only processes the log stream if its `check` is false.
+- Moved `clang-tidy` from `trunk` to the opt-in `clang-tidy` pre-commit hook (`tools/clang_tidy.sh`).
+- Fixed `.clang-tidy`: `WarningsAsErrors` never escalated findings, and a misspelled option key was dead.
+- Disabled `llvm-header-guard` and `llvm-prefer-static-over-anonymous-namespace`, which contradict `STYLE_CPP.md`.
+- Fixed `compile_commands-update.sh` to record the hermetic clang, so clangd and clang-tidy parse what `--config=clang` builds.
+- Dropped 196 duplicate exec-configuration compile commands via the extractor's new `--bcce-prefer-target-config`.
 
 # 0.13.2
 

--- a/STYLE_CPP.md
+++ b/STYLE_CPP.md
@@ -11,11 +11,15 @@ an AI assistant) can follow them without reverse-engineering the tooling.
   best-effort basis.
 - **`clang-format`** with [`.clang-format`](.clang-format) formats all C++ code. Run
   it; do not hand-format against it. CI rejects any reformatting diff.
-- **`clang-tidy`** with [`.clang-tidy`](.clang-tidy) (`WarningsAsErrors: true`) runs **locally**
-  via `trunk` (a `trunk check` and the editor daemon) against a `compile_commands.json` you
-  generate with `bazel run @hedron_compile_commands//:refresh_all`. **CI does not run it** (no
-  compile DB there), so CI's hard gate is the compiler `-Werror` in the bazel matrix; still treat
-  a clang-tidy finding as a must-fix before pushing. The enabled set is broad: `abseil-*`,
+- **`clang-tidy`** with [`.clang-tidy`](.clang-tidy) (`WarningsAsErrors: '*'`) runs **locally**
+  via the opt-in `clang-tidy` pre-commit hook (`pre-commit run clang-tidy --all-files`, which
+  shells out to [`tools/clang_tidy.sh`](tools/clang_tidy.sh)) against a `compile_commands.json`
+  you generate with [`./compile_commands-update.sh`](compile_commands-update.sh). It is
+  report-only (never `--fix`) and needs a hermetic clang-tidy >= 18; it skips cleanly without
+  either, and it is **not** run by `trunk` - trunk pins clang-tidy 16, which mis-parses this
+  C++23 code and whose auto-applied fixes broke the build. **CI does not run it** (no compile DB
+  there), so CI's hard gate is the compiler `-Werror` in the bazel matrix; still treat a
+  clang-tidy finding as a must-fix before pushing. The enabled set is broad: `abseil-*`,
   `bugprone-*`, `cppcoreguidelines-*`, `google-*`, `misc-*`, `modernize-*`, `performance-*`,
   `portability-*`, `readability-*`.
 

--- a/bazelmod/dev.MODULE.bazel
+++ b/bazelmod/dev.MODULE.bazel
@@ -18,7 +18,7 @@
 bazel_dep(name = "hedron_compile_commands", dev_dependency = True, repo_name = "bazel_compile_commands_extractor")
 git_override(
     module_name = "hedron_compile_commands",
-    commit = "75ba4c31d3b74fa5fb57c7508220571d4e52f828",
+    commit = "6eb3ff1de6445355552ef4230be0caf3e1dd27e5",
     remote = "https://github.com/helly25/bazel-compile-commands-extractor.git",
 )
 

--- a/compile_commands-update.sh
+++ b/compile_commands-update.sh
@@ -15,6 +15,72 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
+# Generate `compile_commands.json` describing the HERMETIC clang, so that clangd
+# and `tools/clang_tidy.sh` parse with the same compiler the `--config=clang`
+# builds use. Note that `--config=clang` cannot do this: it only configures the
+# build of the extractor tool itself, and never reaches the `aquery` the tool
+# runs internally, so the recorded commands still named the autodetected local
+# (Apple) clang. The fork's runtime flags below are the supported override; they
+# must follow `--`, or `bazel run` hands them to bazel rather than to the tool.
 
-bazel run @bazel_compile_commands_extractor//:refresh_all --config=clang && echo "OK" || echo "FAIL"
+set -euo pipefail
+
+function die() {
+  echo "ERROR: ${*}" 1>&2
+  exit 1
+}
+
+OUTPUT_BASE="$(bazel info output_base 2>/dev/null || true)"
+[ -n "${OUTPUT_BASE}" ] || die "'bazel info output_base' failed; is bazel on PATH?"
+
+# The hermetic LLVM install (headers + libs) lives in the `_llvm_llvm` repo; the
+# plain `_llvm` repo only re-exports clang-format/clang-tidy/clangd.
+declare -a CLANG_LOCS=(
+  "${OUTPUT_BASE}/external/toolchains_llvm++llvm+llvm_toolchain_llvm_llvm/bin/clang++"
+  "${OUTPUT_BASE}/external/toolchains_llvm~~llvm~llvm_toolchain_llvm_llvm/bin/clang++"
+  "${OUTPUT_BASE}/external/llvm_toolchain_llvm/bin/clang++"
+)
+
+CLANG=""
+function resolve_clang() {
+  for LOC in "${CLANG_LOCS[@]}"; do
+    if [ -x "${LOC}" ]; then
+      CLANG="${LOC}"
+      return
+    fi
+  done
+}
+
+resolve_clang
+if [ -z "${CLANG}" ]; then
+  # A fresh checkout (or CI runner) has not materialized the toolchain yet: it is
+  # only fetched once something is actually built with `--config=clang`. Build the
+  # smallest cc target there is to trigger that, then look again.
+  echo "Hermetic clang++ not present; fetching the toolchain via a probe build ..." 1>&2
+  bazel build --config=clang //tools:show_compiler >/dev/null \
+    || die "probe build '//tools:show_compiler --config=clang' failed; cannot fetch the LLVM toolchain"
+  resolve_clang
+fi
+
+[ -n "${CLANG}" ] || die "Cannot find the hermetic clang++ even after a '--config=clang' build"
+
+# Sources reachable both normally and through a build-machine tool are compiled
+# twice (target + exec configuration), and both commands would be emitted. Keep
+# only the target-configuration one: clang-tidy works per entry, so the exec copy
+# is duplicate linting for a near-identical result. Files compiled ONLY in the
+# exec configuration keep their command, so nothing leaves the compile DB.
+declare -a BCCE_ARGS=("--bcce-compiler=${CLANG}" "--bcce-prefer-target-config")
+
+# The hermetic clang carries its own libc++ but no system C headers: without the
+# SDK sysroot its <locale> support headers fail on `'time.h' file not found`.
+# The bazel `--config=clang` toolchain supplies this itself; the extracted
+# commands come from the autodetected toolchain, which relies on Apple clang's
+# built-in default, so it has to be made explicit here. Linux needs no such flag.
+if [ "$(uname -s)" = "Darwin" ]; then
+  SDKROOT_PATH="$(xcrun --show-sdk-path 2>/dev/null || true)"
+  [ -n "${SDKROOT_PATH}" ] || die "'xcrun --show-sdk-path' failed; install the Xcode command line tools"
+  BCCE_ARGS+=("--bcce-copt=-isysroot${SDKROOT_PATH}")
+fi
+
+bazel run @bazel_compile_commands_extractor//:refresh_all -- "${BCCE_ARGS[@]}"
+echo "OK"

--- a/tools/clang_tidy.sh
+++ b/tools/clang_tidy.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Run clang-tidy over the given C++ source files (a report-only pass: no --fix,
+# so it never rewrites the tree). clang-tidy is a LOCAL-ONLY developer aid, not a
+# CI gate: it needs a compile_commands.json (a local artifact, generated with
+# `./compile_commands-update.sh`) and a clang-tidy new enough for this C++23
+# codebase. When either is missing - a fresh checkout, or a CI runner without the
+# compile DB - this SKIPS cleanly (exit 0) rather than failing, so it never blocks
+# a commit or forces the hermetic toolchain download in CI. CI's hard gate stays
+# the compiler -Werror in the bazel matrix.
+#
+# clang-tidy resolution prefers the hermetic toolchains_llvm binary (so it matches
+# the compile DB's clang flags and understands C++23), then a versioned system
+# clang-tidy on PATH. A resolved clang-tidy older than the minimum below is treated
+# as "not installed" and skipped - clang-tidy 16/17 mis-parse this codebase's C++23
+# and emit false positives whose fixes break the build. That is not hypothetical:
+# trunk pinned clang-tidy 16 and its `--export-fixes` runs rewrote the working tree
+# with build-breaking "fixes", which is why clang-tidy moved here out of trunk.
+# Note that a plain `clang-tidy` on PATH may well BE trunk's 16 (.trunk/tools), so
+# the version gate below is what keeps it from being picked up. Mirrors the binary
+# resolution ladder in tools/clang_format.sh.
+
+set -euo pipefail
+
+# The minimum clang-tidy major version. Below this, C++23 parsing is unreliable.
+readonly MIN_MAJOR=18
+
+function skip() {
+  echo "clang-tidy: skipped (${*}). It is a local-only aid; CI relies on the bazel -Werror gate." 1>&2
+  exit 0
+}
+
+# A compile DB is mandatory; without it clang-tidy cannot resolve include paths.
+[ -f "compile_commands.json" ] \
+  || skip "no compile_commands.json; generate it with './compile_commands-update.sh'"
+
+# The `bazel-<repo>` convenience link points at the execroot; fall back to cwd.
+BAZEL_OUTPUT="bazel-$(basename "${PWD}")"
+[ -d "${BAZEL_OUTPUT}" ] || BAZEL_OUTPUT="."
+
+# The output base holds every fetched repo, including the `--config=clang`
+# dev-dependency LLVM toolchain that the execroot symlink forest may omit.
+OUTPUT_BASE="$(bazel info output_base 2>/dev/null || true)"
+
+declare -a CLANG_TIDY_LOCS=(
+  # 1) Hermetic toolchain via the `bazel-<repo>` execroot link.
+  # 1.1) Bazel workspaces
+  "${BAZEL_OUTPUT}/external/llvm_toolchain_llvm/bin/clang-tidy"
+  "${BAZEL_OUTPUT}/external/llvm_toolchain/bin/clang-tidy"
+  # 1.2) Bazel modules < 8
+  "${BAZEL_OUTPUT}/external/toolchains_llvm~~llvm~llvm_toolchain_llvm/bin/clang-tidy"
+  "${BAZEL_OUTPUT}/external/toolchains_llvm~~llvm~llvm_toolchain_llvm_llvm/bin/clang-tidy"
+  # 1.3) Bazel modules >= 8
+  "${BAZEL_OUTPUT}/external/toolchains_llvm++llvm+llvm_toolchain_llvm/bin/clang-tidy"
+  "${BAZEL_OUTPUT}/external/toolchains_llvm++llvm+llvm_toolchain_llvm_llvm/bin/clang-tidy"
+
+  # 2) Same hermetic toolchain via the output base (covers the dev-dependency
+  #    case where it is absent from the execroot symlink forest). Still hermetic,
+  #    so this is tried BEFORE any system clang-tidy below.
+  "${OUTPUT_BASE:+${OUTPUT_BASE}/external/toolchains_llvm++llvm+llvm_toolchain_llvm/bin/clang-tidy}"
+  "${OUTPUT_BASE:+${OUTPUT_BASE}/external/toolchains_llvm++llvm+llvm_toolchain_llvm_llvm/bin/clang-tidy}"
+
+  # 3) System clang-tidy by versioned name (its version may differ from the
+  #    hermetic toolchain, so it is a last resort). Nothing below MIN_MAJOR is
+  #    listed - such a binary would be rejected by the version gate anyway.
+  "$(which "clang-tidy-23" 2>/dev/null || true)"
+  "$(which "clang-tidy-22" 2>/dev/null || true)"
+  "$(which "clang-tidy-21" 2>/dev/null || true)"
+  "$(which "clang-tidy-20" 2>/dev/null || true)"
+  "$(which "clang-tidy-19" 2>/dev/null || true)"
+  "$(which "clang-tidy-18" 2>/dev/null || true)"
+
+  # 4) LLVM_PATH or a plain clang-tidy on PATH.
+  "${LLVM_PATH:-/usr}/bin/clang-tidy"
+  "$(which clang-tidy 2>/dev/null || true)"
+)
+
+CLANG_TIDY=""
+for LOC in "${CLANG_TIDY_LOCS[@]}"; do
+  if [ -n "${LOC}" ] && [ -x "${LOC}" ]; then
+    # Gate on the major version: "LLVM version 22.1.8" -> 22. Skip anything older
+    # than MIN_MAJOR (an unparseable version is treated as too old / unusable).
+    major="$("${LOC}" --version 2>/dev/null | grep -oE 'version [0-9]+' | grep -oE '[0-9]+' | head -1 || true)"
+    if [ -n "${major}" ] && [ "${major}" -ge "${MIN_MAJOR}" ]; then
+      CLANG_TIDY="${LOC}"
+      break
+    fi
+  fi
+done
+
+[ -n "${CLANG_TIDY}" ] \
+  || skip "no clang-tidy >= ${MIN_MAJOR} found; build once with --config=clang to fetch the hermetic toolchain, or install a recent clang-tidy"
+
+# Nothing to check (pre-commit may invoke with no matching files).
+[ "${#}" -gt 0 ] || exit 0
+
+# Report only: --header-filter restricts diagnostics to this repo's own headers
+# (not the toolchain's force-included / system headers), -p points at the compile
+# DB. WarningsAsErrors in .clang-tidy makes any finding a non-zero exit.
+exec "${CLANG_TIDY}" --header-filter='(^|/)mbo/' -p . "${@}"


### PR DESCRIPTION
Adopts helly25/xff#386 here, plus two compile-DB fixes found while verifying it.

## clang-tidy out of trunk

trunk pinned clang-tidy **16**, which mis-parses this C++23 codebase, and its `--export-fixes` runs rewrote the working tree with build-breaking "fixes". trunk.io 403s any modern clang-tidy download, so a version bump there is not possible. Confirmed here: `which clang-tidy` resolves to `.trunk/tools/clang-tidy` = LLVM 16.0.3, while the hermetic toolchain is 22.1.8.

- Drop clang-tidy from `.trunk/trunk.yaml`.
- Add `tools/clang_tidy.sh`: resolves the hermetic clang-tidy (mirroring `clang_format.sh`'s ladder), gates on **>= 18**, and reports only — never `--fix`. The version gate is load-bearing: a plain `clang-tidy` on `PATH` may well *be* trunk's 16, and it is rejected (verified).
- Add an opt-in `clang-tidy` pre-commit hook, plus a CI job that builds the compile DB, uploads it as an artifact, and runs just that hook. The main `pre-commit` job skips it.

## `.clang-tidy` latent bugs

- `WarningsAsErrors: true` — a check-name glob, not a bool, so it matched nothing and findings never escalated. Now `'*'`.
- `bugprone-signed-char-misuse.CharTypdefsToIgnore` — misspelled (missing `e`), so the option was dead. Surfaced by `--verify-config`.
- `llvm-header-guard` and `llvm-prefer-static-over-anonymous-namespace` disabled: they contradict `STYLE_CPP.md`. The former, with no header root, suggests `USERS_MARCUS_DOCUMENTS_..._SCOPED_STREAM_H` for every header.

## `compile_commands-update.sh` was generating the wrong compile DB

`bazel run @…//:refresh_all --config=clang` does nothing useful: that flag only configures the build *of the extractor tool*, and never reaches the `aquery` it runs internally. Every recorded command therefore named the autodetected Apple clang, while clangd and clang-tidy used the hermetic one — which is why clang-tidy died on `'concepts' file not found`.

- Pass `--bcce-compiler=<hermetic clang++>` explicitly (after `--`, or `bazel run` eats it).
- On Darwin add `--bcce-copt=-isysroot$(xcrun --show-sdk-path)`: the hermetic clang ships libc++ but no system C headers, so `<locale>` failed on `time.h`.
- Adopt `--bcce-prefer-target-config` (helly25/bazel-compile-commands-extractor#29), dropping **196** duplicate exec-configuration entries — 2223 -> 2027 entries over an unchanged set of 2027 files. Needs the extractor pin bump to `6eb3ff1`.

This fixes clangd too, which had the same mismatch.

## Test

- `pre-commit run -a` green.
- clang-tidy 22 now runs with **zero** hard errors against the regenerated DB.
- Verified against the real pin (no `--override_module`): `dropped 196 duplicate source entries`. Exec-only files (`mbo/mope/ini.h`, `mbo/diff/internal/update_absl_log_flags.h`) are retained; `status_builder.cc` went 2 entries -> 1.
- Both hook skip paths exit 0 (no compile DB; only trunk's clang-tidy 16 on `PATH`), and the hook does not run at the default commit stage.

## Deliberately not a gate yet

The CI job is `continue-on-error: true` and the hook is `stages: [manual]`. `WarningsAsErrors: '*'` against a tree that is not yet clean would block nearly every commit — one sampled file alone yields ~500 findings, ~80% from `cppcoreguidelines-pro-bounds-avoid-unchecked-container-access`, which flags every `operator[]`.

Promoting it to a real gate: re-tune `.clang-tidy` for the noisy new-in-22 checks, sweep the residual findings, then drop both `stages: [manual]` and `continue-on-error`. Recorded in the hook description.

Note the whole recipe is verified on macOS; the ubuntu runner path gets its first exercise from this PR's CI, which reports rather than blocks.