### PR TITLE
Fix an unchecked optional in diff, and settle the tail checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -65,6 +65,19 @@
 #      aggregates. The hardening would trade the entire feature for protection
 #      against `struct Evil : Extend<Other>`.
 #
+# bugprone-random-generator-seed is off. Every generator it flags is seeded with
+# a constant ON PURPOSE - tests and benchmarks must be reproducible, and a
+# randomly seeded one would make failures impossible to reproduce.
+#
+# cppcoreguidelines-macro-usage is off. The macros it flags define constants
+# consumed by the PREPROCESSOR (`#if MBO_LOG_HAS_CXA_DEMANGLE`), where a
+# `constexpr` cannot be used - the substitution it suggests does not compile.
+#
+# hicpp-signed-bitwise is off. It fires on parity tests like `(d + lo) & 1` over
+# `std::ptrdiff_t` in the Myers diff, where the signed type is required by the
+# algorithm (diagonals run negative) and masking the low bit is the standard way
+# to test it. Casting to unsigned to appease the check would obscure that.
+#
 # misc-no-recursion is off. Recursion is the natural shape of the code it flags:
 # Stringify walks nested structures, DebugStr formats them, BigNumberLen recurses
 # once for the negative case. The check reports every member of a call chain, so a
@@ -125,6 +138,7 @@ Checks: >
   -boost-*,
   bugprone-*,
   -bugprone-crtp-constructor-accessibility,
+  -bugprone-random-generator-seed,
   -bugprone-easily-swappable-parameters,
   -bugprone-std-namespace-modification,
   -bugprone-exception-escape,
@@ -137,6 +151,7 @@ Checks: >
   cppcoreguidelines-*,
   -cppcoreguidelines-avoid-const-or-ref-data-members,
   -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-macro-usage,
   -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
   -cppcoreguidelines-pro-bounds-avoid-unchecked-container-access,
   -cppcoreguidelines-pro-bounds-constant-array-index,
@@ -146,6 +161,7 @@ Checks: >
   google-*,
   -google-build-using-namespace,
   -hicpp-no-array-decay,
+  -hicpp-signed-bitwise,
   -hicpp-no-assembler,
   -llvm-else-after-return,
   -llvm-header-guard,

--- a/mbo/diff/diff_main.cc
+++ b/mbo/diff/diff_main.cc
@@ -243,6 +243,9 @@ int Diff(std::string_view lhs_name, std::string_view rhs_name) {
   ABSL_QCHECK(output_format) << "Unknown format";
   ABSL_QCHECK(absl::GetFlag(FLAGS_algorithm) != "unified" || output_format == Diff::Options::OutputFormat::kUnified)
       << "The deprecated '--algorithm=unified' alias implies '--format=unified'.";
+  const std::optional<Diff::Options::FileHeaderUse> file_header_use =
+      Diff::Options::ParseFileHeaderUse(absl::GetFlag(FLAGS_file_header_use));
+  ABSL_QCHECK(file_header_use) << "Unknown file_header_use";
   const bool is_direct = algorithm == Diff::Options::Algorithm::kDirect;
   const bool is_normal = output_format == Diff::Options::OutputFormat::kNormal;
   const bool is_side_by_side = output_format == Diff::Options::OutputFormat::kSideBySide;
@@ -254,7 +257,7 @@ int Diff(std::string_view lhs_name, std::string_view rhs_name) {
       .output_format = *output_format,
       .context_size = GetFlagOrDefault(FLAGS_context, is_direct || is_normal || is_side_by_side, default_context),
       .side_by_side_width = absl::GetFlag(FLAGS_width),
-      .file_header_use = *Diff::Options::ParseFileHeaderUse(absl::GetFlag(FLAGS_file_header_use)),
+      .file_header_use = *file_header_use,
       .ignore_blank_lines = absl::GetFlag(FLAGS_ignore_blank_lines),
       .ignore_case = absl::GetFlag(FLAGS_ignore_case),
       .ignore_all_space = absl::GetFlag(FLAGS_ignore_all_space),

--- a/mbo/log/scoped_stream.h
+++ b/mbo/log/scoped_stream.h
@@ -63,7 +63,7 @@ struct VoidStream {
   VoidStream(VoidStream&&) noexcept = default;
   VoidStream& operator=(VoidStream&&) noexcept = default;
 
-  VoidStream& operator=(const Voidifier&) noexcept { return *this; }
+  VoidStream& operator=(const Voidifier& /*unused*/) noexcept { return *this; }
 
   operator bool() const noexcept { return false; }  // NOLINT(*-explicit-*)
 

--- a/mbo/mope/mope.h
+++ b/mbo/mope/mope.h
@@ -160,7 +160,7 @@ class Template {
   static absl::Status ExpandSection(const TagData<Section>& tag, Context& ctx, std::string& output);
 
   template<typename Sink>
-  friend void AbslStringify(Sink&, TagType);
+  friend void AbslStringify(Sink& /*sink*/, TagType /*tag*/);
   friend std::ostream& operator<<(std::ostream&, TagType);
 
   DataMap data_ = {};

--- a/mbo/types/opaque_test.cc
+++ b/mbo/types/opaque_test.cc
@@ -136,9 +136,9 @@ struct StringWrap : std::string {
 }  // namespace mbo::types
 
 namespace std {
-/* NOLINTBEGIN(cert-dcl58-cpp,misc-use-internal-linkage) */
+/* NOLINTBEGIN(cert-dcl58-cpp,misc-use-internal-linkage,cppcoreguidelines-owning-memory) */
 MBO_TYPES_OPAQUE_HOOKS(std::vector<std::string>);
 MBO_TYPES_OPAQUE_HOOKS(std::vector<mbo::types::StringWrap>);
 MBO_TYPES_OPAQUE_HOOKS(std::list<mbo::types::StringWrap>);
-/* NOLINTEND(cert-dcl58-cpp,misc-use-internal-linkage) */
+/* NOLINTEND(cert-dcl58-cpp,misc-use-internal-linkage,cppcoreguidelines-owning-memory) */
 }  // namespace std

--- a/mbo/types/optional_data_or_ref.h
+++ b/mbo/types/optional_data_or_ref.h
@@ -46,7 +46,7 @@ class OptionalDataOrRef {
 
   constexpr ~OptionalDataOrRef() noexcept { Destruct(); }
 
-  constexpr OptionalDataOrRef() noexcept {}  // NOLINT(hicpp-use-equals-default): Not the same
+  constexpr OptionalDataOrRef() noexcept {}  // NOLINT(*-use-equals-default): Not the same
 
   constexpr OptionalDataOrRef(std::nullopt_t /* unused */) {}  // NOLINT(*-explicit-*)
 
@@ -193,6 +193,8 @@ class OptionalDataOrRef {
 
   // Returns `value()` if `holds_value()` is true, a reference `defaults`.
   // BEWARE of dangling references.
+  // NOLINTNEXTLINE(bugprone-return-const-ref-from-parameter): documented above; returning the
+  // caller's own reference is the point of the API.
   constexpr const_reference get(const T& defaults) const noexcept { return has_value() ? value() : defaults; }
 
   // Returns a reference to existing data or created data. If the object:


### PR DESCRIPTION
## A real bug: unchecked optional in `diff`

`diff_main.cc` dereferenced `ParseFileHeaderUse(...)` without checking it. The flag is a plain `std::string` with **no validator**, and the parser returns `std::optional`:

```cpp
.file_header_use = *Diff::Options::ParseFileHeaderUse(absl::GetFlag(FLAGS_file_header_use)),
```

So `--file_header_use=garbage` dereferenced a disengaged optional — undefined behaviour. It now checks, exactly like the sibling flags immediately above it (`--algorithm`, `--format`) already did:

```cpp
ABSL_QCHECK(file_header_use) << "Unknown file_header_use";
```

Confirmed by running it: that invocation now exits with `Check failed: file_header_use Unknown file_header_use` instead of misbehaving.

## Also fixed

- **Named parameters** in `scoped_stream.h` and `mope.h`.
- **`modernize-use-equals-default`** — the existing `NOLINT` covered only the `hicpp` alias, so the check still fired; widened to `*-use-equals-default`.
- **`bugprone-return-const-ref-from-parameter`** on `OptionalDataOrRef::get(defaults)` — returning the caller's own reference *is* the documented purpose, and the header already warns "BEWARE of dangling references". `NOLINT` pointing at that.
- **`cppcoreguidelines-owning-memory`** joins the `NOLINT` region already covering those macro-generated hooks.

## Disabled, with reasons recorded

- **`bugprone-random-generator-seed`** — every generator it flags is seeded with a constant *on purpose*: tests and benchmarks must be reproducible, and a randomly seeded one would make failures impossible to reproduce.
- **`cppcoreguidelines-macro-usage`** — the macros it flags are consumed by the **preprocessor** (`#if MBO_LOG_HAS_CXA_DEMANGLE`), where the suggested `constexpr` does not compile.
- **`hicpp-signed-bitwise`** — parity tests like `(d + lo) & 1` over `std::ptrdiff_t` in the Myers diff, where the signed type is required by the algorithm (diagonals run negative) and masking the low bit is the standard test.

## Test

- `bazel test --config=clang //...` — **109/109 pass**.
- `pre-commit run -a` green.