### PR TITLE
clang-tidy: parse against libc++ everywhere, and document the real hook setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,9 @@ The project only comes with a Bazel BUILD.bazel file and can be added to other B
 
 The project is formatted with specific clang-format settings which require clang 16+ (in case of MacOs LLVM 16+ can be installed using brew). For simplicity in dev mode the project pulls the appropriate clang tools and can be compiled with those tools using `bazel [build|test] --config=clang ...`.
 
-Lint and format are driven by [Trunk](https://docs.trunk.io/cli). Devs are **required** to install the CLI locally — `curl https://get.trunk.io -fsSL | bash` — then run `trunk check` and `trunk fmt` before pushing. The repo enables `trunk-fmt-pre-commit` and `trunk-check-pre-push` so the hooks run automatically once installed. CI runs `trunk check` only (no auto-fixing on the GitHub side); failing lint must be fixed locally and re-pushed.
+Lint and format are driven by [Trunk](https://docs.trunk.io/cli) plus [pre-commit](https://pre-commit.com). Devs are **required** to install both — `curl https://get.trunk.io -fsSL | bash` and `pip install pre-commit` (or your package manager's equivalent) — then run `pre-commit install` **once**. pre-commit is this repo's single git-hook entry point and delegates `trunk fmt` to trunk on every commit; trunk's own git-hook actions are deliberately disabled in `.trunk/trunk.yaml` so the two cannot fight over `.git/hooks` (a CI check fails the build if they are re-enabled). CI runs `pre-commit`, `trunk check` and `clang-tidy` as separate jobs and never auto-fixes; failing lint must be fixed locally and re-pushed.
+
+`clang-tidy` is one of these pre-commit hooks as well — it moved there from trunk, which pinned a version too old to parse this code. It is opt-in for now (`pre-commit run clang-tidy --all-files --hook-stage manual`) and becomes automatic like the rest once the finding sweep lands. See [STYLE_CPP.md](STYLE_CPP.md) for how to run it and how to build the `compile_commands.json` it needs.
 
 ### MODULES.bazel
 

--- a/compile_commands-update.sh
+++ b/compile_commands-update.sh
@@ -71,6 +71,16 @@ fi
 # exec configuration keep their command, so nothing leaves the compile DB.
 declare -a BCCE_ARGS=("--bcce-compiler=${CLANG}" "--bcce-prefer-target-config")
 
+# Parse against libc++ on EVERY platform, so clang-tidy sees the same standard
+# library everywhere. The extracted commands come from the default build
+# configuration, not `--config=clang`, so they carry no `-stdlib`; the hermetic
+# clang then falls back to each platform's default - libc++ on macOS, libstdc++
+# on Linux. That made the same check report differently per platform: a finding
+# fixed on a Mac could be absent on the Linux CI runner and the reverse. The
+# hermetic toolchain ships its own libc++ on both, so asking for it is enough
+# (a no-op on macOS, the actual switch on Linux).
+BCCE_ARGS+=("--bcce-copt=-stdlib=libc++")
+
 # The hermetic clang carries its own libc++ but no system C headers: without the
 # SDK sysroot its <locale> support headers fail on `'time.h' file not found`.
 # The bazel `--config=clang` toolchain supplies this itself; the extracted


### PR DESCRIPTION
Two parts of the same story: making clang-tidy behave identically on macOS and Linux, and describing the setup honestly in the README.

## 1. Parse against libc++ on every platform

`compile_commands-update.sh` extracts the compile DB from the **default build configuration** — `--config=clang` never reaches the extractor's `aquery`; we only substitute the compiler binary afterwards via `--bcce-compiler`. So the recorded commands carry no `-stdlib`, and the hermetic clang falls back to each platform's default:

| platform | standard library |
|---|---|
| macOS | libc++ (the hermetic toolchain's own) |
| Linux | libstdc++ |

Same clang-tidy, different standard library, therefore different template instantiations and different findings. A finding fixed on a Mac could simply be absent on the Linux CI runner, and the reverse — which makes the finding sweep platform-dependent and would make enforcement flap between local and CI.

Fix: pass `--bcce-copt=-stdlib=libc++`. The hermetic toolchain ships libc++ on both platforms, so this is a no-op on macOS and the actual switch on Linux.

**Test:** all **3002** compile DB entries carry the flag; clang-tidy still parses cleanly on macOS with no hard errors. The Linux half is exactly what this changes, and the CI `clang-tidy` job verifies it.

### This treats the symptom

The root cause is that the DB is extracted in the default configuration with only its *compiler* replaced. Extracting with `--config=clang` (a `refresh_compile_commands` target with `targets = {"@//...": "--config=clang"}`) would make **every** flag — stdlib, include paths, feature macros, sysroot — match what bazel actually builds, and would let both `--bcce-compiler` and this flag go away. Worth doing; tracked separately.

## 2. README: document the dev hook setup that actually exists

The dev-setup paragraph claimed the repo *"enables `trunk-fmt-pre-commit` and `trunk-check-pre-push` so the hooks run automatically once installed"*. That has been **false** for some time: both actions are disabled in `.trunk/trunk.yaml`, and main.yml's "Trunk must not own git hooks" step fails the build if either is re-enabled. A dev following the README would never run `pre-commit install` and would end up with **no git hooks at all**.

It now says what is there: pre-commit owns the git hook and delegates `trunk fmt` to trunk, trunk's own hook actions stay disabled so the two cannot fight over `.git/hooks`, and CI runs `pre-commit`, `trunk check` and `clang-tidy` as separate jobs. clang-tidy is one of the pre-commit hooks too — it moved there from trunk, which pinned a version too old to parse this code — opt-in for now and automatic once the finding sweep lands.

This paragraph originates in #183, which proposed it before the CI guard and the clang-tidy job existed. The rest of that PR is superseded and it is being closed.