### PR TITLE
Fix the any_scan.h value-param findings caused by #272

### DIFF
--- a/mbo/container/any_scan.h
+++ b/mbo/container/any_scan.h
@@ -516,8 +516,8 @@ class AnyScan : public container_internal::AnyScanImpl<ValueType, DifferenceType
   template<::mbo::types::ContainerHasInputIterator Container>
   requires(types::ConstructibleFrom<ValueType, typename std::remove_cvref_t<Container>::value_type>)
   AnyScan(  // NOLINT(*-explicit-constructor,*-explicit-conversions)
-      container_internal::MakeAnyScanData<Container, container_internal::ScanMode::kAny> data)
-      : AnyScanImpl(std::move(data)) {}
+      const container_internal::MakeAnyScanData<Container, container_internal::ScanMode::kAny>& data)
+      : AnyScanImpl(data) {}
 
   using AnyScanImpl::begin;
   using AnyScanImpl::end;
@@ -539,8 +539,8 @@ class ConstScan
   template<container_internal::AcceptableContainer Container>
   requires(types::ConstructibleFrom<const ValueType, typename std::remove_cvref_t<Container>::value_type>)
   ConstScan(  // NOLINT(*-explicit-constructor,*-explicit-conversions)
-      container_internal::MakeAnyScanData<Container, container_internal::ScanMode::kConst> data)
-      : AnyScanImpl(std::move(data)) {}
+      const container_internal::MakeAnyScanData<Container, container_internal::ScanMode::kConst>& data)
+      : AnyScanImpl(data) {}
 
   using AnyScanImpl::begin;
   using AnyScanImpl::end;
@@ -562,8 +562,8 @@ class ConvertingScan
   template<container_internal::AcceptableContainer Container>
   requires(types::ConstructibleFrom<ValueType, typename std::remove_cvref_t<Container>::value_type>)
   ConvertingScan(  // NOLINT(*-explicit-constructor,*-explicit-conversions)
-      container_internal::MakeAnyScanData<Container, container_internal::ScanMode::kConverting> data)
-      : AnyScanImpl(std::move(data)) {}
+      const container_internal::MakeAnyScanData<Container, container_internal::ScanMode::kConverting>& data)
+      : AnyScanImpl(data) {}
 
   using AnyScanImpl::begin;
   using AnyScanImpl::end;


### PR DESCRIPTION
Clears all **45** `performance-unnecessary-value-param` findings in `mbo/container/any_scan.h` — 10% of everything remaining.

## This is a regression I introduced in #272

#272 changed `AnyScanImpl`'s constructors to take `MakeAnyScanData` by const reference. That silently broke the three public wrappers — `AnyScan`, `ConstScan`, `ConvertingScan` — which take the same type **by value** and then `std::move(data)` into `AnyScanImpl`:

```cpp
AnyScan(container_internal::MakeAnyScanData<Container, ScanMode::kAny> data)
    : AnyScanImpl(std::move(data)) {}   // moving into a const& -- a no-op
```

Moving into a `const&` parameter does nothing, so those `std::move` calls became misleading dead code and the by-value parameters became "copied for each invocation but only used as a const reference".

The count went **25 → 45**: the findings moved off the impl constructor and onto the three wrappers, and multiplied. My verification for #272 confirmed the specific diagnostic cleared but never re-measured the file, so this went unnoticed until the enforcement sweep.

## Fix

Make the three wrappers take a const reference too, and drop the pointless `std::move`. Consistent with the type: 16 bytes holding one `const std::shared_ptr`, whose `const` member makes even a move a copy (measured in #272).

## Test

- `performance-unnecessary-value-param` reports **zero** for the header (was 45).
- `bazel test --config=clang //...` — **109/109 pass**.
- `pre-commit run -a` green.

Remaining in this header, for later PRs: `readability-redundant-typename` (5), `cppcoreguidelines-rvalue-reference-param-not-moved` (3), and single findings from three other checks.