### PR TITLE
Disable the CppCoreGuidelines bounds / type-safety profile

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,19 @@
 ---
+# The CppCoreGuidelines bounds / type-safety profile is off. Those checks assume
+# code sits above a safe container abstraction, but this library IS that layer:
+# they fire on the deliberate design of the containers and hashes, not on defects
+# (961 of 1600 findings, 60% of everything the linter reports here; measured
+# across all 81 sources, counting each distinct diagnostic once).
+#   * pro-bounds-avoid-unchecked-container-access - flags every `operator[]`,
+#     including inside the containers implementing it.
+#   * pro-type-union-access - the `limited_ordered` union is how LimitedSet/
+#     LimitedMap avoid default-constructing their elements.
+#   * pro-bounds-constant-array-index, pro-bounds-pointer-arithmetic,
+#     pro-bounds-array-to-pointer-decay and its alias hicpp-no-array-decay -
+#     raw-buffer indexing and pointer walking are the point of the hash code.
+# Bounds safety here is a matter for tests, sanitizers (--config=asan) and review.
+# Re-enabling any of them means auditing its findings, not just flipping the flag.
+#
 # abseil-unchecked-statusor-access is off because clang-tidy 22.1.8 SEGFAULTS in
 # it: its dataflow analysis (runTypeErasedDataflowAnalysis) crashes on
 # mbo/strings/strip.cc, reproducibly on both macOS and Linux. Re-test on a future
@@ -27,9 +42,15 @@ Checks: >
   -clang-diagnostic-unused-command-line-argument,
   cppcoreguidelines-*,
   -cppcoreguidelines-avoid-const-or-ref-data-members,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -cppcoreguidelines-pro-bounds-avoid-unchecked-container-access,
+  -cppcoreguidelines-pro-bounds-constant-array-index,
+  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  -cppcoreguidelines-pro-type-union-access,
   -fuchsia*,
   google-*,
   -google-build-using-namespace,
+  -hicpp-no-array-decay,
   -hicpp-no-assembler,
   -llvm-else-after-return,
   -llvm-header-guard,


### PR DESCRIPTION
First of the clang-tidy triage PRs. No C++ changes: `.clang-tidy` only.

## Why

Now that #270 made clang-tidy actually run, the baseline is measurable: **1600 distinct findings across 81 sources**. 60% of them come from one coherent group — the CppCoreGuidelines bounds / type-safety profile.

Those checks assume the code sits *above* a safe container abstraction. This library **is** that layer, so they fire on deliberate design rather than on defects:

- `pro-bounds-avoid-unchecked-container-access` — flags every `operator[]`, including inside the containers implementing it (687 findings, 51 files).
- `pro-type-union-access` — the `limited_ordered` union is how `LimitedSet`/`LimitedMap` avoid default-constructing their elements (99 findings, almost all in `limited_ordered.h`).
- `pro-bounds-constant-array-index`, `pro-bounds-pointer-arithmetic`, `pro-bounds-array-to-pointer-decay` and its alias `hicpp-no-array-decay` — raw-buffer indexing and pointer walking are the point of the hash code (175 findings).

Fixing these would mean rewriting deliberate low-level design, or scattering NOLINTs across it. Bounds safety here is covered by tests, sanitizers (`--config=asan`) and review.

## Effect

Measured by sweeping all 81 sources before and after, counting each distinct diagnostic once (the raw log double-counts: a header diagnostic is re-reported by every TU including it):

| | before | after |
|---|---|---|
| distinct findings | 1600 | **639** |
| distinct checks firing | 71 | 65 |
| files with findings | 124 | 104 |
| crashes | 0 | 0 |

All six disabled checks now report zero, and `clang-tidy --verify-config` is clean, so none of the names is a typo silently doing nothing.

The remaining 639 are the genuine ones, and they are what the follow-up PRs fix. The largest are `misc-include-cleaner` (69), `misc-const-correctness` (63), `readability-identifier-length` (39), `readability-function-cognitive-complexity` (37) and `readability-redundant-typename` (33); several are concentrated enough to fix in one go (`google-build-explicit-make-pair` is 32 findings in a single file).

## Note

Re-enabling any of these means auditing its findings, not just flipping the flag — the comment in `.clang-tidy` says so, and it is tracked as separate follow-up work.