### PR TITLE
Disable misc-include-cleaner

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,6 +14,16 @@
 # Bounds safety here is a matter for tests, sanitizers (--config=asan) and review.
 # Re-enabling any of them means auditing its findings, not just flipping the flag.
 #
+# misc-include-cleaner is off. It demands a direct include for every symbol used,
+# which fights this codebase's umbrella headers: a test includes `stringify.h` and
+# uses the concepts that header exists to expose, and the check asks it to reach
+# past the public header into `internal/struct_names.h` instead - deepening the
+# coupling the umbrella header was written to avoid. That accounted for 69
+# findings across 30 files. The check is also reported to mishandle concepts
+# (uses inside `requires` clauses going unattributed); that is a known issue and
+# not something verified here, so the umbrella-header conflict is the operative
+# reason. If the include hygiene is ever wanted, IWYU proper is the better tool.
+#
 # abseil-unchecked-statusor-access is off because clang-tidy 22.1.8 SEGFAULTS in
 # it: its dataflow analysis (runTypeErasedDataflowAnalysis) crashes on
 # mbo/strings/strip.cc, reproducibly on both macOS and Linux. Re-test on a future
@@ -58,6 +68,7 @@ Checks: >
   -llvm-prefer-static-over-anonymous-namespace,
   -llvmlibc-*,
   misc-*,
+  -misc-include-cleaner,
   modernize-*,
   -modernize-use-nodiscard,
   -modernize-use-std-format,


### PR DESCRIPTION
Fourth clang-tidy triage PR. `.clang-tidy` only, clearing the largest remaining check: **69 findings across 30 files**.

## Why

The check demands a direct include for every symbol used, which fights this codebase's umbrella headers.

`mbo/types/stringify_test.cc` includes exactly one project header, `mbo/types/stringify.h`, and then uses the concepts that header exists to expose:

```cpp
using ::mbo::types::types_internal::kStructNameSupport;
using ::mbo::types::types_internal::SupportsFieldNames;
using ::mbo::types::types_internal::SupportsFieldNamesConstexpr;
```

The check asks it to include `mbo/types/internal/struct_names.h` directly instead. Satisfying that would have tests reaching past the public header into an internal one — deepening precisely the coupling the umbrella header was written to avoid. Same shape in `json_test.cc` (`mbo::types::ThreeWayComparableTo`, which lives in `traits.h`).

## On the concepts issue

The check is also reported to mishandle concepts, with uses inside `requires` clauses going unattributed. I have recorded that in `.clang-tidy` as a **known issue rather than something reproduced here** — every finding I inspected was a genuine "no direct include" report, including `traits_test.cc` being flagged for `std::same_as` when it really does not include `<concepts>`.

So the umbrella-header conflict is the operative reason, and the rationale in the config says so rather than overclaiming a tool bug. If include hygiene is wanted later, IWYU proper is the better tool for it.

## Test

- The check reports **zero** on previously affected files (`stringify.cc`, `json_test.cc`, `demangle.cc`).
- The other **26** `misc-*` checks stay enabled — this disables one check, not the group.
- `clang-tidy --verify-config` clean, so the name is not a typo silently doing nothing.
- `pre-commit run -a` green.