### PR TITLE
Act on the triage: two checks off, enum-class cleared

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -24,6 +24,18 @@
 # not something verified here, so the umbrella-header conflict is the operative
 # reason. If the include hygiene is ever wanted, IWYU proper is the better tool.
 #
+# bugprone-easily-swappable-parameters is off. It flags any run of adjacent
+# same-type parameters - e.g. `LongLines(std::size_t, std::size_t, std::size_t)` -
+# without evidence that a call site ever got them wrong. Satisfying it means
+# reordering parameters or introducing strong types to please a heuristic.
+# TODO(helly25): re-enable once the interfaces it flags are revisited; it does
+# catch real swap hazards where a strong type would genuinely help.
+#
+# readability-use-concise-preprocessor-directives is off. It rewrites
+# `#if defined(X)` into `#ifdef X`, which is purely cosmetic and cannot apply to
+# the compound conditions sitting right next to them, so following it makes
+# neighbouring directives LESS consistent rather than more.
+#
 # abseil-unchecked-statusor-access is off because clang-tidy 22.1.8 SEGFAULTS in
 # it: its dataflow analysis (runTypeErasedDataflowAnalysis) crashes on
 # mbo/strings/strip.cc, reproducibly on both macOS and Linux. Re-test on a future
@@ -44,6 +56,7 @@ Checks: >
   -altera-*,
   -boost-*,
   bugprone-*,
+  -bugprone-easily-swappable-parameters,
   -bugprone-exception-escape,
   -cert-err58-cpp,
   clang*,
@@ -80,6 +93,7 @@ Checks: >
   -readability-avoid-nested-conditional-operator,
   -readability-else-after-return,
   -readability-redundant-inline-specifier,
+  -readability-use-concise-preprocessor-directives,
 
 # A check-name glob, not a bool: the former `true` matched no check, so findings
 # never escalated to a non-zero exit.

--- a/mbo/status/status_builder.h
+++ b/mbo/status/status_builder.h
@@ -73,7 +73,14 @@ class StatusBuilder final {
   }
 
   // Switching the builder to append mode.
-  enum Append { Append };  // NOLINT(*-identifier-naming)
+  //
+  // A tag enum, unscoped on purpose: the whole point is that a caller writes
+  // `builder << Append` at the use site. Scoping it would make that
+  // `builder << StatusBuilder::Append::Append`, which is worse to read and an
+  // API break for every caller, to satisfy a rule aimed at enums that carry
+  // values.
+  // NOLINTNEXTLINE(*-identifier-naming,cppcoreguidelines-use-enum-class)
+  enum Append { Append };
 
   StatusBuilder& operator<<(enum Append /* unused */) & { return SetAppend(); }
 

--- a/mbo/types/internal/test_types.h
+++ b/mbo/types/internal/test_types.h
@@ -16,30 +16,32 @@
 #ifndef MBO_TYPES_INTERNAL_TEST_TYPES_H_
 #define MBO_TYPES_INTERNAL_TEST_TYPES_H_
 
+#include <cstddef>
+
 #include "gtest/gtest.h"
 #include "mbo/types/internal/cases.h"
 
 namespace mbo::types::types_internal::test_types {
 
 struct Empty {
-  enum { kFieldCount = 0 };
+  static constexpr std::size_t kFieldCount = 0;
 };
 
 struct Base1 {
-  enum { kFieldCount = 1 };
+  static constexpr std::size_t kFieldCount = 1;
 
   int a;
 };
 
 struct Base2 {
-  enum { kFieldCount = 2 };
+  static constexpr std::size_t kFieldCount = 2;
 
   int a;
   int b;
 };
 
 struct Base3 {
-  enum { kFieldCount = 3 };
+  static constexpr std::size_t kFieldCount = 3;
 
   int a;
   int b;
@@ -62,14 +64,14 @@ template<typename Base>
 struct Derived0 : Base {
   using BaseType = Base;
 
-  enum { kFieldCount = 0 };
+  static constexpr std::size_t kFieldCount = 0;
 };
 
 template<typename Base>
 struct Derived1 : Base {
   using BaseType = Base;
 
-  enum { kFieldCount = 1 };
+  static constexpr std::size_t kFieldCount = 1;
 
   int a;
 };
@@ -78,7 +80,7 @@ template<typename Base>
 struct Derived2 : Base {
   using BaseType = Base;
 
-  enum { kFieldCount = 2 };
+  static constexpr std::size_t kFieldCount = 2;
 
   int a;
   int b;
@@ -88,7 +90,7 @@ template<typename Base>
 struct Derived3 : Base {
   using BaseType = Base;
 
-  enum { kFieldCount = 3 };
+  static constexpr std::size_t kFieldCount = 3;
 
   int a;
   int b;
@@ -132,7 +134,7 @@ struct Multi0
   using BaseAType = BaseA;
   using BaseBType = BaseB;
 
-  enum { kFieldCount = 0 };
+  static constexpr std::size_t kFieldCount = 0;
 };
 
 template<typename BaseA, typename BaseB>
@@ -142,7 +144,7 @@ struct Multi1
   using BaseAType = BaseA;
   using BaseBType = BaseB;
 
-  enum { kFieldCount = 1 };
+  static constexpr std::size_t kFieldCount = 1;
 
   int a;
 };
@@ -154,7 +156,7 @@ struct Multi2
   using BaseAType = BaseA;
   using BaseBType = BaseB;
 
-  enum { kFieldCount = 2 };
+  static constexpr std::size_t kFieldCount = 2;
 
   int a;
   int b;
@@ -165,24 +167,24 @@ struct MultiOutOfRange final {
 };
 
 struct EmptyB {
-  enum { kFieldCount = 0 };
+  static constexpr std::size_t kFieldCount = 0;
 };
 
 struct Base1B {
-  enum { kFieldCount = 1 };
+  static constexpr std::size_t kFieldCount = 1;
 
   int b_a;
 };
 
 struct Base2B {
-  enum { kFieldCount = 2 };
+  static constexpr std::size_t kFieldCount = 2;
 
   int b_a;
   int b_b;
 };
 
 struct Base3B {
-  enum { kFieldCount = 3 };
+  static constexpr std::size_t kFieldCount = 3;
 
   int b_a;
   int b_b;

--- a/mbo/types/stringify.h
+++ b/mbo/types/stringify.h
@@ -224,7 +224,7 @@ struct StringifyOptions {
   // Special types:
 
   // Handling of containers whose first type is convertible to a string.
-  enum StrKeyed {
+  enum class StrKeyed {
     // No special treatment
     kNormal = 0,
 


### PR DESCRIPTION
Implements the triage decisions for three checks — **50 findings**.

## Disabled, with reasons recorded in `.clang-tidy`

**`bugprone-easily-swappable-parameters` (13)** — flags any run of adjacent same-type parameters, e.g. `LongLines(std::size_t, std::size_t, std::size_t)`, with no evidence that a call site ever got them wrong. Satisfying it means reordering parameters or introducing strong types to please a heuristic. Carries a `TODO(helly25)` to re-enable: it *does* catch real swap hazards where a strong type would genuinely help.

**`readability-use-concise-preprocessor-directives` (20)** — rewrites `#if defined(X)` into `#ifdef X`. Purely cosmetic, and it cannot apply to the compound conditions sitting right next to them, so following it makes neighbouring directives **less** consistent rather than more.

## `cppcoreguidelines-use-enum-class` (17) — cleared, not disabled

The three sites want three different answers, which is why disabling would have been the wrong call:

**`status_builder.h`** — `enum Append { Append };` is a **tag** enum, unscoped on purpose so a caller writes `builder << Append`. Scoping it means `builder << StatusBuilder::Append::Append` — worse to read, and an API break for every caller — to satisfy a rule aimed at enums that carry values. `NOLINT` with that reason.

**`stringify.h`** — `StrKeyed` does carry values, and every use is *already* qualified (`StrKeyed::kNormal`, `SO::StrKeyed::kFirstIsName`), so scoping it is free. Verified no unqualified use exists.

**`test_types.h`** — 15 anonymous `enum { kFieldCount = N };` constants. `enum class` cannot even express this: an anonymous scoped enum has no name. They become `static constexpr std::size_t`, which is what the idiom is for; consumers already wrote `static_cast<std::size_t>(T::kFieldCount)`, so the casts are now merely redundant. Also added the `<cstddef>` that was until now only arriving transitively.

## Test

- All three checks report **zero** across the affected files.
- `bazel test --config=clang //...` — **109/109 pass**.
- `pre-commit run -a` green.