### PR TITLE
Silence the CRTP check, and disable the variadic checks in config

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -46,6 +46,25 @@
 # extend_test.cc, i.e. the reflection machinery. The findings it reports are
 # cosmetic; the risk of anyone running --fix is not.
 #
+# cert-dcl50-cpp and modernize-avoid-variadic-functions are off. C-style variadic
+# functions are not a legacy wart to be migrated away from here - they are how a
+# reflection library talks to the compiler. `__builtin_dump_struct` calls back
+# into a variadic visitor, and that signature is fixed by the builtin, not chosen.
+# Both checks would have every such visitor carry a suppression forever, so the
+# decision belongs in this file rather than scattered through the code.
+#
+# bugprone-crtp-constructor-accessibility is off, and this was checked by trying
+# its advice rather than assuming. It asks for the CRTP base's constructor to be
+# private with the derived class as friend. Two things break:
+#   1. `friend T` alone is not enough - the shorthand wrappers (mbo::types::Extend
+#      and friends) sit between `T` and the base and run its constructor, so they
+#      need befriending too. That part is solvable.
+#   2. The blocker: a private constructor makes the type a NON-AGGREGATE, and
+#      Extend types exist to be aggregates - `const Extend2 ext2{.a = 25, .b = 42}`
+#      is how they are built, and the reflection machinery decomposes them as
+#      aggregates. The hardening would trade the entire feature for protection
+#      against `struct Evil : Extend<Other>`.
+#
 # misc-no-recursion is off. Recursion is the natural shape of the code it flags:
 # Stringify walks nested structures, DebugStr formats them, BigNumberLen recurses
 # once for the negative case. The check reports every member of a call chain, so a
@@ -105,9 +124,11 @@ Checks: >
   -altera-*,
   -boost-*,
   bugprone-*,
+  -bugprone-crtp-constructor-accessibility,
   -bugprone-easily-swappable-parameters,
   -bugprone-std-namespace-modification,
   -bugprone-exception-escape,
+  -cert-dcl50-cpp,
   -cert-err58-cpp,
   clang*,
   clang-analyzer-*,
@@ -135,6 +156,7 @@ Checks: >
   -misc-include-cleaner,
   -misc-no-recursion,
   modernize-*,
+  -modernize-avoid-variadic-functions,
   -modernize-use-nodiscard,
   -modernize-use-std-format,
   -modernize-use-trailing-return-type,

--- a/mbo/types/extend_test.cc
+++ b/mbo/types/extend_test.cc
@@ -255,7 +255,6 @@ TEST_F(ExtendTest, Streamable) {
 
 namespace debug {
 
-// NOLINTBEGIN(bugprone-easily-swappable-parameters,cert-dcl50-cpp)
 int DumpStructVisitor(
     std::size_t /*field_index*/,
     std::string_view format,
@@ -314,8 +313,6 @@ void PrintStructVisitor(
     fields.emplace_back(StructVisitorElement{.format{format}, .indent{indent}, .type{type}, .name{name}, .line = line});
   }
 }
-
-// NOLINTEND(bugprone-easily-swappable-parameters,cert-dcl50-cpp)
 
 // NOLINTBEGIN(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
 template<typename T>

--- a/mbo/types/internal/struct_names_clang.h
+++ b/mbo/types/internal/struct_names_clang.h
@@ -98,9 +98,7 @@ class StructMetaBase {
     Uninitialized storage_;
   };
 
-  // NOLINTBEGIN(*-swappable-parameters)
-
-  static constexpr int DumpStructFieldCounter(  // NOLINT(cert-dcl50-cpp)
+  static constexpr int DumpStructFieldCounter(
       std::size_t& field_index,
       std::string_view format,
       std::string_view indent = {},
@@ -112,8 +110,6 @@ class StructMetaBase {
     }
     return 0;
   }
-
-  // NOLINTEND(*-swappable-parameters)
 
   static constexpr int FieldCount(const T* ptr, std::size_t& field_index) {
     __builtin_dump_struct(ptr, &DumpStructFieldCounter, field_index);  // NOLINT(*-vararg)
@@ -156,9 +152,7 @@ class StructMeta final {
 
   using FieldData = std::array<FieldInfo, kFieldCount>;
 
-  // NOLINTBEGIN(*-swappable-parameters)
-
-  static constexpr int DumpStructVisitor(  // NOLINT(cert-dcl50-cpp)
+  static constexpr int DumpStructVisitor(
       FieldData& fields,
       std::size_t& field_index,
       std::string_view format,
@@ -175,8 +169,6 @@ class StructMeta final {
     }
     return 0;
   }
-
-  // NOLINTEND(*-swappable-parameters)
 
   static constexpr void Init(const T* ptr, FieldData& fields, std::size_t& field_index) {
     __builtin_dump_struct(ptr, &DumpStructVisitor, fields, field_index);  // NOLINT(*-vararg)
@@ -230,9 +222,7 @@ class StructMeta<T, true, false> final {
 
   using FieldData = std::array<FieldInfo, kFieldCount>;
 
-  // NOLINTBEGIN(*-swappable-parameters)
-
-  static int DumpStructVisitor(  // NOLINT(cert-dcl50-cpp)
+  static int DumpStructVisitor(
       FieldData& fields,
       std::size_t& field_index,
       std::string_view format,
@@ -248,8 +238,6 @@ class StructMeta<T, true, false> final {
     }
     return 0;
   }
-
-  // NOLINTEND(*-swappable-parameters)
 
   static void Init(const T* ptr, FieldData& fields, std::size_t& field_index) {
     __builtin_dump_struct(ptr, &DumpStructVisitor, fields, field_index);  // NOLINT(*-vararg)


### PR DESCRIPTION
Stacked on #287.

## `bugprone-crtp-constructor-accessibility` — disabled, after trying its advice

The check asks for the CRTP base's constructor to be private with the derived class as friend. I implemented that rather than assuming it wouldn't work:

1. **`friend T` alone is not enough.** The shorthand wrappers (`mbo::types::Extend` and friends) sit *between* `T` and the base and run its constructor, so they need befriending too. Solvable — and done.
2. **The blocker: a private constructor makes the type a non-aggregate.** `Extend` types exist to *be* aggregates — `const Extend2 ext2{.a = 25, .b = 42}` is how they are built, and the reflection machinery decomposes them as aggregates. Every such construction stopped compiling:

```
error: base class '::mbo::extender::Extend<Extend2, std::tuple<Default>>' has private default constructor
```

The hardening would trade the entire feature for protection against `struct Evil : Extend<Other>`. The reasoning, including what was attempted, is recorded in `.clang-tidy`.

## `cert-dcl50-cpp` and `modernize-avoid-variadic-functions` — disabled in config

C-style variadics are not a legacy wart to be migrated away from here — they are how a reflection library talks to the compiler. `__builtin_dump_struct` calls back into a **variadic visitor, and that signature is fixed by the builtin**, not chosen. Suppressing per site would mean every such visitor carrying a `NOLINT` forever, so the decision belongs in `.clang-tidy`.

## Suppressions removed as a result

Putting it in config lets code get *simpler*, not just quieter:

- `extend_test.cc` — the whole `NOLINTBEGIN`/`NOLINTEND` region is gone.
- `struct_names_clang.h` — three per-function `NOLINT`s gone, plus three `*-swappable-parameters` regions that were only needed for a check already disabled in #283.

## Test

- All three checks report zero.
- `bazel test --config=clang //...` — **109/109 pass**.
- `pre-commit run -a` green.