### PR TITLE
Apply the safe misc-const-correctness fixes

### DIFF
--- a/mbo/container/internal/limited_ordered.h
+++ b/mbo/container/internal/limited_ordered.h
@@ -627,7 +627,7 @@ class [[nodiscard]] LimitedOrdered {
   MBO_ALWAYS_INLINE constexpr std::size_t index_of(const Key& key) const
   requires(!kOptimizeIndexOf || (kOptimizeIndexOf && !kCustomIndexOfBeyondUnroll && Capacity > kUnrollMaxCapacity))
   {
-    const_iterator it = lower_bound(key);
+    const const_iterator it = lower_bound(key);
     return it == end() || key_comp_(key, GetKey(*it)) ? npos : it - begin();
   }
 
@@ -643,17 +643,17 @@ class [[nodiscard]] LimitedOrdered {
 
   MBO_FORCE_INLINE constexpr iterator find(const Key& key) {
     if constexpr (kOptimizeIndexOf) {
-      std::size_t pos = index_of(key);
+      const std::size_t pos = index_of(key);
       return pos == npos ? end() : iterator(&values_[pos]);
     } else {  // Not kOptimizeIndexOf
-      iterator it = lower_bound(key);
+      const iterator it = lower_bound(key);
       return it == end() || key_comp_(key, GetKey(*it)) ? end() : it;
     }
   }
 
   MBO_FORCE_INLINE constexpr const_iterator find(const Key& key) const {
     if constexpr (kOptimizeIndexOf) {
-      std::size_t pos = index_of(key);
+      const std::size_t pos = index_of(key);
       return pos == npos ? end() : const_iterator(&values_[pos]);
     } else {  // Not kOptimizeIndexOf
       const_iterator it = lower_bound(key);
@@ -755,8 +755,8 @@ class [[nodiscard]] LimitedOrdered {
         std::swap(values_[pos].data.second, other.values_[pos].data.second);
       }
     }
-    std::size_t other_size = other.size_;
-    std::size_t this_size = size_;
+    const std::size_t other_size = other.size_;
+    const std::size_t this_size = size_;
     for (; pos < size_; ++pos) {
       other.emplace(std::move(values_[pos].data));
     }
@@ -769,7 +769,7 @@ class [[nodiscard]] LimitedOrdered {
 
   template<typename... Args>
   constexpr std::pair<iterator, bool> emplace(Args&&... args) noexcept(!kRequireThrows) {
-    RawValue new_val(std::forward<Args>(args)...);
+    const RawValue new_val(std::forward<Args>(args)...);
     const iterator dst = lower_bound(GetKey(new_val));
     if (dst != end() && !key_comp_(GetKey(*dst), GetKey(new_val)) && !key_comp_(GetKey(new_val), GetKey(*dst))) {
       return std::make_pair(dst, false);

--- a/mbo/container/limited_set_benchmark.h
+++ b/mbo/container/limited_set_benchmark.h
@@ -103,8 +103,8 @@ class Benchmarks {
       }
       return test_data;
     }();
-    std::size_t test = 0;
-    std::size_t item = 0;
+    const std::size_t test = 0;
+    const std::size_t item = 0;
     int64_t item_count = 0;
     const auto* data = &test_data[0].data;
     const auto* input = &test_data[0].input;

--- a/mbo/container/limited_vector.h
+++ b/mbo/container/limited_vector.h
@@ -267,8 +267,8 @@ class LimitedVector final {
     for (; pos < size_ && pos < other.size(); ++pos) {
       std::swap(values_[pos].data, other.at(pos));
     }
-    std::size_t other_size = other.size_;
-    std::size_t this_size = size_;
+    const std::size_t other_size = other.size_;
+    const std::size_t this_size = size_;
     for (; pos < size_; ++pos) {
       other.emplace_back(std::move(values_[pos].data));
     }
@@ -519,7 +519,7 @@ LimitedVector(T&&... v) -> LimitedVector<std::common_type_t<T...>, sizeof...(T)>
 template<std::size_t LN, std::size_t RN, typename LHS, typename RHS>
 requires std::three_way_comparable_with<LHS, RHS>
 constexpr inline auto operator<=>(const LimitedVector<LHS, LN>& lhs, const LimitedVector<RHS, RN>& rhs) noexcept {
-  std::size_t minsize = std::min(LN, RN);
+  const std::size_t minsize = std::min(LN, RN);
   for (std::size_t index = 0; index < minsize; ++index) {
     const auto comp = lhs[index] <=> rhs[index];
     if (comp != 0) {
@@ -535,7 +535,7 @@ constexpr inline bool operator==(const LimitedVector<LHS, LN>& lhs, const Limite
   if (lhs.size() != rhs.size()) {
     return false;
   }
-  std::size_t minsize = std::min(LN, RN);
+  const std::size_t minsize = std::min(LN, RN);
   for (std::size_t index = 0; index < minsize; ++index) {
     const auto comp = lhs[index] <=> rhs[index];
     if (comp != 0) {
@@ -548,7 +548,7 @@ constexpr inline bool operator==(const LimitedVector<LHS, LN>& lhs, const Limite
 template<std::size_t LN, std::size_t RN, typename LHS, typename RHS>
 requires std::three_way_comparable_with<LHS, RHS>
 constexpr inline bool operator<(const LimitedVector<LHS, LN>& lhs, const LimitedVector<RHS, RN>& rhs) noexcept {
-  std::size_t minsize = std::min(LN, RN);
+  const std::size_t minsize = std::min(LN, RN);
   for (std::size_t index = 0; index < minsize; ++index) {
     const auto comp = lhs[index] <=> rhs[index];
     if (comp != 0) {

--- a/mbo/diff/internal/context.h
+++ b/mbo/diff/internal/context.h
@@ -53,7 +53,7 @@ class Context final {
   }
 
   std::string_view PopFront() noexcept {
-    std::string_view result = data_.front();
+    const std::string_view result = data_.front();
     data_.pop_front();
     return result;
   }

--- a/mbo/diff/internal/data.cc
+++ b/mbo/diff/internal/data.cc
@@ -82,7 +82,7 @@ std::vector<Data::LineCache> Data::SplitAndAdaptLastLine(
   const std::size_t count = std::count_if(text.begin(), text.end(), [](char chr) { return chr == '\n'; });
   std::vector<LineCache> result;
   result.reserve(count + 1);  // N newlines split into N + 1 lines.
-  for (std::string_view line : absl::StrSplit(text, '\n')) {
+  for (const std::string_view line : absl::StrSplit(text, '\n')) {
     result.push_back(Process(options, regex_replace, line, owned));
   }
   // A missing final newline normally makes the last line carry the `\ No newline at end of file`

--- a/mbo/diff/internal/update_absl_log_flags.cc
+++ b/mbo/diff/internal/update_absl_log_flags.cc
@@ -34,13 +34,13 @@ void UpdateAbslLogFlags() {
   // cannot be called to prevent duplicate initalization which triggers
   // `absl::log_internal::SetTimeZone() has already been called`.
   {
-    absl::CommandLineFlag* flag = absl::FindCommandLineFlag("minloglevel");
+    const absl::CommandLineFlag* flag = absl::FindCommandLineFlag("minloglevel");
     if (flag->CurrentValue() == flag->DefaultValue()) {
       absl::SetFlag(&FLAGS_minloglevel, 1);
     }
   }
   {
-    absl::CommandLineFlag* flag = absl::FindCommandLineFlag("stderrthreshold");
+    const absl::CommandLineFlag* flag = absl::FindCommandLineFlag("stderrthreshold");
     if (flag->CurrentValue() == flag->DefaultValue()) {
       absl::SetFlag(&FLAGS_stderrthreshold, 1);
     }

--- a/mbo/file/glob.cc
+++ b/mbo/file/glob.cc
@@ -149,7 +149,7 @@ MBO_ALWAYS_INLINE absl::StatusOr<GlobRangeInfo> GlobFindRange(std::string_view& 
         result.has_slash = true;
         continue;
       case '-': {
-        char last = re2_pattern.back();
+        const char last = re2_pattern.back();
         re2_pattern += chr;
         pattern.remove_prefix(1);
         if (pattern.front() == ']') {

--- a/mbo/file/glob.h
+++ b/mbo/file/glob.h
@@ -142,7 +142,7 @@ struct GlobEntry : mbo::types::Extend<GlobEntry> {
       return 0;
     }
     std::error_code error;
-    std::size_t result = entry.file_size(error);
+    const std::size_t result = entry.file_size(error);
     return error ? 0 : result;
   }
 };

--- a/mbo/file/glob_test.cc
+++ b/mbo/file/glob_test.cc
@@ -300,7 +300,7 @@ absl::StatusOr<std::filesystem::path> CreateFileSystemEntries(
       return absl::AbortedError(absl::StrCat("Cannot create dir: ", path));
     }
     if (!file.empty()) {
-      std::ofstream output(*root / path / file, std::ios::binary);
+      const std::ofstream output(*root / path / file, std::ios::binary);
     }
   }
   return *root;

--- a/mbo/json/json.h
+++ b/mbo/json/json.h
@@ -388,7 +388,7 @@ class Json {
       std::ostream& os,
       SerializeMode mode = SerializeMode::kCompact,
       const types::StringifyRootOptions& root_options = types::StringifyRootOptions{}) const {
-    ::mbo::types::Stringify stringify{static_cast<types::Stringify::OutputMode>(mode), root_options};
+    const ::mbo::types::Stringify stringify{static_cast<types::Stringify::OutputMode>(mode), root_options};
     if (IsNull()) {
       struct Null {};
 

--- a/mbo/log/scoped_stream.h
+++ b/mbo/log/scoped_stream.h
@@ -255,7 +255,7 @@ void ScopedStreamErr(const Disallowed&&) {  // NOLINT(*-named-parameter)
 
 template<ScopedStreamMode kMode = ScopedStreamMode::kContinue>
 MBO_FORCE_INLINE auto ScopedStreamVoid(const std::source_location& loc = std::source_location::current()) {
-  static VoidStream void_stream;
+  static const VoidStream void_stream;
   return ScopedStream<kMode, VoidStream, VoidStream>(loc, void_stream);
 }
 

--- a/mbo/strings/split.h
+++ b/mbo/strings/split.h
@@ -27,7 +27,7 @@ class AtLast {
   explicit AtLast(char sep) : sep_(sep) {}
 
   std::string_view Find(std::string_view text, std::size_t pos) const {
-    std::size_t next_pos = text.substr(pos).rfind(sep_);
+    const std::size_t next_pos = text.substr(pos).rfind(sep_);
     if (next_pos == std::string_view::npos) {
       return std::string_view{text.data() + text.size(), 0};
     }

--- a/mbo/testing/matchers.h
+++ b/mbo/testing/matchers.h
@@ -247,7 +247,7 @@ class CapacityIsMatcher {
     }
 
     bool MatchAndExplain(Container container, ::testing::MatchResultListener* listener) const override {
-      CapacityType capacity = container.capacity();
+      const CapacityType capacity = container.capacity();
       ::testing::StringMatchResultListener capacity_listener;
       const bool result = capacity_matcher_.MatchAndExplain(capacity, &capacity_listener);
       *listener << "whose capacity " << capacity << (result ? " matches" : " doesn't match");

--- a/mbo/testing/runfiles_dir.cc
+++ b/mbo/testing/runfiles_dir.cc
@@ -87,7 +87,7 @@ absl::StatusOr<std::string> RunfilesDir(std::string_view workspace, std::string_
     }
     const std::string mapping_file = absl::StrCat(test_bin, "/_repo_mapping");
     MBO_ASSIGN_OR_RETURN(const std::string mapping, mbo::file::GetContents(mapping_file));
-    for (std::string_view line : absl::StrSplit(mapping, '\n')) {
+    for (const std::string_view line : absl::StrSplit(mapping, '\n')) {
       const std::vector<std::string_view> parts = absl::StrSplit(line, ',', absl::AllowEmpty());
       if (parts.size() == 3 && parts[1] == workspace) {
         return runfiles->Rlocation(mbo::file::JoinPaths(parts[2], source_rel));

--- a/mbo/testing/status.h
+++ b/mbo/testing/status.h
@@ -334,7 +334,7 @@ class StatusPayloads {
       payload_map.emplace(type_url, payload);
     });
     ::testing::StringMatchResultListener inner;
-    bool match = payload_matcher_.MatchAndExplain(payload_map, &inner);
+    const bool match = payload_matcher_.MatchAndExplain(payload_map, &inner);
     if (inner.str().empty()) {
       if (actual_status.ok()) {
         *listener << "which has OK status (and no payload)";

--- a/mbo/testing/status_test.cc
+++ b/mbo/testing/status_test.cc
@@ -176,7 +176,7 @@ TEST_F(StatusMatcherTest, StatusIsWithCodeMatcher) {
   EXPECT_THAT(absl::OkStatus(), Not(StatusIs(Ne(absl::StatusCode::kOk))));
   EXPECT_THAT(absl::AbortedError("boom"), StatusIs(Ne(absl::StatusCode::kOk), HasSubstr("boom")));
 
-  absl::StatusOr<int> status_or = absl::UnavailableError("down");
+  const absl::StatusOr<int> status_or = absl::UnavailableError("down");
   EXPECT_THAT(status_or, StatusIs(AnyOf(absl::StatusCode::kUnavailable, absl::StatusCode::kDeadlineExceeded)));
   EXPECT_THAT(status_or, Not(StatusIs(absl::StatusCode::kNotFound)));
 

--- a/mbo/types/stringify_ostream.cc
+++ b/mbo/types/stringify_ostream.cc
@@ -31,7 +31,7 @@ std::shared_ptr<const Stringify> g_stringify ABSL_GUARDED_BY(g_mx) = nullptr;
 namespace types_internal {
 
 std::shared_ptr<const Stringify> GetStringifyForOstream() {
-  absl::MutexLock lock(g_mx);
+  const absl::MutexLock lock(g_mx);
   if (g_stringify == nullptr) {
     g_stringify = std::make_shared<Stringify>();
   }
@@ -41,12 +41,12 @@ std::shared_ptr<const Stringify> GetStringifyForOstream() {
 }  // namespace types_internal
 
 void SetStringifyOstreamOutputMode(Stringify::OutputMode output_mode) {
-  absl::MutexLock lock(g_mx);
+  const absl::MutexLock lock(g_mx);
   g_stringify.reset(new Stringify(output_mode));  // NOLINT
 }
 
 void SetStringifyOstreamOptions(const StringifyOptions& options) {
-  absl::MutexLock lock(g_mx);
+  const absl::MutexLock lock(g_mx);
   g_stringify.reset(new Stringify(options));  // NOLINT
 }
 


### PR DESCRIPTION
Fifth clang-tidy triage PR. **31 `const` additions across 17 files** — all bare `const`, no logic changed.

## The headline: this check's `--fix` is not safe here

I did not take the automatic fixes wholesale, and that turned out to matter. Applying all of them **broke the build in three distinct ways**:

| file | failure |
|---|---|
| `mbo/types/stringify.h:916` | `cannot assign to variable 'idx' with const-qualified type` — the variable *is* assigned. The check was simply wrong. |
| `mbo/types/internal/struct_names_clang.h:127` | a non-const reference can no longer bind to the now-const value |
| `optional_ref_test.cc`, `optional_data_or_ref_test.cc` | `static assertion failed` — `const` changes the deduced type the tests assert on |

`mbo/hash/hash_benchmark.cc` is the clearest case. It proposed `const` for:

```cpp
total_bytes += static_cast<int64_t>(key.size());   // proposed const
benchmark::DoNotOptimize(Algo::GetHash64(keys[counter++ & ...]));  // proposed const
```

These are template-heavy sites where the mutating instantiation is not visible to the translation unit that exported the fix. Anyone running `clang-tidy --fix` for this check on this repo will silently break it.

Those five files are reverted here and keep **18 findings**, to be handled individually rather than mechanically.

## Method

Fixes were exported per TU with `--export-fixes` and merged once via `clang-apply-replacements`, rather than running `--fix` in parallel. With 81 TUs and headers included by many of them, parallel `--fix` would have had several processes rewriting the same header concurrently.

## Test

- `bazel test --config=clang //...` — **109/109 pass**.
- Every surviving change verified to be a bare `const` addition (`git diff` contains no other kind of line).
- `pre-commit run -a` green.

## Follow-up

The remaining 18 findings live in `stringify.cc` (1), `hash_benchmark.cc` (6), `struct_names_test.cc` (4), `optional_ref_test.cc` (1), `optional_data_or_ref_test.cc` (6). Since several are demonstrably wrong rather than merely awkward, `NOLINT` with a per-site reason looks right — but that is a judgement call per site, so it is left out of this PR.