### PR TITLE
Drop redundant `typename` (C++20 P0634)

### DIFF
--- a/mbo/container/any_scan.h
+++ b/mbo/container/any_scan.h
@@ -304,7 +304,7 @@ class AnyScanImpl {
   requires(mbo::types::IsPair<std::remove_cvref_t<Pair>>)
   struct FirstType {
     using RawPair = std::remove_cvref_t<Pair>;
-    using RawFirst = typename RawPair::first_type;
+    using RawFirst = RawPair::first_type;
     using type = mbo::types::Cases<
         mbo::types::IfThen<std::is_const_v<Pair> && std::is_reference_v<Pair>, const RawFirst&>,
         mbo::types::IfThen<std::is_const_v<Pair>, const RawFirst>,
@@ -317,8 +317,8 @@ class AnyScanImpl {
     using RawSrc = std::remove_cvref_t<SrcValueTypeT>;
     using RawDst = std::remove_cvref_t<DstAccessType>;
     if constexpr (::mbo::types::IsPair<RawSrc> && ::mbo::types::IsPair<RawDst>) {
-      using SrcFirstType = typename FirstType<SrcValueTypeT>::type;
-      using DstFirstType = typename FirstType<DstAccessType>::type;
+      using SrcFirstType = FirstType<SrcValueTypeT>::type;
+      using DstFirstType = FirstType<DstAccessType>::type;
       static_assert(
           std::convertible_to<SrcFirstType, DstFirstType>,
           "A common reason for this to fail is scanning over `std::map` and similar indexed containers "

--- a/mbo/digest/digest.h
+++ b/mbo/digest/digest.h
@@ -62,7 +62,7 @@ template<typename Algo>
 requires(IsDigestAlgorithm<Algo> && HasStreaming<Algo>)
 class Streamer {
  public:
-  using DigestType = typename Algo::DigestType;
+  using DigestType = Algo::DigestType;
 
   constexpr Streamer() noexcept : state_(Algo::StreamInit()) {}
 
@@ -74,7 +74,7 @@ class Streamer {
   [[nodiscard]] constexpr DigestType Finalize() const noexcept { return Algo::StreamFinalize(state_); }
 
  private:
-  typename Algo::StreamState state_;
+  Algo::StreamState state_;
 };
 
 // Lowercase hex rendering, the conventional presentation of a digest (matches

--- a/mbo/digest/digest_concepts.h
+++ b/mbo/digest/digest_concepts.h
@@ -40,7 +40,7 @@ concept IsDigestAlgorithm = requires(std::string_view data) {
 // Streaming (incremental) interface. `StreamFinalize` takes the state by
 // value, so a stream can be finalized ("peeked") and then continued.
 template<typename Algo>
-concept HasStreaming = requires(typename Algo::StreamState state, std::string_view data) {
+concept HasStreaming = requires(Algo::StreamState state, std::string_view data) {
   { Algo::StreamInit() } noexcept -> std::same_as<typename Algo::StreamState>;
   { Algo::StreamUpdate(state, data) } noexcept;
   { Algo::StreamFinalize(state) } noexcept -> std::same_as<typename Algo::DigestType>;

--- a/mbo/digest/digest_hmac.h
+++ b/mbo/digest/digest_hmac.h
@@ -52,12 +52,12 @@ requires(IsDigestAlgorithm<Algo> && HasStreaming<Algo>)
 struct Hmac {
   static constexpr std::size_t kDigestSize = Algo::kDigestSize;
   static constexpr std::size_t kBlockSize = Algo::kBlockSize;
-  using DigestType = typename Algo::DigestType;
+  using DigestType = Algo::DigestType;
 
   static_assert(kDigestSize <= kBlockSize, "HMAC requires the digest to fit one block.");
 
   struct StreamState {
-    typename Algo::StreamState inner;
+    Algo::StreamState inner;
     std::array<char, kBlockSize> opad = {};
   };
 
@@ -116,7 +116,7 @@ template<typename Algo>
 requires(IsDigestAlgorithm<Algo> && HasStreaming<Algo>)
 class HmacStreamer {
  public:
-  using DigestType = typename Algo::DigestType;
+  using DigestType = Algo::DigestType;
 
   constexpr explicit HmacStreamer(std::string_view key) noexcept : state_(Hmac<Algo>::StreamInit(key)) {}
 
@@ -128,7 +128,7 @@ class HmacStreamer {
   [[nodiscard]] constexpr DigestType Finalize() const noexcept { return Hmac<Algo>::StreamFinalize(state_); }
 
  private:
-  typename Hmac<Algo>::StreamState state_;
+  Hmac<Algo>::StreamState state_;
 };
 
 // NOLINTEND(*-magic-numbers,*-easily-swappable-parameters,*-constant-array-index)

--- a/mbo/hash/hash.h
+++ b/mbo/hash/hash.h
@@ -137,7 +137,7 @@ struct Hasher {
 // (e.g. rapidhash in hash_extra.h has no canonical streaming form) -- absence
 // is honest.
 template<typename Algo>
-concept HasStreaming = requires(typename Algo::StreamState state, std::string_view data, uint64_t seed) {
+concept HasStreaming = requires(Algo::StreamState state, std::string_view data, uint64_t seed) {
   { Algo::StreamInit(seed) } noexcept -> std::same_as<typename Algo::StreamState>;
   { Algo::StreamUpdate(state, data) } noexcept;
   { Algo::StreamFinalize(state) } noexcept -> std::same_as<uint64_t>;
@@ -166,7 +166,7 @@ class Streamer {
   [[nodiscard]] constexpr uint64_t Finalize() const noexcept { return Algo::StreamFinalize(state_); }
 
  private:
-  typename Algo::StreamState state_;
+  Algo::StreamState state_;
 };
 
 // The selected default algorithms behind the `mbo::hash` entry points.

--- a/mbo/json/json.h
+++ b/mbo/json/json.h
@@ -415,7 +415,7 @@ class Json {
   }
 
   // Change value to an `Array`.
-  Json& MakeArray() { return MakeType(std::make_unique<typename Array::element_type>()); }
+  Json& MakeArray() { return MakeType(std::make_unique<Array::element_type>()); }
 
   // Change value to an `Object`
   Json& MakeObject() { return MakeType(Object{}); }

--- a/mbo/testing/status.h
+++ b/mbo/testing/status.h
@@ -79,7 +79,7 @@ template<typename StatusOrType>
 class IsOkAndHoldsMatcherImpl : public ::testing::MatcherInterface<StatusOrType> {
  public:
   // NOLINTNEXTLINE(readability-identifier-naming)
-  using value_type = typename std::remove_reference<StatusOrType>::type::value_type;
+  using value_type = std::remove_reference<StatusOrType>::type::value_type;
 
   template<typename InnerMatcher, std::enable_if_t<!std::is_same_v<InnerMatcher, IsOkAndHoldsMatcherImpl>, int> = 0>
   explicit IsOkAndHoldsMatcherImpl(InnerMatcher&& inner_matcher)

--- a/mbo/types/cases.h
+++ b/mbo/types/cases.h
@@ -63,7 +63,7 @@ using types_internal::IfFalseThenVoid;
 //   `Cases<IfThen<cond1, type1>, IfThen<cond2, type2>, IfElse<default_type>>`
 //
 template<typename... IfThenCases>
-using Cases = typename types_internal::CasesImpl<IfThenCases...>::type;
+using Cases = types_internal::CasesImpl<IfThenCases...>::type;
 
 // Evaluates the first non zero case (1-based, 0 if all zero).
 //

--- a/mbo/types/container_proxy.h
+++ b/mbo/types/container_proxy.h
@@ -58,7 +58,7 @@ namespace mbo::types {
 // ```
 template<
     typename T,
-    typename Container = typename T::element_type,
+    typename Container = T::element_type,
     Container& (T::*GetMutable)() = &T::operator*,
     const Container& (T::*GetConst)() const = &T::operator*>
 requires requires { typename std::remove_cvref_t<Container>::value_type; }
@@ -78,8 +78,8 @@ struct ContainerProxy : T {
   }
 
  public:
-  using size_type = typename C::size_type;
-  using value_type = typename C::value_type;
+  using size_type = C::size_type;
+  using value_type = C::value_type;
 
   // NOLINTBEGIN(readability-identifier-naming)
   // clang-format off

--- a/mbo/types/extender.h
+++ b/mbo/types/extender.h
@@ -132,13 +132,13 @@ struct MakeExtender {
 
   template<typename ExtenderOrActualType>
   struct Impl : ImplT<ExtenderOrActualType> {
-    using Type = typename ExtenderOrActualType::Type;
+    using Type = ExtenderOrActualType::Type;
   };
 };
 
 template<typename ExtenderBase>
 struct AbslStringify_ : ExtenderBase {  // NOLINT(readability-identifier-naming)
-  using Type = typename ExtenderBase::Type;
+  using Type = ExtenderBase::Type;
 
   template<typename Other>
   friend struct AbslStringify_;
@@ -164,7 +164,7 @@ struct AbslStringify_ : ExtenderBase {  // NOLINT(readability-identifier-naming)
 template<typename ExtenderBase>
 struct AbslHashable_ : ExtenderBase {  // NOLINT(readability-identifier-naming)
  private:
-  using T = typename ExtenderBase::Type;
+  using T = ExtenderBase::Type;
 
  public:
   template<typename H>
@@ -176,7 +176,7 @@ struct AbslHashable_ : ExtenderBase {  // NOLINT(readability-identifier-naming)
 template<typename ExtenderBase>
 struct Comparable_ : ExtenderBase {  // NOLINT(readability-identifier-naming)
  private:
-  using T = typename ExtenderBase::Type;
+  using T = ExtenderBase::Type;
 
  public:
   // Define operator `<=>` on `const T&` since that is what defines the
@@ -232,7 +232,7 @@ struct Comparable_ : ExtenderBase {  // NOLINT(readability-identifier-naming)
 template<typename ExtenderBase>
 struct Printable_ : ExtenderBase {  // NOLINT(readability-identifier-naming)
  public:
-  using T = typename ExtenderBase::Type;
+  using T = ExtenderBase::Type;
 
   // Produce a string based on control via `field_options`.
   //

--- a/mbo/types/internal/extend.h
+++ b/mbo/types/internal/extend.h
@@ -67,14 +67,14 @@ struct GetRequirementImpl {
 
 template<typename Extender>
 struct GetRequirementImpl<Extender, true> {
-  using type = typename Extender::RequiredExtender;
+  using type = Extender::RequiredExtender;
 };
 
 template<typename Extender>
-using GetRequirement = typename GetRequirementImpl<Extender>::type;
+using GetRequirement = GetRequirementImpl<Extender>::type;
 
 template<std::size_t N, typename... Ts>
-using GetType = typename std::tuple_element<N, std::tuple<Ts...>>::type;
+using GetType = std::tuple_element<N, std::tuple<Ts...>>::type;
 
 template<std::size_t N, typename Required, typename... Extenders>
 struct RequiredPresentForIndexImpl
@@ -116,7 +116,7 @@ concept HasExtenderTuple = requires { typename T::ExtenderTuple; };
 // There is also the special case of a shorthand extender which has a `ExtenderTuple` member type.
 template<typename T, bool = HasExtenderTuple<T>>
 struct ExtendExtenderTupleElemT {
-  using type = typename T::ExtenderTuple;
+  using type = T::ExtenderTuple;
 };
 
 template<typename T>

--- a/mbo/types/internal/is_braces_constructible.h
+++ b/mbo/types/internal/is_braces_constructible.h
@@ -127,7 +127,7 @@ template<typename T, typename... Args>
 struct IsBracesConstructibleImpl : decltype(types_internal::IsBracesConstructibleFunc<T, Args...>(0)) {};
 
 template<typename T, typename... Args>
-using IsBracesConstructibleImplT = typename IsBracesConstructibleImpl<T, Args...>::type;
+using IsBracesConstructibleImplT = IsBracesConstructibleImpl<T, Args...>::type;
 
 #ifdef __clang__
 # pragma clang diagnostic pop

--- a/mbo/types/internal/test_types.h
+++ b/mbo/types/internal/test_types.h
@@ -51,7 +51,7 @@ struct BaseOutOfRange final {
 };
 
 template<std::size_t base>
-using ConstructBase = typename CasesImpl<
+using ConstructBase = CasesImpl<
     IfThen<base == 0, Empty>,
     IfThen<base == 1, Base1>,
     IfThen<base == 2, Base1>,
@@ -100,7 +100,7 @@ struct DerivedOutOfRange final {
 };
 
 template<std::size_t derived, std::size_t base>
-using ConstructType = typename CasesImpl<
+using ConstructType = CasesImpl<
     IfThen<derived == 0, Derived0<ConstructBase<base>>>,
     IfThen<derived == 1, Derived1<ConstructBase<base>>>,
     IfThen<derived == 2, Derived2<ConstructBase<base>>>,
@@ -190,7 +190,7 @@ struct Base3B {
 };
 
 template<std::size_t base>
-using ConstructBase2 = typename CasesImpl<
+using ConstructBase2 = CasesImpl<
     IfThen<base == 0, EmptyB>,
     IfThen<base == 1, Base2B>,
     IfThen<base == 2, Base2B>,
@@ -198,7 +198,7 @@ using ConstructBase2 = typename CasesImpl<
     IfElse<BaseOutOfRange>>::type;
 
 template<std::size_t derived, std::size_t a, std::size_t b>
-using ConstructMultiType = typename CasesImpl<
+using ConstructMultiType = CasesImpl<
     IfThen<derived == 0, Multi0<ConstructBase<a>, ConstructBase2<b>>>,
     IfThen<derived == 1, Multi1<ConstructBase<a>, ConstructBase2<b>>>,
     IfThen<derived == 2, Multi2<ConstructBase<a>, ConstructBase2<b>>>,

--- a/mbo/types/optional_data_or_ref_test.cc
+++ b/mbo/types/optional_data_or_ref_test.cc
@@ -104,7 +104,7 @@ TEST_F(OptionalDataOrRefTest, InitRef) {
 
 TEST_F(OptionalDataOrRefTest, Value) {
   int val = 10;
-  static_assert(std::same_as<int, typename OptionalDataOrRef<int>::value_type>);
+  static_assert(std::same_as<int, OptionalDataOrRef<int>::value_type>);
   OptionalDataOrRef<int> ref(val);
   EXPECT_THAT(ref.has_value(), true);
   EXPECT_THAT(ref.HoldsData(), false);


### PR DESCRIPTION
Clears all **33** `readability-redundant-typename` findings across 14 files.

## What

C++20 ([P0634R3, "Down with `typename!`"](https://wg21.link/p0634)) removed the requirement for `typename` in contexts where only a type can appear. These are all such contexts — alias declarations, member declarations, and `requires`-clause parameter lists:

```cpp
-    using RawFirst = typename RawPair::first_type;
+    using RawFirst = RawPair::first_type;

-  typename Algo::StreamState state_;
+  Algo::StreamState state_;

-concept HasStreaming = requires(typename Algo::StreamState state, std::string_view data) {
+concept HasStreaming = requires(Algo::StreamState state, std::string_view data) {
```

The keyword stays *valid* where it was written, so this is a readability change, not a correctness one. The relaxed rules are C++20, which is this project's baseline (`--cxxopt=-std=c++20`), so the best-effort GCC build is unaffected — its support predates the baseline.

## Method

Applied with clang-tidy's own fixes, exported per TU with `--export-fixes` and merged once via `clang-apply-replacements`, rather than running `--fix` in parallel across 81 TUs that share headers.

Unlike `misc-const-correctness` in #275 — where the auto-fix broke the build three different ways — this check's fixes **are** safe here. I verified that by reading the entire diff: all **66** changed lines are bare keyword removals, with no other edit of any kind.

## Test

- `readability-redundant-typename` reports **zero** across the affected files.
- `bazel test --config=clang //...` — **109/109 pass**.
- `pre-commit run -a` green.