### PR TITLE
Fix the header guards that were actually wrong, and enforce the rule

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -36,6 +36,16 @@
 # the compound conditions sitting right next to them, so following it makes
 # neighbouring directives LESS consistent rather than more.
 #
+# readability-identifier-naming exempts guard-shaped macros via
+# MacroDefinitionIgnoredRegexp. That is not cosmetic: the check's UPPER_CASE
+# notion splits inside words at digit boundaries - it asks for
+# MBO_DIGEST_DIGEST_M_D5_H in place of MBO_DIGEST_DIGEST_MD5_H_ - and drops the
+# trailing underscore, so it can never accept the `{PATH}_{FILE}_` guards
+# STYLE_CPP.md mandates. The regexp previously omitted digits, so correct guards
+# containing one (BLAKE2B, SHA1, MD5) leaked through and were reported. The rule
+# itself is enforced by the `header-guards` pre-commit hook, which checks what
+# clang-tidy structurally cannot.
+#
 # abseil-unchecked-statusor-access is off because clang-tidy 22.1.8 SEGFAULTS in
 # it: its dataflow analysis (runTypeErasedDataflowAnalysis) crashes on
 # mbo/strings/strip.cc, reproducibly on both macOS and Linux. Re-test on a future
@@ -175,7 +185,7 @@ CheckOptions:
   - key:             readability-identifier-naming.MacroDefinitionCase
     value:           UPPER_CASE
   - key:             readability-identifier-naming.MacroDefinitionIgnoredRegexp
-    value:           '^[A-Z]+(_[A-Z]+)*_$'
+    value:           '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*_$'
   - key:             readability-identifier-naming.MemberCase
     value:           lower_case
   - key:             readability-identifier-naming.PrivateMemberSuffix

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -95,6 +95,19 @@ repos:
         entry: .pre-commit/check_clang_tidy_targets.sh
         pass_filenames: false
         files: ^(.*/BUILD\.bazel|bazelmod/clang_tidy_targets\.bzl)$
+      - id: header-guards
+        name: header guards follow STYLE_CPP
+        description: |
+          Header guards must be `{PATH}_{FILE}_` per STYLE_CPP.md. clang-tidy cannot check this:
+          readability-identifier-naming's UPPER_CASE splits inside words at digit boundaries (it
+          wants MBO_DIGEST_DIGEST_M_D5_H for digest_md5.h) and drops the trailing underscore, so
+          it can never accept the documented convention - which is why guard-shaped names are
+          exempted from it there. llvm-header-guard is likewise disabled, deriving the guard from
+          the absolute checkout path. This enforces the actual rule, including that the closing
+          `#endif` comment names the guard.
+        language: python
+        entry: .pre-commit/check_header_guards.py
+        files: \.h$
       - id: no-do-not-merge
         name: No 'DO NOT MERGE'
         description: |

--- a/.pre-commit/check_header_guards.py
+++ b/.pre-commit/check_header_guards.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Checks header guards against STYLE_CPP.md: `{PATH}_{FILE}_`.
+
+That is the path plus filename, uppercased, every non-alphanumeric replaced by
+`_`, with a trailing `_`.
+
+clang-tidy cannot do this for us. `readability-identifier-naming`'s UPPER_CASE
+notion splits inside words at digit boundaries (it wants MBO_DIGEST_DIGEST_M_D5_H
+for digest_md5.h) and drops the trailing underscore, so it can never accept the
+documented convention - which is exactly why `MacroDefinitionIgnoredRegexp`
+exempts guard-shaped names from it. This check enforces the real rule instead of
+leaving it to review.
+
+`llvm-header-guard` is likewise disabled: it derives the guard from the absolute
+checkout path.
+"""
+
+import re
+import sys
+
+
+def expected_guard(path: str) -> str:
+    return re.sub(r"[^A-Za-z0-9]", "_", path).upper() + "_"
+
+
+def check(path: str) -> list[str]:
+    errors: list[str] = []
+    try:
+        text = open(path, encoding="utf-8", errors="replace").read()
+    except OSError as err:
+        return [f"{path}: cannot read: {err}"]
+
+    want = expected_guard(path)
+    match = re.search(r"^#ifndef\s+(\S+)", text, re.M)
+    if not match:
+        return [f"{path}: no `#ifndef` header guard found; expected `{want}`"]
+    got = match.group(1)
+    if got != want:
+        errors.append(f"{path}: guard is `{got}`, expected `{want}`")
+
+    if not re.search(rf"^#define\s+{re.escape(got)}\s*$", text, re.M):
+        errors.append(f"{path}: `#ifndef {got}` has no matching `#define {got}`")
+
+    # Only the LAST `#endif` closes the guard. Inner ones legitimately comment
+    # their own condition (`#endif  // NDEBUG`), so they must not be touched.
+    lines = text.split("\n")
+    for line in reversed(lines):
+        if line.startswith("#endif"):
+            comment = re.match(r"#endif\s*//\s*(\S+)\s*$", line)
+            if comment and comment.group(1) != got:
+                errors.append(
+                    f"{path}: closing `#endif` says `{comment.group(1)}`, expected `{got}`"
+                )
+            break
+    return errors
+
+
+def main(argv: list[str]) -> int:
+    errors: list[str] = []
+    for path in argv[1:]:
+        if path.endswith(".h"):
+            errors.extend(check(path))
+    for error in errors:
+        print(error, file=sys.stderr)
+    if errors:
+        print(
+            "\nHeader guards follow STYLE_CPP.md: {PATH}_{FILE}_ (uppercased, "
+            "non-alphanumerics -> `_`, trailing `_`).",
+            file=sys.stderr,
+        )
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/mbo/container/convert_container.h
+++ b/mbo/container/convert_container.h
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef MBO_TYPES_COPY_CONVERT_CONTAINER_H_
-#define MBO_TYPES_COPY_CONVERT_CONTAINER_H_
+#ifndef MBO_CONTAINER_CONVERT_CONTAINER_H_
+#define MBO_CONTAINER_CONVERT_CONTAINER_H_
 
 #include "mbo/types/traits.h"
 
@@ -125,4 +125,4 @@ inline container_internal::ConvertContainer<const std::initializer_list<U>&, Fun
 
 }  // namespace mbo::container
 
-#endif  // MBO_TYPES_COPY_CONVERT_CONTAINER_H_
+#endif  // MBO_CONTAINER_CONVERT_CONTAINER_H_

--- a/mbo/diff/chunked_diff.h
+++ b/mbo/diff/chunked_diff.h
@@ -69,4 +69,4 @@ class ChunkedDiff : public BaseDiff {
 
 }  // namespace mbo::diff
 
-#endif  // MBO_DIFF_DIFF_H_
+#endif  // MBO_DIFF_CHUNKED_DIFF_H_

--- a/mbo/file/artefact.h
+++ b/mbo/file/artefact.h
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef MBO_FILE_ARTIFACT_H_
-#define MBO_FILE_ARTIFACT_H_
+#ifndef MBO_FILE_ARTEFACT_H_
+#define MBO_FILE_ARTEFACT_H_
 
 #include <string>
 #include <string_view>
@@ -51,4 +51,4 @@ inline Artefact::Options Artefact::Options::Default() noexcept {
 
 }  // namespace mbo::file
 
-#endif  // MBO_FILE_ARTIFACT_H_
+#endif  // MBO_FILE_ARTEFACT_H_

--- a/mbo/log/scoped_log_check.h
+++ b/mbo/log/scoped_log_check.h
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef MBO_LOG_SCOPED_CHECK_H_
-#define MBO_LOG_SCOPED_CHECK_H_
+#ifndef MBO_LOG_SCOPED_LOG_CHECK_H_
+#define MBO_LOG_SCOPED_LOG_CHECK_H_
 
 #include <concepts>  // IWYU pragma: keep
 #include <iostream>
@@ -140,4 +140,4 @@ void ScopedLogCheck(bool, std::string_view, const Disallowed&&) {  // NOLINT(*-n
   mbo::log::ScopedStream<ScopedStreamMode::kQuickExit>( \
       std::source_location::current(), std::cerr, "Failed MBO_LOG_CHECK(" #check ")")
 
-#endif  // MBO_LOG_SCOPED_STREAM_H_
+#endif  // MBO_LOG_SCOPED_LOG_CHECK_H_

--- a/mbo/status/status_macros.h
+++ b/mbo/status/status_macros.h
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef MBO_TYPES_STATUS_STATUS_MACROS_H_
-#define MBO_TYPES_STATUS_STATUS_MACROS_H_
+#ifndef MBO_STATUS_STATUS_MACROS_H_
+#define MBO_STATUS_STATUS_MACROS_H_
 
 #include <utility>  // IWYU pragma: keep
 
@@ -124,4 +124,4 @@
   case 0:                                              \
   default:  // NOLINT
 
-#endif  // MBO_TYPES_STATUS_STATUS_MACROS_H_
+#endif  // MBO_STATUS_STATUS_MACROS_H_

--- a/mbo/types/compare.h
+++ b/mbo/types/compare.h
@@ -166,4 +166,4 @@ inline std::strong_ordering WeakToStrong(std::weak_ordering order) {
 
 }  // namespace mbo::types
 
-#endif  // MBO_TYPES_COMPARE_H
+#endif  // MBO_TYPES_COMPARE_H_

--- a/mbo/types/typed_view.h
+++ b/mbo/types/typed_view.h
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef MBO_TYPES_TYPED_VIEW_H
-#define MBO_TYPES_TYPED_VIEW_H
+#ifndef MBO_TYPES_TYPED_VIEW_H_
+#define MBO_TYPES_TYPED_VIEW_H_
 
 #include <iterator>
 #include <ranges>
@@ -52,4 +52,4 @@ class TypedView : std::ranges::view_interface<TypedView<View>> {
 
 // NOLINTEND(readability-identifier-naming)
 
-#endif  // MBO_TYPES_TYPED_VIEW_H
+#endif  // MBO_TYPES_TYPED_VIEW_H_

--- a/mbo/types/variant.h
+++ b/mbo/types/variant.h
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef MBO_TYPES_VARIANT_H
-#define MBO_TYPES_VARIANT_H
+#ifndef MBO_TYPES_VARIANT_H_
+#define MBO_TYPES_VARIANT_H_
 
 #include <type_traits>
 #include <variant>
@@ -75,4 +75,4 @@ Overloaded(Ts...) -> Overloaded<Ts...>;
 
 }  // namespace mbo::types
 
-#endif  // MBO_TYPES_VARIANT_H
+#endif  // MBO_TYPES_VARIANT_H_


### PR DESCRIPTION
Three separate problems were hiding behind one clang-tidy category. Separating them mattered — the fix for each is different.

## 1. Six guards were genuinely wrong

| header | was | should be |
|---|---|---|
| `mbo/container/convert_container.h` | `MBO_TYPES_COPY_CONVERT_CONTAINER_H_` | `MBO_CONTAINER_CONVERT_CONTAINER_H_` |
| `mbo/status/status_macros.h` | `MBO_TYPES_STATUS_STATUS_MACROS_H_` | `MBO_STATUS_STATUS_MACROS_H_` |
| `mbo/log/scoped_log_check.h` | `MBO_LOG_SCOPED_CHECK_H_` | `MBO_LOG_SCOPED_LOG_CHECK_H_` |
| `mbo/file/artefact.h` | `MBO_FILE_ARTIFACT_H_` (misspelt) | `MBO_FILE_ARTEFACT_H_` |
| `mbo/types/typed_view.h` | `MBO_TYPES_TYPED_VIEW_H` | …`_H_` |
| `mbo/types/variant.h` | `MBO_TYPES_VARIANT_H` | …`_H_` |

The first two still carried `MBO_TYPES_` from a previous location — precisely the collision `STYLE_CPP.md` warns about. Two closing `#endif` comments named a *different* header's guard (`chunked_diff.h` said `MBO_DIFF_DIFF_H_`).

## 2. Our ignore regexp was itself wrong

`^[A-Z]+(_[A-Z]+)*_$` admits **no digits**, so correct guards containing one — `BLAKE2B`, `SHA1`, `MD5` — leaked through and were reported. Now `^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*_$`.

## 3. clang-tidy has a different idea, which renaming cannot fix

`readability-identifier-naming`'s UPPER_CASE notion splits **inside words** at digit boundaries and drops the trailing underscore:

| our guard | clang-tidy demands |
|---|---|
| `MBO_DIGEST_DIGEST_BLAKE2B_H_` | `MBO_DIGEST_DIGEST_BLAK_E2_B_H` |
| `MBO_DIGEST_DIGEST_MD5_H_` | `MBO_DIGEST_DIGEST_M_D5_H` |

It can never accept `{PATH}_{FILE}_`. That is *why* the exemption exists — it only needed to be complete. (`llvm-header-guard` is no better: it derives the guard from the absolute checkout path.)

## Enforcing the rule we actually have

Since neither check can express it, a new `header-guards` pre-commit hook does — including that the closing `#endif` names the guard. All **98** headers pass, and it correctly rejects a deliberately broken guard.

## A mistake worth recording

My first `#endif` audit rewrote **every** commented `#endif`, including legitimate inner ones (`#endif // NDEBUG`, `#endif // defined(__clang__)`) — it would have corrupted 9 files. Only the *last* `#endif` closes the guard. Both the fix and the hook now consider only that one, giving **2** real mismatches rather than the 16 the naive version claimed.

## Test

- All 98 headers conform; guards and closing comments both audited.
- `bazel test --config=clang //...` — **109/109 pass**.
- `pre-commit run -a` green, including the new hook.