### PR TITLE
Clear the three most concentrated clang-tidy checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -84,6 +84,10 @@ CheckOptions:
     value:           'NULL'
   - key:             performance-unnecessary-value-param.AllowedTypes
     value:           'absl::Status;absl::StatusOr;std::string_view'
+  - key:             readability-implicit-bool-conversion.AllowIntegerConditions
+    value:           '1'
+  - key:             readability-implicit-bool-conversion.AllowPointerConditions
+    value:           '1'
   - key:             readability-function-cognitive-complexity.Threshold
     value:           '25'
   - key:             readability-braces-around-statements.ShortStatementLines

--- a/mbo/container/any_scan.h
+++ b/mbo/container/any_scan.h
@@ -353,7 +353,7 @@ class AnyScanImpl {
   // For MakAnyScan / MakeConstScan
   template<AcceptableContainer Container>
   requires(kAccessByRef)
-  explicit AnyScanImpl(MakeAnyScanData<Container, kScanMode> data)
+  explicit AnyScanImpl(const MakeAnyScanData<Container, kScanMode>& data)
       : funcs_{
             .iter =
                 [data = data] {
@@ -374,7 +374,7 @@ class AnyScanImpl {
       !kAccessByRef  // This is the ConvertingScan constructor
       && types::ConstructibleFrom<AccessType, ::mbo::types::ContainerConstIteratorValueType<Container>>
       && types::ConstructibleFrom<value_type, AccessType>)
-  explicit AnyScanImpl(MakeAnyScanData<Container, kScanMode> data)
+  explicit AnyScanImpl(const MakeAnyScanData<Container, kScanMode>& data)
       : funcs_{
             // NOTE: data must be copied here!
             .iter =

--- a/mbo/hash/hash_differential_test.cc
+++ b/mbo/hash/hash_differential_test.cc
@@ -31,7 +31,11 @@
 namespace mbo::hash {
 namespace {
 
-// NOLINTBEGIN(*-magic-numbers)
+// readability-implicit-bool-conversion is suppressed rather than "fixed": inside
+// the reference macros (XXH64 / XXH3_*) it misattributes a conversion to the gtest
+// `<<` message chain, pointing at string literals like "len: " and proposing they
+// be replaced with `true`. Nothing here converts anything to bool.
+// NOLINTBEGIN(*-magic-numbers,readability-implicit-bool-conversion)
 
 TEST(DifferentialTest, Xxh64MatchesReference) {
   std::mt19937_64 rng(0xD1FF64U);  // NOLINT(cert-msc51-cpp,cert-msc32-c,bugprone-random-generator-seed): reproducible
@@ -89,7 +93,7 @@ TEST(DifferentialTest, Xxh3Hash128MatchesReference) {
   }
 }
 
-// NOLINTEND(*-magic-numbers)
+// NOLINTEND(*-magic-numbers,readability-implicit-bool-conversion)
 
 }  // namespace
 }  // namespace mbo::hash

--- a/mbo/strings/numbers.h
+++ b/mbo/strings/numbers.h
@@ -51,7 +51,7 @@ unsigned BigNumberLen(T v) {
   // We first check whether we can do even better by limiting us to 4 byte types.
   // We use a macro to let the compiler compute the actual length values.
   if constexpr (sizeof(v) <= 4) {
-#define CHECK_CAP(cap) std::make_pair<uint32_t, unsigned>(cap, std::string_view(#cap).size() - 3)
+#define CHECK_CAP(cap) std::pair<uint32_t, unsigned>(cap, std::string_view(#cap).size() - 3)
     constexpr auto kData = mbo::container::ToLimitedMap<std::pair<uint32_t, unsigned>>({
         CHECK_CAP(4'294'967'295ULL),
         CHECK_CAP(999'999'999ULL),
@@ -68,7 +68,7 @@ unsigned BigNumberLen(T v) {
 #undef CHECK_CAP
     return kData.lower_bound(v)->second;
   } else {
-#define CHECK_CAP(cap) std::make_pair<uint64_t, unsigned>(cap, std::string_view(#cap).size() - 3)
+#define CHECK_CAP(cap) std::pair<uint64_t, unsigned>(cap, std::string_view(#cap).size() - 3)
     constexpr auto kData = mbo::container::ToLimitedMap<std::pair<uint64_t, unsigned>>({
         CHECK_CAP(18'446'744'073'709'551'615ULL),
         CHECK_CAP(9'999'999'999'999'999'999ULL),


### PR DESCRIPTION
Second of the clang-tidy triage PRs, independent of #271 (different files). Clears 80 of the 639 remaining findings.

Only one of the three turned out to be an actual defect. That is worth stating plainly, because "80 findings fixed" would otherwise overstate it.

## `google-build-explicit-make-pair` — 32 findings, a real defect

`mbo/strings/numbers.h` used `std::make_pair<uint32_t, unsigned>(...)`. Explicit template arguments pin the parameters to `uint32_t&&` / `unsigned&&`, defeating the deduction `make_pair` exists to provide. Now `std::pair` directly, as the diagnostic recommends.

## `performance-unnecessary-value-param` — 25 findings, marginal

All 25 are **one** source location in `mbo/container/any_scan.h`, re-reported per template instantiation.

The motivation is **not** copy cost, and I checked rather than assumed:

- `MakeAnyScanData` is 16 bytes — a single `shared_ptr`. A copy is one atomic increment.
- By-value and `const&` compile to an *identical* parameter: both `ptr` in the IR. The type is not register-transportable, because `shared_ptr` is not trivially copyable. (`[[clang::trivial_abi]]` does force `[2 x ptr]`, but clang simultaneously warns the attribute "cannot be applied" — an ABI hazard, so not an option.)
- The `const shared_ptr` member means even a "move" copies, verified: after `Data b{std::move(a)}` the source still holds its pointer and `use_count == 2`.

So by-value buys nothing here; `const&` drops one atomic pair per construction. Real but tiny — this is tidiness, not performance. Happy to drop this hunk if you would rather not churn the signature.

## `readability-implicit-bool-conversion` — 23 findings, not defects

- `diff_myers.cc` (2): `(d + lo) & 1` is an idiomatic parity test. Enabled `AllowIntegerConditions` / `AllowPointerConditions`, which is standard C++ style (`if (ptr)`, `if (n)`) and clears these legitimately.
- `hash_differential_test.cc` (21): a false positive. Inside the `XXH64` / `XXH3_*` reference macros the check misattributes a conversion to the gtest `<<` message chain — it points at the **string literal** `"len: "` and proposes replacing it with `true`. Suppressed with that rationale, extending the `NOLINT` region the file already uses.

## Test

- All three checks report zero findings on the affected files.
- `bazel test --config=clang //mbo/strings:all //mbo/container:any_scan_test //mbo/diff:all //mbo/hash:hash_differential_test` — 9/9 pass.
- `pre-commit run -a` green.